### PR TITLE
test: add unit tests for core logic

### DIFF
--- a/internal/codexbridge/bridge_test.go
+++ b/internal/codexbridge/bridge_test.go
@@ -1,0 +1,86 @@
+package codexbridge
+
+import (
+	"strings"
+	"testing"
+
+	codex "github.com/agynio/codex-sdk-go"
+)
+
+func agentMessageItem(text string, phase *codex.MessagePhase) codex.ThreadItem {
+	return codex.ThreadItem{
+		AgentMessage: &codex.AgentMessageThreadItem{
+			Text:  text,
+			Phase: phase,
+		},
+	}
+}
+
+func TestExtractFinalAnswerFinalPhase(t *testing.T) {
+	phase := codex.MessagePhaseFinalAnswer
+	turn := codex.Turn{
+		ID: "turn-final",
+		Items: []codex.ThreadItem{
+			agentMessageItem("final response", &phase),
+		},
+	}
+	got, err := extractFinalAnswer(turn)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got != "final response" {
+		t.Fatalf("unexpected final answer: %q", got)
+	}
+}
+
+func TestExtractFinalAnswerFallback(t *testing.T) {
+	turn := codex.Turn{
+		ID: "turn-fallback",
+		Items: []codex.ThreadItem{
+			agentMessageItem("draft", nil),
+			agentMessageItem("last response", nil),
+		},
+	}
+	got, err := extractFinalAnswer(turn)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got != "last response" {
+		t.Fatalf("expected fallback to last agent message, got %q", got)
+	}
+}
+
+func TestExtractFinalAnswerEmptyTurn(t *testing.T) {
+	turn := codex.Turn{ID: "turn-empty"}
+	got, err := extractFinalAnswer(turn)
+	if err == nil {
+		t.Fatal("expected error for empty turn")
+	}
+	if got != "" {
+		t.Fatalf("expected empty answer, got %q", got)
+	}
+	if !strings.Contains(err.Error(), "missing agent message") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestExtractFinalAnswerNoAgentMessages(t *testing.T) {
+	turn := codex.Turn{
+		ID: "turn-no-agent",
+		Items: []codex.ThreadItem{
+			{
+				UserMessage: &codex.UserMessageThreadItem{ID: "user-1"},
+			},
+		},
+	}
+	got, err := extractFinalAnswer(turn)
+	if err == nil {
+		t.Fatal("expected error for missing agent messages")
+	}
+	if got != "" {
+		t.Fatalf("expected empty answer, got %q", got)
+	}
+	if !strings.Contains(err.Error(), "missing agent message") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/codexbridge/mapping_test.go
+++ b/internal/codexbridge/mapping_test.go
@@ -1,0 +1,57 @@
+package codexbridge
+
+import "testing"
+
+func TestThreadMappingSetGet(t *testing.T) {
+	mapping := NewThreadMapping()
+	mapping.Set("platform-1", "codex-1")
+	got, ok := mapping.CodexForPlatform("platform-1")
+	if !ok {
+		t.Fatal("expected mapping to exist")
+	}
+	if got != "codex-1" {
+		t.Fatalf("expected codex id codex-1, got %q", got)
+	}
+}
+
+func TestThreadMappingBidirectional(t *testing.T) {
+	mapping := NewThreadMapping()
+	mapping.Set("platform-2", "codex-2")
+	got, ok := mapping.PlatformForCodex("codex-2")
+	if !ok {
+		t.Fatal("expected reverse mapping to exist")
+	}
+	if got != "platform-2" {
+		t.Fatalf("expected platform id platform-2, got %q", got)
+	}
+}
+
+func TestThreadMappingMissing(t *testing.T) {
+	mapping := NewThreadMapping()
+	if got, ok := mapping.CodexForPlatform("missing"); ok || got != "" {
+		t.Fatalf("expected no mapping, got %q", got)
+	}
+	if got, ok := mapping.PlatformForCodex("missing"); ok || got != "" {
+		t.Fatalf("expected no reverse mapping, got %q", got)
+	}
+}
+
+func TestThreadMappingOverwrite(t *testing.T) {
+	mapping := NewThreadMapping()
+	mapping.Set("platform-3", "codex-3")
+	mapping.Set("platform-3", "codex-4")
+	got, ok := mapping.CodexForPlatform("platform-3")
+	if !ok {
+		t.Fatal("expected mapping to exist")
+	}
+	if got != "codex-4" {
+		t.Fatalf("expected codex id codex-4, got %q", got)
+	}
+	got, ok = mapping.PlatformForCodex("codex-4")
+	if !ok {
+		t.Fatal("expected reverse mapping to exist")
+	}
+	if got != "platform-3" {
+		t.Fatalf("expected platform id platform-3, got %q", got)
+	}
+}

--- a/internal/codexbridge/turn_tracker_test.go
+++ b/internal/codexbridge/turn_tracker_test.go
@@ -1,0 +1,101 @@
+package codexbridge
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func receiveResult(t *testing.T, ch <-chan TurnResult) TurnResult {
+	t.Helper()
+	select {
+	case result, ok := <-ch:
+		if !ok {
+			t.Fatal("channel closed without result")
+		}
+		return result
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timed out waiting for result")
+	}
+	return TurnResult{}
+}
+
+func assertClosed(t *testing.T, ch <-chan TurnResult) {
+	t.Helper()
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Fatal("expected channel to be closed")
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timed out waiting for channel close")
+	}
+}
+
+func TestTurnTrackerRegisterThenNotify(t *testing.T) {
+	tracker := NewTurnTracker()
+	ch := tracker.Register("turn-1")
+	result := TurnResult{ThreadID: "thread-1", TurnID: "turn-1", Message: "ok"}
+	tracker.Notify(result)
+	got := receiveResult(t, ch)
+	if got != result {
+		t.Fatalf("unexpected result: %+v", got)
+	}
+	assertClosed(t, ch)
+}
+
+func TestTurnTrackerNotifyBeforeRegister(t *testing.T) {
+	tracker := NewTurnTracker()
+	result := TurnResult{ThreadID: "thread-2", TurnID: "turn-2", Message: "done"}
+	tracker.Notify(result)
+	ch := tracker.Register("turn-2")
+	got := receiveResult(t, ch)
+	if got != result {
+		t.Fatalf("unexpected result: %+v", got)
+	}
+	assertClosed(t, ch)
+}
+
+func TestTurnTrackerCancelDropsPending(t *testing.T) {
+	tracker := NewTurnTracker()
+	result := TurnResult{ThreadID: "thread-3", TurnID: "turn-3", Message: "ignored"}
+	tracker.Notify(result)
+	tracker.Cancel("turn-3")
+	ch := tracker.Register("turn-3")
+	select {
+	case got := <-ch:
+		t.Fatalf("unexpected result after cancel: %+v", got)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestTurnTrackerMultipleConcurrentTurns(t *testing.T) {
+	tracker := NewTurnTracker()
+	turnIDs := []string{"turn-a", "turn-b", "turn-c"}
+	channels := make(map[string]<-chan TurnResult, len(turnIDs))
+	for _, id := range turnIDs {
+		channels[id] = tracker.Register(id)
+	}
+
+	var wg sync.WaitGroup
+	for _, id := range turnIDs {
+		turnID := id
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			tracker.Notify(TurnResult{ThreadID: "thread", TurnID: turnID, Message: turnID + "-message"})
+		}()
+	}
+	wg.Wait()
+
+	for _, id := range turnIDs {
+		got := receiveResult(t, channels[id])
+		if got.TurnID != id {
+			t.Fatalf("expected turn id %s, got %s", id, got.TurnID)
+		}
+		if got.Message != id+"-message" {
+			t.Fatalf("unexpected message for %s: %q", id, got.Message)
+		}
+		assertClosed(t, channels[id])
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,93 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+const validAgentID = "550e8400-e29b-41d4-a716-446655440000"
+
+func setRequiredEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("AGENT_ID", validAgentID)
+	t.Setenv("THREADS_ADDRESS", "threads:1234")
+	t.Setenv("NOTIFICATIONS_ADDRESS", "notifs:2345")
+	t.Setenv("TEAMS_ADDRESS", "teams:3456")
+	t.Setenv("OPENAI_API_KEY", "key")
+}
+
+func TestFromEnvValid(t *testing.T) {
+	setRequiredEnv(t)
+	t.Setenv("CODEX_BINARY", "codex-custom")
+	t.Setenv("WORKSPACE_DIR", "/tmp/workdir")
+
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if cfg.AgentID.String() != validAgentID {
+		t.Fatalf("unexpected agent id: %s", cfg.AgentID.String())
+	}
+	if cfg.ThreadsAddress != "threads:1234" {
+		t.Fatalf("unexpected threads address: %s", cfg.ThreadsAddress)
+	}
+	if cfg.NotificationsAddress != "notifs:2345" {
+		t.Fatalf("unexpected notifications address: %s", cfg.NotificationsAddress)
+	}
+	if cfg.TeamsAddress != "teams:3456" {
+		t.Fatalf("unexpected teams address: %s", cfg.TeamsAddress)
+	}
+	if cfg.OpenAIAPIKey != "key" {
+		t.Fatalf("unexpected openai api key: %s", cfg.OpenAIAPIKey)
+	}
+	if cfg.CodexBinary != "codex-custom" {
+		t.Fatalf("unexpected codex binary: %s", cfg.CodexBinary)
+	}
+	if cfg.WorkDir != "/tmp/workdir" {
+		t.Fatalf("unexpected work dir: %s", cfg.WorkDir)
+	}
+}
+
+func TestFromEnvMissingRequired(t *testing.T) {
+	tests := []struct {
+		name     string
+		missing  string
+		expected string
+	}{
+		{name: "agent-id", missing: "AGENT_ID", expected: "AGENT_ID"},
+		{name: "threads", missing: "THREADS_ADDRESS", expected: "THREADS_ADDRESS"},
+		{name: "notifications", missing: "NOTIFICATIONS_ADDRESS", expected: "NOTIFICATIONS_ADDRESS"},
+		{name: "teams", missing: "TEAMS_ADDRESS", expected: "TEAMS_ADDRESS"},
+		{name: "openai", missing: "OPENAI_API_KEY", expected: "OPENAI_API_KEY"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setRequiredEnv(t)
+			t.Setenv(test.missing, "")
+			_, err := FromEnv()
+			if err == nil {
+				t.Fatalf("expected error for missing %s", test.missing)
+			}
+			if !strings.Contains(err.Error(), test.expected) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestFromEnvDefaults(t *testing.T) {
+	setRequiredEnv(t)
+	t.Setenv("CODEX_BINARY", "")
+	t.Setenv("WORKSPACE_DIR", "")
+
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if cfg.CodexBinary != "codex" {
+		t.Fatalf("expected default codex binary, got %s", cfg.CodexBinary)
+	}
+	if cfg.WorkDir != "/workspace" {
+		t.Fatalf("expected default workspace dir, got %s", cfg.WorkDir)
+	}
+}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1,0 +1,47 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/agynio/agynd-cli/internal/platform"
+)
+
+func TestBuildInputText(t *testing.T) {
+	message := platform.Message{
+		ID:   "msg-1",
+		Body: " hello ",
+	}
+	got, err := buildInput(message)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got != "hello" {
+		t.Fatalf("expected trimmed text, got %q", got)
+	}
+}
+
+func TestBuildInputFilesOnly(t *testing.T) {
+	message := platform.Message{
+		ID:      "msg-2",
+		FileIDs: []string{"file-a", "file-b"},
+	}
+	got, err := buildInput(message)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got != "Received files: file-a, file-b" {
+		t.Fatalf("unexpected file-only input: %q", got)
+	}
+}
+
+func TestBuildInputEmpty(t *testing.T) {
+	message := platform.Message{ID: "msg-3"}
+	_, err := buildInput(message)
+	if err == nil {
+		t.Fatal("expected error for empty message")
+	}
+	if !strings.Contains(err.Error(), "has no content") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/platform/consumer_test.go
+++ b/internal/platform/consumer_test.go
@@ -1,0 +1,102 @@
+package platform
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	threadsv1 "github.com/agynio/agynd-cli/.gen/go/agynio/api/threads/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type fakeThreadsClient struct {
+	responses []*threadsv1.GetUnackedMessagesResponse
+	index     int
+}
+
+func (f *fakeThreadsClient) CreateThread(ctx context.Context, in *threadsv1.CreateThreadRequest, opts ...grpc.CallOption) (*threadsv1.CreateThreadResponse, error) {
+	return nil, fmt.Errorf("CreateThread not implemented")
+}
+
+func (f *fakeThreadsClient) ArchiveThread(ctx context.Context, in *threadsv1.ArchiveThreadRequest, opts ...grpc.CallOption) (*threadsv1.ArchiveThreadResponse, error) {
+	return nil, fmt.Errorf("ArchiveThread not implemented")
+}
+
+func (f *fakeThreadsClient) AddParticipant(ctx context.Context, in *threadsv1.AddParticipantRequest, opts ...grpc.CallOption) (*threadsv1.AddParticipantResponse, error) {
+	return nil, fmt.Errorf("AddParticipant not implemented")
+}
+
+func (f *fakeThreadsClient) SendMessage(ctx context.Context, in *threadsv1.SendMessageRequest, opts ...grpc.CallOption) (*threadsv1.SendMessageResponse, error) {
+	return nil, fmt.Errorf("SendMessage not implemented")
+}
+
+func (f *fakeThreadsClient) GetThreads(ctx context.Context, in *threadsv1.GetThreadsRequest, opts ...grpc.CallOption) (*threadsv1.GetThreadsResponse, error) {
+	return nil, fmt.Errorf("GetThreads not implemented")
+}
+
+func (f *fakeThreadsClient) GetMessages(ctx context.Context, in *threadsv1.GetMessagesRequest, opts ...grpc.CallOption) (*threadsv1.GetMessagesResponse, error) {
+	return nil, fmt.Errorf("GetMessages not implemented")
+}
+
+func (f *fakeThreadsClient) GetUnackedMessages(ctx context.Context, in *threadsv1.GetUnackedMessagesRequest, opts ...grpc.CallOption) (*threadsv1.GetUnackedMessagesResponse, error) {
+	if f.index >= len(f.responses) {
+		return nil, fmt.Errorf("unexpected GetUnackedMessages call")
+	}
+	resp := f.responses[f.index]
+	f.index++
+	return resp, nil
+}
+
+func (f *fakeThreadsClient) AckMessages(ctx context.Context, in *threadsv1.AckMessagesRequest, opts ...grpc.CallOption) (*threadsv1.AckMessagesResponse, error) {
+	return nil, fmt.Errorf("AckMessages not implemented")
+}
+
+func TestConsumerSyncSortsMessages(t *testing.T) {
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	messageA := &threadsv1.Message{
+		Id:        "b",
+		ThreadId:  "thread-1",
+		SenderId:  "sender-1",
+		Body:      "hello",
+		CreatedAt: timestamppb.New(base.Add(2 * time.Second)),
+	}
+	messageB := &threadsv1.Message{
+		Id:        "c",
+		ThreadId:  "thread-1",
+		SenderId:  "sender-1",
+		Body:      "hello",
+		CreatedAt: timestamppb.New(base),
+	}
+	messageC := &threadsv1.Message{
+		Id:        "a",
+		ThreadId:  "thread-1",
+		SenderId:  "sender-1",
+		Body:      "hello",
+		CreatedAt: timestamppb.New(base),
+	}
+
+	fake := &fakeThreadsClient{
+		responses: []*threadsv1.GetUnackedMessagesResponse{{
+			Messages: []*threadsv1.Message{messageA, messageB, messageC},
+		}},
+	}
+	threads := &Threads{client: fake}
+	consumer := NewConsumer(threads, 100, 0)
+
+	var got []Message
+	err := consumer.Sync(context.Background(), "participant-1", func(message Message) error {
+		got = append(got, message)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(got))
+	}
+	if got[0].ID != "a" || got[1].ID != "c" || got[2].ID != "b" {
+		t.Fatalf("unexpected sort order: %q, %q, %q", got[0].ID, got[1].ID, got[2].ID)
+	}
+}

--- a/internal/platform/threads_test.go
+++ b/internal/platform/threads_test.go
@@ -1,0 +1,121 @@
+package platform
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	threadsv1 "github.com/agynio/agynd-cli/.gen/go/agynio/api/threads/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestMessageFromProtoValid(t *testing.T) {
+	createdAt := time.Date(2024, 5, 1, 12, 0, 0, 0, time.UTC)
+	proto := &threadsv1.Message{
+		Id:        "msg-1",
+		ThreadId:  "thread-1",
+		SenderId:  "sender-1",
+		Body:      "hello",
+		FileIds:   []string{"file-a"},
+		CreatedAt: timestamppb.New(createdAt),
+	}
+	message, err := messageFromProto(proto)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if message.ID != "msg-1" {
+		t.Fatalf("unexpected id: %s", message.ID)
+	}
+	if message.ThreadID != "thread-1" {
+		t.Fatalf("unexpected thread id: %s", message.ThreadID)
+	}
+	if message.SenderID != "sender-1" {
+		t.Fatalf("unexpected sender id: %s", message.SenderID)
+	}
+	if message.Body != "hello" {
+		t.Fatalf("unexpected body: %s", message.Body)
+	}
+	if !reflect.DeepEqual(message.FileIDs, []string{"file-a"}) {
+		t.Fatalf("unexpected file ids: %v", message.FileIDs)
+	}
+	if !message.CreatedAt.Equal(createdAt) {
+		t.Fatalf("unexpected created time: %s", message.CreatedAt)
+	}
+}
+
+func TestMessageFromProtoNil(t *testing.T) {
+	_, err := messageFromProto(nil)
+	if err == nil {
+		t.Fatal("expected error for nil message")
+	}
+}
+
+func TestMessageFromProtoMissingFields(t *testing.T) {
+	createdAt := timestamppb.New(time.Now())
+	valid := &threadsv1.Message{
+		Id:        "msg-1",
+		ThreadId:  "thread-1",
+		SenderId:  "sender-1",
+		Body:      "hello",
+		CreatedAt: createdAt,
+	}
+	tests := []struct {
+		name string
+		msg  *threadsv1.Message
+	}{
+		{
+			name: "missing-id",
+			msg: &threadsv1.Message{
+				ThreadId:  valid.ThreadId,
+				SenderId:  valid.SenderId,
+				Body:      valid.Body,
+				CreatedAt: valid.CreatedAt,
+			},
+		},
+		{
+			name: "missing-thread-id",
+			msg: &threadsv1.Message{
+				Id:        valid.Id,
+				SenderId:  valid.SenderId,
+				Body:      valid.Body,
+				CreatedAt: valid.CreatedAt,
+			},
+		},
+		{
+			name: "missing-sender-id",
+			msg: &threadsv1.Message{
+				Id:        valid.Id,
+				ThreadId:  valid.ThreadId,
+				Body:      valid.Body,
+				CreatedAt: valid.CreatedAt,
+			},
+		},
+		{
+			name: "missing-created-at",
+			msg: &threadsv1.Message{
+				Id:       valid.Id,
+				ThreadId: valid.ThreadId,
+				SenderId: valid.SenderId,
+				Body:     valid.Body,
+			},
+		},
+		{
+			name: "missing-body-and-files",
+			msg: &threadsv1.Message{
+				Id:        valid.Id,
+				ThreadId:  valid.ThreadId,
+				SenderId:  valid.SenderId,
+				CreatedAt: valid.CreatedAt,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := messageFromProto(test.msg)
+			if err == nil {
+				t.Fatal("expected error for missing field")
+			}
+		})
+	}
+}

--- a/internal/subscriber/subscriber_test.go
+++ b/internal/subscriber/subscriber_test.go
@@ -1,0 +1,35 @@
+package subscriber
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNextBackoffProgression(t *testing.T) {
+	tests := []struct {
+		name     string
+		current  time.Duration
+		expected time.Duration
+	}{
+		{name: "zero", current: 0, expected: time.Second},
+		{name: "one-second", current: time.Second, expected: 2 * time.Second},
+		{name: "two-seconds", current: 2 * time.Second, expected: 4 * time.Second},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := nextBackoff(test.current)
+			if got != test.expected {
+				t.Fatalf("expected %s, got %s", test.expected, got)
+			}
+		})
+	}
+}
+
+func TestNextBackoffCapsAtThirtySeconds(t *testing.T) {
+	if got := nextBackoff(20 * time.Second); got != 30*time.Second {
+		t.Fatalf("expected cap at 30s, got %s", got)
+	}
+	if got := nextBackoff(30 * time.Second); got != 30*time.Second {
+		t.Fatalf("expected cap at 30s, got %s", got)
+	}
+}

--- a/internal/uuidutil/parse_test.go
+++ b/internal/uuidutil/parse_test.go
@@ -1,0 +1,28 @@
+package uuidutil
+
+import "testing"
+
+func TestParseUUIDValid(t *testing.T) {
+	value := "550e8400-e29b-41d4-a716-446655440000"
+	parsed, err := ParseUUID(value, "FIELD")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if parsed.String() != value {
+		t.Fatalf("expected %s, got %s", value, parsed.String())
+	}
+}
+
+func TestParseUUIDEmpty(t *testing.T) {
+	_, err := ParseUUID("", "FIELD")
+	if err == nil {
+		t.Fatal("expected error for empty value")
+	}
+}
+
+func TestParseUUIDMalformed(t *testing.T) {
+	_, err := ParseUUID("not-a-uuid", "FIELD")
+	if err == nil {
+		t.Fatal("expected error for malformed uuid")
+	}
+}


### PR DESCRIPTION
## Summary
- add unit coverage for internal pure logic helpers
- exercise thread mapping, turn tracking, backoff, config, and platform parsing

## Testing
- go test ./...
- go vet ./...

Closes #7