### PR TITLE
Add binary release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - "v*.*.*"
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 env:
@@ -15,6 +15,51 @@ env:
   CHART_REGISTRY: oci://ghcr.io/agynio/charts
 
 jobs:
+  binary:
+    name: Build and release binaries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.x'
+
+      - name: Install buf
+        uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          version: 1.66.0
+
+      - name: Generate protobuf bindings
+        run: |
+          buf generate buf.build/agynio/api \
+            --path agynio/api/threads/v1 \
+            --path agynio/api/notifications/v1 \
+            --path agynio/api/teams/v1
+
+      - name: Build binaries
+        run: |
+          mkdir -p dist
+          for ARCH in amd64 arm64; do
+            CGO_ENABLED=0 GOOS=linux GOARCH="$ARCH" \
+              go build -trimpath -ldflags "-s -w" \
+              -o "dist/agynd-linux-${ARCH}" ./cmd/agynd
+          done
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+          files: |
+            dist/agynd-linux-amd64
+            dist/agynd-linux-arm64
+
   image:
     name: Build and push container image
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add binary release job for linux/amd64 and linux/arm64
- create GitHub release with uploaded agynd binaries
- update release workflow permissions for contents write

## Testing
- CGO_ENABLED=0 go test ./...
- CGO_ENABLED=0 go vet ./...

Refs #13