### PR TITLE
chore(ci): document buf generate alignment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
 
       - name: Generate protobuf bindings
         run: |
+          # Use gateway protos to include transitive imports.
           buf generate buf.build/agynio/api \
             --path agynio/api/gateway/v1 \
             --include-imports

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download
 
 COPY buf.gen.yaml buf.yaml ./
+# Use gateway protos to include transitive imports.
 RUN buf generate buf.build/agynio/api \
     --path agynio/api/gateway/v1 \
     --include-imports


### PR DESCRIPTION
## Summary
- document the gateway proto entrypoint in the release workflow `buf generate` step
- document the same gateway entrypoint in the Dockerfile build stage

## Testing
- GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go test ./...
- GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go vet ./...

## Issue
Closes #27