### PR TITLE
feat: add bearer token auth for gateway communication

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ type agentConfig struct {
 type Config struct {
 	AgentID        uuid.UUID
 	GatewayAddress string
+	AuthToken      string
 	LLMBaseURL     string
 	ModelOverride  string
 	SDK            string
@@ -64,9 +65,13 @@ func fromEnv(configPath string) (Config, error) {
 		workDir = "/workspace"
 	}
 
+	// AUTH_TOKEN is optional; when empty, no bearer token is sent to the gateway.
+	authToken := strings.TrimSpace(os.Getenv("AUTH_TOKEN"))
+
 	return Config{
 		AgentID:        agentID,
 		GatewayAddress: gatewayAddress,
+		AuthToken:      authToken,
 		LLMBaseURL:     llmBaseURL,
 		ModelOverride:  modelOverride,
 		SDK:            sdk,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -37,6 +37,7 @@ func TestFromEnvValid(t *testing.T) {
 	setRequiredEnv(t)
 	configPath := writeAgentConfig(t, "codex", "/opt/bin/codex")
 	t.Setenv("WORKSPACE_DIR", "/tmp/workdir")
+	t.Setenv("AUTH_TOKEN", " bearer-token ")
 
 	cfg, err := fromEnv(configPath)
 	if err != nil {
@@ -59,6 +60,9 @@ func TestFromEnvValid(t *testing.T) {
 	}
 	if cfg.WorkDir != "/tmp/workdir" {
 		t.Fatalf("unexpected work dir: %s", cfg.WorkDir)
+	}
+	if cfg.AuthToken != "bearer-token" {
+		t.Fatalf("unexpected auth token: %s", cfg.AuthToken)
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -79,7 +79,7 @@ func New(ctx context.Context, cfg config.Config, version string) (*Daemon, error
 }
 
 func connectPlatform(ctx context.Context, cfg config.Config) (*platformSetup, error) {
-	gatewayConn, err := platform.DialGateway(cfg.GatewayAddress)
+	gatewayConn, err := platform.DialGateway(cfg.GatewayAddress, cfg.AuthToken)
 	if err != nil {
 		return nil, fmt.Errorf("dial gateway: %w", err)
 	}

--- a/internal/platform/grpc.go
+++ b/internal/platform/grpc.go
@@ -1,10 +1,34 @@
 package platform
 
 import (
+	"context"
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 )
 
-func DialGateway(address string) (*grpc.ClientConn, error) {
-	return grpc.NewClient(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+func DialGateway(address string, authToken string) (*grpc.ClientConn, error) {
+	opts := []grpc.DialOption{
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	}
+	if authToken != "" {
+		opts = append(opts, grpc.WithUnaryInterceptor(bearerTokenInterceptor(authToken)))
+		opts = append(opts, grpc.WithStreamInterceptor(bearerTokenStreamInterceptor(authToken)))
+	}
+	return grpc.NewClient(address, opts...)
+}
+
+func bearerTokenInterceptor(token string) grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+token)
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+}
+
+func bearerTokenStreamInterceptor(token string) grpc.StreamClientInterceptor {
+	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+token)
+		return streamer(ctx, desc, cc, method, opts...)
+	}
 }


### PR DESCRIPTION
## Summary
- add AUTH_TOKEN to config loading and surface on Config
- attach bearer auth metadata in gRPC gateway dialer
- cover auth token trimming in config tests

## Testing
- go build ./...
- go vet ./...
- go test ./...

Closes #33