### PR TITLE
Add agn e2e coverage

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,8 +8,19 @@ on:
 jobs:
   e2e:
     runs-on: ubuntu-latest
+    env:
+      GOPRIVATE: github.com/agynio/*
     steps:
       - uses: actions/checkout@v4
+
+      - name: Configure Git for private modules
+        run: git config --global url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
+
+      - uses: actions/checkout@v4
+        with:
+          repository: agynio/agn-cli
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: .agn-cli
 
       - uses: actions/setup-go@v5
         with:
@@ -24,9 +35,8 @@ jobs:
       - name: Generate protobuf bindings
         run: |
           buf generate buf.build/agynio/api \
-            --path agynio/api/threads/v1 \
-            --path agynio/api/notifications/v1 \
-            --path agynio/api/agents/v1
+            --path agynio/api/gateway/v1 \
+            --include-imports
 
       - name: Install Codex CLI
         run: npm install -g @openai/codex
@@ -35,3 +45,4 @@ jobs:
         run: go test -v -count=1 -tags e2e ./test/e2e/
         env:
           OPENAI_API_KEY: test-key
+          AGN_REPO_PATH: ${{ github.workspace }}/.agn-cli

--- a/test/e2e/agn_test.go
+++ b/test/e2e/agn_test.go
@@ -1,0 +1,104 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	agnsdk "github.com/agynio/agn-sdk-go"
+)
+
+const agnTestLLMEndpoint = "https://testllm.dev/v1/org/agynio/suite/agn"
+
+var (
+	buildAgnOnce  sync.Once
+	buildAgnErr   error
+	agnBinaryPath string
+)
+
+func buildAgn(t *testing.T) string {
+	t.Helper()
+	buildAgnOnce.Do(func() {
+		repoPath := os.Getenv("AGN_REPO_PATH")
+		if repoPath == "" {
+			buildAgnErr = fmt.Errorf("AGN_REPO_PATH must be set to the agn-cli repository root")
+			return
+		}
+		dir, err := os.MkdirTemp("", "agn-e2e-")
+		if err != nil {
+			buildAgnErr = err
+			return
+		}
+		agnBinaryPath = filepath.Join(dir, "agn")
+		cmd := exec.Command("go", "build", "-o", agnBinaryPath, "./cmd/agn")
+		cmd.Dir = repoPath
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			buildAgnErr = fmt.Errorf("build agn: %w: %s", err, strings.TrimSpace(string(output)))
+		}
+	})
+	if buildAgnErr != nil {
+		t.Fatalf("build agn binary: %v", buildAgnErr)
+	}
+	return agnBinaryPath
+}
+
+func writeAgnTestConfig(t *testing.T, model string) string {
+	t.Helper()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	config := fmt.Sprintf(`llm:
+  endpoint: %s
+  auth:
+    api_key: dummy
+  model: %s
+`, agnTestLLMEndpoint, model)
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		t.Fatalf("write agn config: %v", err)
+	}
+	return configPath
+}
+
+func TestAgnClientHelloResponse(t *testing.T) {
+	binary := buildAgn(t)
+	configPath := writeAgnTestConfig(t, "simple-hello")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	client, err := agnsdk.Start(ctx, agnsdk.Options{
+		BinaryPath: binary,
+		Env: []string{
+			"AGN_CONFIG_PATH=" + configPath,
+			"AGN_MCP_COMMAND=",
+		},
+	})
+	if err != nil {
+		t.Fatalf("start agn client: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = client.Close()
+	})
+
+	result, err := client.Turn(ctx, agnsdk.TurnParams{
+		Prompt: "hi",
+	}, nil)
+	if err != nil {
+		t.Fatalf("turn failed: %v", err)
+	}
+
+	if result.Response != "Hi! How are you?" {
+		t.Fatalf("unexpected response: %q", result.Response)
+	}
+	if strings.TrimSpace(result.ThreadID) == "" {
+		t.Fatalf("thread ID is empty")
+	}
+}


### PR DESCRIPTION
## Summary
- add agn SDK e2e test that builds agn-cli and validates deterministic response
- update e2e workflow for private module access, agn-cli checkout, and gateway proto generation

## Testing
- buf generate buf.build/agynio/api --path agynio/api/gateway/v1 --include-imports
- GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go test ./...
- GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go vet ./...
- PATH="$(npm prefix -g)/bin:$PATH" AGN_REPO_PATH=/workspace/agn-cli OPENAI_API_KEY=test-key GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go test -v -count=1 -tags e2e ./test/e2e/

Refs #23