### PR TITLE
chore(ci): align binary release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,18 +16,16 @@ env:
 
 jobs:
   binary:
-    name: Build and release binaries
+    name: Build and release binary
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.x'
+          go-version: '1.24'
 
       - name: Install buf
         uses: bufbuild/buf-setup-action@v1
@@ -43,19 +41,16 @@ jobs:
             --path agynio/api/teams/v1
 
       - name: Build binaries
+        env:
+          CGO_ENABLED: 0
         run: |
           mkdir -p dist
-          for ARCH in amd64 arm64; do
-            CGO_ENABLED=0 GOOS=linux GOARCH="$ARCH" \
-              go build -trimpath -ldflags "-s -w" \
-              -o "dist/agynd-linux-${ARCH}" ./cmd/agynd
-          done
+          GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o dist/agynd-linux-amd64 ./cmd/agynd
+          GOOS=linux GOARCH=arm64 go build -trimpath -ldflags="-s -w" -o dist/agynd-linux-arm64 ./cmd/agynd
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          name: ${{ github.ref_name }}
-          tag_name: ${{ github.ref_name }}
           files: |
             dist/agynd-linux-amd64
             dist/agynd-linux-arm64


### PR DESCRIPTION
## Summary
- align the binary release job with the agn-cli reference job (Go 1.24, explicit build commands, CGO env)
- keep buf generation for agynd protos before building
- simplify release step to upload the two binaries

## Testing
- go test ./...
- go vet ./...

## Issue
Closes #21