### PR TITLE
fix: accumulate items from item/completed notifications in Bridge

### DIFF
--- a/internal/codexbridge/bridge.go
+++ b/internal/codexbridge/bridge.go
@@ -4,16 +4,22 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"sync"
 
 	codex "github.com/agynio/codex-sdk-go"
 )
 
 type Bridge struct {
 	tracker *TurnTracker
+	mu      sync.Mutex
+	items   map[string][]codex.ThreadItem
 }
 
 func New(tracker *TurnTracker) *Bridge {
-	return &Bridge{tracker: tracker}
+	return &Bridge{
+		tracker: tracker,
+		items:   make(map[string][]codex.ThreadItem),
+	}
 }
 
 func (b *Bridge) OnTurnStarted(*codex.TurnStartedNotification) {}
@@ -23,11 +29,22 @@ func (b *Bridge) OnTurnCompleted(notification *codex.TurnCompletedNotification) 
 		return
 	}
 	turnID := notification.Turn.ID
+
+	b.mu.Lock()
+	accumulated := b.items[turnID]
+	delete(b.items, turnID)
+	b.mu.Unlock()
+
+	turn := notification.Turn
+	if len(turn.Items) == 0 && len(accumulated) > 0 {
+		turn.Items = accumulated
+	}
+
 	result := TurnResult{
 		ThreadID: notification.ThreadID,
 		TurnID:   turnID,
 	}
-	message, err := extractFinalAnswer(notification.Turn)
+	message, err := extractFinalAnswer(turn)
 	if err != nil {
 		result.Err = err
 	} else {
@@ -38,7 +55,14 @@ func (b *Bridge) OnTurnCompleted(notification *codex.TurnCompletedNotification) 
 
 func (b *Bridge) OnItemStarted(*codex.ItemStartedNotification) {}
 
-func (b *Bridge) OnItemCompleted(*codex.ItemCompletedNotification) {}
+func (b *Bridge) OnItemCompleted(notification *codex.ItemCompletedNotification) {
+	if notification == nil {
+		return
+	}
+	b.mu.Lock()
+	b.items[notification.TurnID] = append(b.items[notification.TurnID], notification.Item)
+	b.mu.Unlock()
+}
 
 func (b *Bridge) OnAgentMessageDelta(*codex.AgentMessageDeltaNotification) {}
 

--- a/internal/codexbridge/bridge_test.go
+++ b/internal/codexbridge/bridge_test.go
@@ -84,3 +84,33 @@ func TestExtractFinalAnswerNoAgentMessages(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestBridgeAccumulatesItems(t *testing.T) {
+	tracker := NewTurnTracker()
+	bridge := New(tracker)
+	ch := tracker.Register("turn-acc")
+
+	bridge.OnItemCompleted(&codex.ItemCompletedNotification{
+		ThreadID: "thread-1",
+		TurnID:   "turn-acc",
+		Item:     agentMessageItem("Hi! How are you?", nil),
+	})
+
+	bridge.OnTurnCompleted(&codex.TurnCompletedNotification{
+		ThreadID: "thread-1",
+		Turn: codex.Turn{
+			ID:     "turn-acc",
+			Status: codex.TurnStatusCompleted,
+			Items:  nil,
+		},
+	})
+
+	result := receiveResult(t, ch)
+	if result.Err != nil {
+		t.Fatalf("unexpected error: %v", result.Err)
+	}
+	if result.Message != "Hi! How are you?" {
+		t.Fatalf("unexpected message: %q", result.Message)
+	}
+	assertClosed(t, ch)
+}


### PR DESCRIPTION
## Summary
- accumulate item/completed notifications per turn and merge them on turn completion
- add coverage to ensure accumulated items supply final answers

## Testing
- GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go build ./...
- GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go vet ./...
- GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go test ./...

Closes #35