### PR TITLE
test(e2e): remove proxy usage

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -3,13 +3,9 @@
 package e2e
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -17,8 +13,6 @@ import (
 
 	"github.com/agynio/codex-sdk-go"
 )
-
-const testLLMBaseURL = "https://testllm.dev/v1/org/agynio/suite/codex"
 
 type turnCompletedHandler struct {
 	codex.NopNotificationHandler
@@ -33,9 +27,8 @@ func (h *turnCompletedHandler) OnTurnCompleted(notification *codex.TurnCompleted
 }
 
 func TestCodexClientHelloResponse(t *testing.T) {
-	proxyURL := startTestProxy(t)
 	codexHome := t.TempDir()
-	writeCodexConfig(t, codexHome, proxyURL)
+	writeCodexConfig(t, codexHome)
 
 	handler := &turnCompletedHandler{completed: make(chan *codex.TurnCompletedNotification, 1)}
 	ctx := context.Background()
@@ -100,105 +93,21 @@ func TestCodexClientHelloResponse(t *testing.T) {
 	}
 }
 
-func startTestProxy(t *testing.T) string {
-	t.Helper()
-
-	client := &http.Client{Timeout: 30 * time.Second}
-	mux := http.NewServeMux()
-	mux.HandleFunc("/v1/models", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = io.WriteString(w, `{"data":[]}`)
-	})
-	mux.HandleFunc("/v1/responses", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			http.Error(w, "read request body", http.StatusBadRequest)
-			return
-		}
-		if err := r.Body.Close(); err != nil {
-			http.Error(w, "close request body", http.StatusBadRequest)
-			return
-		}
-
-		var payload map[string]any
-		if err := json.Unmarshal(body, &payload); err != nil {
-			http.Error(w, "invalid json payload", http.StatusBadRequest)
-			return
-		}
-		stripInputToLastItem(payload)
-		normalized, err := json.Marshal(payload)
-		if err != nil {
-			http.Error(w, "normalize payload", http.StatusBadRequest)
-			return
-		}
-
-		forwardReq, err := http.NewRequestWithContext(r.Context(), http.MethodPost, testLLMBaseURL+"/responses", bytes.NewReader(normalized))
-		if err != nil {
-			http.Error(w, "build upstream request", http.StatusInternalServerError)
-			return
-		}
-		forwardReq.Header = r.Header.Clone()
-		forwardReq.Header.Set("Content-Type", "application/json")
-		forwardReq.Header.Del("Content-Length")
-
-		resp, err := client.Do(forwardReq)
-		if err != nil {
-			http.Error(w, "upstream request failed", http.StatusBadGateway)
-			return
-		}
-		defer resp.Body.Close()
-
-		for key, values := range resp.Header {
-			for _, value := range values {
-				w.Header().Add(key, value)
-			}
-		}
-		w.WriteHeader(resp.StatusCode)
-		if _, err := io.Copy(w, resp.Body); err != nil {
-			t.Logf("copy upstream response: %v", err)
-		}
-	})
-
-	server := httptest.NewServer(mux)
-	t.Cleanup(server.Close)
-	return server.URL
-}
-
-func stripInputToLastItem(payload map[string]any) {
-	inputRaw, ok := payload["input"]
-	if !ok {
-		return
-	}
-	items, ok := inputRaw.([]any)
-	if !ok || len(items) == 0 {
-		return
-	}
-	payload["input"] = []any{items[len(items)-1]}
-}
-
-func writeCodexConfig(t *testing.T, dir, baseURL string) {
+func writeCodexConfig(t *testing.T, dir string) {
 	t.Helper()
 	configPath := filepath.Join(dir, "config.toml")
-	config := fmt.Sprintf(`model = "simple-hello"
+	config := `model = "simple-hello"
 approval_policy = "never"
 model_provider = "testllm"
 
 [model_providers.testllm]
 name = "Test LLM"
-base_url = "%s/v1"
+base_url = "https://testllm.dev/v1/org/agynio/suite/codex"
 wire_api = "responses"
 request_max_retries = 0
 stream_max_retries = 0
 supports_websockets = false
-`, baseURL)
+`
 	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
 		t.Fatalf("write config.toml: %v", err)
 	}


### PR DESCRIPTION
## Summary
- remove the stripping proxy from the e2e codex test
- hardcode the testllm base URL in the generated config
- drop proxy-specific helpers and imports

## Testing
- go build ./...
- go vet ./...
- go test ./...

Refs #17