### PR TITLE
feat(daemon): add agn summarization config

### DIFF
--- a/internal/daemon/agentconfig.go
+++ b/internal/daemon/agentconfig.go
@@ -6,19 +6,19 @@ import (
 	"strings"
 )
 
-type SummarizationConfig struct {
+type summarizationConfig struct {
 	KeepTokens *int
 	MaxTokens  *int
-	LLM        *SummarizationLLMConfig
+	LLM        *summarizationLLMConfig
 }
 
-type SummarizationLLMConfig struct {
+type summarizationLLMConfig struct {
 	Endpoint string
-	Auth     SummarizationAuthConfig
+	Auth     summarizationAuthConfig
 	Model    string
 }
 
-type SummarizationAuthConfig struct {
+type summarizationAuthConfig struct {
 	APIKey    string
 	APIKeyEnv string
 }
@@ -28,11 +28,9 @@ type agentConfigurationPayload struct {
 }
 
 type summarizationPayload struct {
-	KeepTokens    *int                     `json:"keep_tokens"`
-	KeepTokensAlt *int                     `json:"keepTokens"`
-	MaxTokens     *int                     `json:"max_tokens"`
-	MaxTokensAlt  *int                     `json:"maxTokens"`
-	LLM           *summarizationLLMPayload `json:"llm"`
+	KeepTokens *int                     `json:"keep_tokens"`
+	MaxTokens  *int                     `json:"max_tokens"`
+	LLM        *summarizationLLMPayload `json:"llm"`
 }
 
 type summarizationLLMPayload struct {
@@ -42,13 +40,11 @@ type summarizationLLMPayload struct {
 }
 
 type summarizationAuthPayload struct {
-	APIKey       string `json:"api_key"`
-	APIKeyAlt    string `json:"apiKey"`
-	APIKeyEnv    string `json:"api_key_env"`
-	APIKeyEnvAlt string `json:"apiKeyEnv"`
+	APIKey    string `json:"api_key"`
+	APIKeyEnv string `json:"api_key_env"`
 }
 
-func parseAgentSummarization(raw string) (*SummarizationConfig, error) {
+func parseAgentSummarization(raw string) (*summarizationConfig, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		return nil, nil
@@ -62,34 +58,14 @@ func parseAgentSummarization(raw string) (*SummarizationConfig, error) {
 	return normalizeSummarizationPayload(payload.Summarization)
 }
 
-func normalizeSummarizationPayload(payload *summarizationPayload) (*SummarizationConfig, error) {
+func normalizeSummarizationPayload(payload *summarizationPayload) (*summarizationConfig, error) {
 	if payload == nil {
 		return nil, nil
 	}
 
-	keepTokens, err := pickOptionalInt(
-		payload.KeepTokens,
-		payload.KeepTokensAlt,
-		"summarization.keep_tokens",
-		"summarization.keepTokens",
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	maxTokens, err := pickOptionalInt(
-		payload.MaxTokens,
-		payload.MaxTokensAlt,
-		"summarization.max_tokens",
-		"summarization.maxTokens",
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	cfg := SummarizationConfig{
-		KeepTokens: keepTokens,
-		MaxTokens:  maxTokens,
+	cfg := summarizationConfig{
+		KeepTokens: payload.KeepTokens,
+		MaxTokens:  payload.MaxTokens,
 	}
 
 	if payload.LLM != nil {
@@ -107,7 +83,7 @@ func normalizeSummarizationPayload(payload *summarizationPayload) (*Summarizatio
 	return &cfg, nil
 }
 
-func normalizeSummarizationLLM(payload *summarizationLLMPayload) (*SummarizationLLMConfig, error) {
+func normalizeSummarizationLLM(payload *summarizationLLMPayload) (*summarizationLLMConfig, error) {
 	endpoint := strings.TrimSpace(payload.Endpoint)
 	if endpoint == "" {
 		return nil, fmt.Errorf("summarization.llm.endpoint is required")
@@ -123,62 +99,22 @@ func normalizeSummarizationLLM(payload *summarizationLLMPayload) (*Summarization
 		return nil, err
 	}
 
-	return &SummarizationLLMConfig{
+	return &summarizationLLMConfig{
 		Endpoint: endpoint,
 		Auth:     auth,
 		Model:    model,
 	}, nil
 }
 
-func normalizeSummarizationAuth(payload summarizationAuthPayload) (SummarizationAuthConfig, error) {
-	apiKey, err := pickOptionalString(
-		payload.APIKey,
-		payload.APIKeyAlt,
-		"summarization.llm.auth.api_key",
-		"summarization.llm.auth.apiKey",
-	)
-	if err != nil {
-		return SummarizationAuthConfig{}, err
-	}
-
-	apiKeyEnv, err := pickOptionalString(
-		payload.APIKeyEnv,
-		payload.APIKeyEnvAlt,
-		"summarization.llm.auth.api_key_env",
-		"summarization.llm.auth.apiKeyEnv",
-	)
-	if err != nil {
-		return SummarizationAuthConfig{}, err
-	}
-
+func normalizeSummarizationAuth(payload summarizationAuthPayload) (summarizationAuthConfig, error) {
+	apiKey := strings.TrimSpace(payload.APIKey)
+	apiKeyEnv := strings.TrimSpace(payload.APIKeyEnv)
 	if apiKey == "" && apiKeyEnv == "" {
-		return SummarizationAuthConfig{}, fmt.Errorf("summarization.llm.auth requires api_key or api_key_env")
+		return summarizationAuthConfig{}, fmt.Errorf("summarization.llm.auth requires api_key or api_key_env")
 	}
 	if apiKey != "" && apiKeyEnv != "" {
-		return SummarizationAuthConfig{}, fmt.Errorf("summarization.llm.auth supports only one of api_key or api_key_env")
+		return summarizationAuthConfig{}, fmt.Errorf("summarization.llm.auth supports only one of api_key or api_key_env")
 	}
 
-	return SummarizationAuthConfig{APIKey: apiKey, APIKeyEnv: apiKeyEnv}, nil
-}
-
-func pickOptionalInt(primary, fallback *int, field, altField string) (*int, error) {
-	if primary != nil && fallback != nil && *primary != *fallback {
-		return nil, fmt.Errorf("%s conflicts with %s", field, altField)
-	}
-	if primary != nil {
-		return primary, nil
-	}
-	return fallback, nil
-}
-
-func pickOptionalString(primary, fallback, field, altField string) (string, error) {
-	primary = strings.TrimSpace(primary)
-	fallback = strings.TrimSpace(fallback)
-	if primary != "" && fallback != "" && primary != fallback {
-		return "", fmt.Errorf("%s conflicts with %s", field, altField)
-	}
-	if primary != "" {
-		return primary, nil
-	}
-	return fallback, nil
+	return summarizationAuthConfig{APIKey: apiKey, APIKeyEnv: apiKeyEnv}, nil
 }

--- a/internal/daemon/agentconfig.go
+++ b/internal/daemon/agentconfig.go
@@ -1,0 +1,184 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type SummarizationConfig struct {
+	KeepTokens *int
+	MaxTokens  *int
+	LLM        *SummarizationLLMConfig
+}
+
+type SummarizationLLMConfig struct {
+	Endpoint string
+	Auth     SummarizationAuthConfig
+	Model    string
+}
+
+type SummarizationAuthConfig struct {
+	APIKey    string
+	APIKeyEnv string
+}
+
+type agentConfigurationPayload struct {
+	Summarization *summarizationPayload `json:"summarization"`
+}
+
+type summarizationPayload struct {
+	KeepTokens    *int                     `json:"keep_tokens"`
+	KeepTokensAlt *int                     `json:"keepTokens"`
+	MaxTokens     *int                     `json:"max_tokens"`
+	MaxTokensAlt  *int                     `json:"maxTokens"`
+	LLM           *summarizationLLMPayload `json:"llm"`
+}
+
+type summarizationLLMPayload struct {
+	Endpoint string                   `json:"endpoint"`
+	Auth     summarizationAuthPayload `json:"auth"`
+	Model    string                   `json:"model"`
+}
+
+type summarizationAuthPayload struct {
+	APIKey       string `json:"api_key"`
+	APIKeyAlt    string `json:"apiKey"`
+	APIKeyEnv    string `json:"api_key_env"`
+	APIKeyEnvAlt string `json:"apiKeyEnv"`
+}
+
+func parseAgentSummarization(raw string) (*SummarizationConfig, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+
+	var payload agentConfigurationPayload
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return nil, fmt.Errorf("parse agent configuration: %w", err)
+	}
+
+	return normalizeSummarizationPayload(payload.Summarization)
+}
+
+func normalizeSummarizationPayload(payload *summarizationPayload) (*SummarizationConfig, error) {
+	if payload == nil {
+		return nil, nil
+	}
+
+	keepTokens, err := pickOptionalInt(
+		payload.KeepTokens,
+		payload.KeepTokensAlt,
+		"summarization.keep_tokens",
+		"summarization.keepTokens",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	maxTokens, err := pickOptionalInt(
+		payload.MaxTokens,
+		payload.MaxTokensAlt,
+		"summarization.max_tokens",
+		"summarization.maxTokens",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := SummarizationConfig{
+		KeepTokens: keepTokens,
+		MaxTokens:  maxTokens,
+	}
+
+	if payload.LLM != nil {
+		llm, err := normalizeSummarizationLLM(payload.LLM)
+		if err != nil {
+			return nil, err
+		}
+		cfg.LLM = llm
+	}
+
+	if cfg.KeepTokens == nil && cfg.MaxTokens == nil && cfg.LLM == nil {
+		return nil, nil
+	}
+
+	return &cfg, nil
+}
+
+func normalizeSummarizationLLM(payload *summarizationLLMPayload) (*SummarizationLLMConfig, error) {
+	endpoint := strings.TrimSpace(payload.Endpoint)
+	if endpoint == "" {
+		return nil, fmt.Errorf("summarization.llm.endpoint is required")
+	}
+
+	model := strings.TrimSpace(payload.Model)
+	if model == "" {
+		return nil, fmt.Errorf("summarization.llm.model is required")
+	}
+
+	auth, err := normalizeSummarizationAuth(payload.Auth)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SummarizationLLMConfig{
+		Endpoint: endpoint,
+		Auth:     auth,
+		Model:    model,
+	}, nil
+}
+
+func normalizeSummarizationAuth(payload summarizationAuthPayload) (SummarizationAuthConfig, error) {
+	apiKey, err := pickOptionalString(
+		payload.APIKey,
+		payload.APIKeyAlt,
+		"summarization.llm.auth.api_key",
+		"summarization.llm.auth.apiKey",
+	)
+	if err != nil {
+		return SummarizationAuthConfig{}, err
+	}
+
+	apiKeyEnv, err := pickOptionalString(
+		payload.APIKeyEnv,
+		payload.APIKeyEnvAlt,
+		"summarization.llm.auth.api_key_env",
+		"summarization.llm.auth.apiKeyEnv",
+	)
+	if err != nil {
+		return SummarizationAuthConfig{}, err
+	}
+
+	if apiKey == "" && apiKeyEnv == "" {
+		return SummarizationAuthConfig{}, fmt.Errorf("summarization.llm.auth requires api_key or api_key_env")
+	}
+	if apiKey != "" && apiKeyEnv != "" {
+		return SummarizationAuthConfig{}, fmt.Errorf("summarization.llm.auth supports only one of api_key or api_key_env")
+	}
+
+	return SummarizationAuthConfig{APIKey: apiKey, APIKeyEnv: apiKeyEnv}, nil
+}
+
+func pickOptionalInt(primary, fallback *int, field, altField string) (*int, error) {
+	if primary != nil && fallback != nil && *primary != *fallback {
+		return nil, fmt.Errorf("%s conflicts with %s", field, altField)
+	}
+	if primary != nil {
+		return primary, nil
+	}
+	return fallback, nil
+}
+
+func pickOptionalString(primary, fallback, field, altField string) (string, error) {
+	primary = strings.TrimSpace(primary)
+	fallback = strings.TrimSpace(fallback)
+	if primary != "" && fallback != "" && primary != fallback {
+		return "", fmt.Errorf("%s conflicts with %s", field, altField)
+	}
+	if primary != "" {
+		return primary, nil
+	}
+	return fallback, nil
+}

--- a/internal/daemon/agentconfig_test.go
+++ b/internal/daemon/agentconfig_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 )
 
-func TestParseAgentSummarizationValid(t *testing.T) {
-	payload := `{"summarization":{"keepTokens":42,"max_tokens":100,"llm":{"endpoint":"https://sum.example.com","auth":{"apiKeyEnv":"SUM_KEY"},"model":"gpt-4.1-mini"}}}`
+func TestParseAgentSummarizationValidAPIKey(t *testing.T) {
+	payload := `{"summarization":{"keep_tokens":42,"max_tokens":100,"llm":{"endpoint":"https://sum.example.com","auth":{"api_key":"sum-key"},"model":"gpt-4.1-mini"}}}`
 
 	cfg, err := parseAgentSummarization(payload)
 	if err != nil {
@@ -30,8 +30,44 @@ func TestParseAgentSummarizationValid(t *testing.T) {
 	if cfg.LLM.Model != "gpt-4.1-mini" {
 		t.Fatalf("unexpected LLM model: %s", cfg.LLM.Model)
 	}
+	if cfg.LLM.Auth.APIKey != "sum-key" || cfg.LLM.Auth.APIKeyEnv != "" {
+		t.Fatalf("unexpected LLM auth: %#v", cfg.LLM.Auth)
+	}
+}
+
+func TestParseAgentSummarizationValidAPIKeyEnv(t *testing.T) {
+	payload := `{"summarization":{"keep_tokens":5,"max_tokens":9,"llm":{"endpoint":"https://sum.example.com","auth":{"api_key_env":"SUM_KEY"},"model":"gpt-4.1-mini"}}}`
+
+	cfg, err := parseAgentSummarization(payload)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected summarization config")
+	}
+	if cfg.KeepTokens == nil || *cfg.KeepTokens != 5 {
+		t.Fatalf("unexpected keep tokens: %#v", cfg.KeepTokens)
+	}
+	if cfg.MaxTokens == nil || *cfg.MaxTokens != 9 {
+		t.Fatalf("unexpected max tokens: %#v", cfg.MaxTokens)
+	}
+	if cfg.LLM == nil {
+		t.Fatal("expected summarization LLM")
+	}
 	if cfg.LLM.Auth.APIKeyEnv != "SUM_KEY" || cfg.LLM.Auth.APIKey != "" {
 		t.Fatalf("unexpected LLM auth: %#v", cfg.LLM.Auth)
+	}
+}
+
+func TestParseAgentSummarizationNoBlock(t *testing.T) {
+	payload := `{"system_prompt":"hello"}`
+
+	cfg, err := parseAgentSummarization(payload)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if cfg != nil {
+		t.Fatalf("expected nil config, got %#v", cfg)
 	}
 }
 

--- a/internal/daemon/agentconfig_test.go
+++ b/internal/daemon/agentconfig_test.go
@@ -1,0 +1,74 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseAgentSummarizationValid(t *testing.T) {
+	payload := `{"summarization":{"keepTokens":42,"max_tokens":100,"llm":{"endpoint":"https://sum.example.com","auth":{"apiKeyEnv":"SUM_KEY"},"model":"gpt-4.1-mini"}}}`
+
+	cfg, err := parseAgentSummarization(payload)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected summarization config")
+	}
+	if cfg.KeepTokens == nil || *cfg.KeepTokens != 42 {
+		t.Fatalf("unexpected keep tokens: %#v", cfg.KeepTokens)
+	}
+	if cfg.MaxTokens == nil || *cfg.MaxTokens != 100 {
+		t.Fatalf("unexpected max tokens: %#v", cfg.MaxTokens)
+	}
+	if cfg.LLM == nil {
+		t.Fatal("expected summarization LLM")
+	}
+	if cfg.LLM.Endpoint != "https://sum.example.com" {
+		t.Fatalf("unexpected LLM endpoint: %s", cfg.LLM.Endpoint)
+	}
+	if cfg.LLM.Model != "gpt-4.1-mini" {
+		t.Fatalf("unexpected LLM model: %s", cfg.LLM.Model)
+	}
+	if cfg.LLM.Auth.APIKeyEnv != "SUM_KEY" || cfg.LLM.Auth.APIKey != "" {
+		t.Fatalf("unexpected LLM auth: %#v", cfg.LLM.Auth)
+	}
+}
+
+func TestParseAgentSummarizationInvalidJSON(t *testing.T) {
+	_, err := parseAgentSummarization("{")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !strings.Contains(err.Error(), "parse agent configuration") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestParseAgentSummarizationInvalidAuth(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+	}{
+		{
+			name:    "missing-auth",
+			payload: `{"summarization":{"llm":{"endpoint":"https://sum.example.com","auth":{},"model":"gpt-4.1-mini"}}}`,
+		},
+		{
+			name:    "conflicting-auth",
+			payload: `{"summarization":{"llm":{"endpoint":"https://sum.example.com","auth":{"api_key":"a","api_key_env":"ENV"},"model":"gpt-4.1-mini"}}}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := parseAgentSummarization(test.payload)
+			if err == nil {
+				t.Fatalf("expected error for %s", test.name)
+			}
+			if !strings.Contains(err.Error(), "summarization.llm.auth") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/internal/daemon/agn.go
+++ b/internal/daemon/agn.go
@@ -21,7 +21,19 @@ func newAgnDaemon(ctx context.Context, cfg config.Config, version string) (*Daem
 		return nil, err
 	}
 
-	_, configPath, err := writeAgnConfig(cfg.LLMBaseURL, cfg.LLMAPIToken, setup.agent.GetModel(), cfg.MCPServers)
+	summarization, err := parseAgentSummarization(setup.agent.GetConfiguration())
+	if err != nil {
+		_ = setup.gatewayConn.Close()
+		return nil, err
+	}
+
+	_, configPath, err := writeAgnConfig(
+		cfg.LLMBaseURL,
+		cfg.LLMAPIToken,
+		setup.agent.GetModel(),
+		summarization,
+		cfg.MCPServers,
+	)
 	if err != nil {
 		_ = setup.gatewayConn.Close()
 		return nil, err

--- a/internal/daemon/agnconfig.go
+++ b/internal/daemon/agnconfig.go
@@ -16,7 +16,7 @@ const agnConfigTemplate = `llm:
   model: %s
 `
 
-func writeAgnConfig(llmBaseURL, apiKey, model string, mcpServers []config.MCPServer) (string, string, error) {
+func writeAgnConfig(llmBaseURL, apiKey, model string, summarization *SummarizationConfig, mcpServers []config.MCPServer) (string, string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", "", fmt.Errorf("resolve home directory: %w", err)
@@ -26,24 +26,52 @@ func writeAgnConfig(llmBaseURL, apiKey, model string, mcpServers []config.MCPSer
 		return "", "", fmt.Errorf("create agn config dir: %w", err)
 	}
 	configPath := filepath.Join(agnDir, "config.yaml")
-	payload := agnConfig(llmBaseURL, apiKey, model, mcpServers)
+	payload := agnConfig(llmBaseURL, apiKey, model, summarization, mcpServers)
 	if err := os.WriteFile(configPath, []byte(payload), 0o600); err != nil {
 		return "", "", fmt.Errorf("write agn config: %w", err)
 	}
 	return agnDir, configPath, nil
 }
 
-func agnConfig(llmBaseURL, apiKey, model string, mcpServers []config.MCPServer) string {
+func agnConfig(llmBaseURL, apiKey, model string, summarization *SummarizationConfig, mcpServers []config.MCPServer) string {
 	payload := fmt.Sprintf(agnConfigTemplate, llmBaseURL, apiKey, model)
-	if len(mcpServers) == 0 {
+	if summarization == nil && len(mcpServers) == 0 {
 		return payload
 	}
 	var builder strings.Builder
 	builder.WriteString(payload)
-	builder.WriteString("mcp:\n  servers:\n")
-	for _, server := range mcpServers {
-		url := fmt.Sprintf("http://localhost:%d/mcp", server.Port)
-		fmt.Fprintf(&builder, "    %s:\n      url: %s\n", server.Name, url)
+	if summarization != nil {
+		appendSummarizationConfig(&builder, summarization)
+	}
+	if len(mcpServers) > 0 {
+		builder.WriteString("mcp:\n  servers:\n")
+		for _, server := range mcpServers {
+			url := fmt.Sprintf("http://localhost:%d/mcp", server.Port)
+			fmt.Fprintf(&builder, "    %s:\n      url: %s\n", server.Name, url)
+		}
 	}
 	return builder.String()
+}
+
+func appendSummarizationConfig(builder *strings.Builder, summarization *SummarizationConfig) {
+	builder.WriteString("summarization:\n")
+	if summarization.KeepTokens != nil {
+		fmt.Fprintf(builder, "  keep_tokens: %d\n", *summarization.KeepTokens)
+	}
+	if summarization.MaxTokens != nil {
+		fmt.Fprintf(builder, "  max_tokens: %d\n", *summarization.MaxTokens)
+	}
+	if summarization.LLM == nil {
+		return
+	}
+	builder.WriteString("  llm:\n")
+	fmt.Fprintf(builder, "    endpoint: %s\n", summarization.LLM.Endpoint)
+	builder.WriteString("    auth:\n")
+	if summarization.LLM.Auth.APIKey != "" {
+		fmt.Fprintf(builder, "      api_key: %s\n", summarization.LLM.Auth.APIKey)
+	}
+	if summarization.LLM.Auth.APIKeyEnv != "" {
+		fmt.Fprintf(builder, "      api_key_env: %s\n", summarization.LLM.Auth.APIKeyEnv)
+	}
+	fmt.Fprintf(builder, "    model: %s\n", summarization.LLM.Model)
 }

--- a/internal/daemon/agnconfig.go
+++ b/internal/daemon/agnconfig.go
@@ -16,7 +16,7 @@ const agnConfigTemplate = `llm:
   model: %s
 `
 
-func writeAgnConfig(llmBaseURL, apiKey, model string, summarization *SummarizationConfig, mcpServers []config.MCPServer) (string, string, error) {
+func writeAgnConfig(llmBaseURL, apiKey, model string, summarization *summarizationConfig, mcpServers []config.MCPServer) (string, string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", "", fmt.Errorf("resolve home directory: %w", err)
@@ -33,7 +33,7 @@ func writeAgnConfig(llmBaseURL, apiKey, model string, summarization *Summarizati
 	return agnDir, configPath, nil
 }
 
-func agnConfig(llmBaseURL, apiKey, model string, summarization *SummarizationConfig, mcpServers []config.MCPServer) string {
+func agnConfig(llmBaseURL, apiKey, model string, summarization *summarizationConfig, mcpServers []config.MCPServer) string {
 	payload := fmt.Sprintf(agnConfigTemplate, llmBaseURL, apiKey, model)
 	if summarization == nil && len(mcpServers) == 0 {
 		return payload
@@ -53,7 +53,7 @@ func agnConfig(llmBaseURL, apiKey, model string, summarization *SummarizationCon
 	return builder.String()
 }
 
-func appendSummarizationConfig(builder *strings.Builder, summarization *SummarizationConfig) {
+func appendSummarizationConfig(builder *strings.Builder, summarization *summarizationConfig) {
 	builder.WriteString("summarization:\n")
 	if summarization.KeepTokens != nil {
 		fmt.Fprintf(builder, "  keep_tokens: %d\n", *summarization.KeepTokens)

--- a/internal/daemon/agnconfig_test.go
+++ b/internal/daemon/agnconfig_test.go
@@ -16,7 +16,7 @@ func TestWriteAgnConfig(t *testing.T) {
 	baseURL := "https://example.com"
 	apiKey := "test-api-key"
 	model := "test-model-id"
-	agnDir, configPath, err := writeAgnConfig(baseURL, apiKey, model, nil)
+	agnDir, configPath, err := writeAgnConfig(baseURL, apiKey, model, nil, nil)
 	if err != nil {
 		t.Fatalf("expected config to be written, got %v", err)
 	}
@@ -53,7 +53,7 @@ func TestWriteAgnConfigWithMCPServers(t *testing.T) {
 		{Name: "memory", Port: 8100},
 		{Name: "filesystem", Port: 8200},
 	}
-	agnDir, configPath, err := writeAgnConfig(baseURL, apiKey, model, mcpServers)
+	agnDir, configPath, err := writeAgnConfig(baseURL, apiKey, model, nil, mcpServers)
 	if err != nil {
 		t.Fatalf("expected config to be written, got %v", err)
 	}
@@ -77,6 +77,60 @@ func TestWriteAgnConfigWithMCPServers(t *testing.T) {
 		"mcp:\n  servers:\n" +
 		"    memory:\n      url: http://localhost:8100/mcp\n" +
 		"    filesystem:\n      url: http://localhost:8200/mcp\n"
+	if string(content) != expected {
+		t.Fatalf("expected config %q, got %q", expected, string(content))
+	}
+}
+
+func TestWriteAgnConfigWithSummarization(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	baseURL := "https://example.com"
+	apiKey := "test-api-key"
+	model := "test-model-id"
+	keepTokens := 10
+	maxTokens := 200
+	summarization := &SummarizationConfig{
+		KeepTokens: &keepTokens,
+		MaxTokens:  &maxTokens,
+		LLM: &SummarizationLLMConfig{
+			Endpoint: "https://summarization.example.com",
+			Auth: SummarizationAuthConfig{
+				APIKeyEnv: "SUMMARIZE_KEY",
+			},
+			Model: "gpt-4.1-mini",
+		},
+	}
+	agnDir, configPath, err := writeAgnConfig(baseURL, apiKey, model, summarization, nil)
+	if err != nil {
+		t.Fatalf("expected config to be written, got %v", err)
+	}
+
+	expectedDir := filepath.Join(tmpHome, ".agyn", "agn")
+	if agnDir != expectedDir {
+		t.Fatalf("expected agn dir %q, got %q", expectedDir, agnDir)
+	}
+
+	expectedPath := filepath.Join(expectedDir, "config.yaml")
+	if configPath != expectedPath {
+		t.Fatalf("expected config path %q, got %q", expectedPath, configPath)
+	}
+
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("expected config to be readable, got %v", err)
+	}
+
+	expected := fmt.Sprintf(agnConfigTemplate, baseURL, apiKey, model) +
+		"summarization:\n" +
+		"  keep_tokens: 10\n" +
+		"  max_tokens: 200\n" +
+		"  llm:\n" +
+		"    endpoint: https://summarization.example.com\n" +
+		"    auth:\n" +
+		"      api_key_env: SUMMARIZE_KEY\n" +
+		"    model: gpt-4.1-mini\n"
 	if string(content) != expected {
 		t.Fatalf("expected config %q, got %q", expected, string(content))
 	}

--- a/internal/daemon/agnconfig_test.go
+++ b/internal/daemon/agnconfig_test.go
@@ -42,6 +42,27 @@ func TestWriteAgnConfig(t *testing.T) {
 	}
 }
 
+func TestAgnConfigNoSummarizationInJSON(t *testing.T) {
+	baseURL := "https://example.com"
+	apiKey := "test-api-key"
+	model := "test-model-id"
+	configJSON := `{"system_prompt":"hello"}`
+
+	summarization, err := parseAgentSummarization(configJSON)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if summarization != nil {
+		t.Fatalf("expected nil summarization, got %#v", summarization)
+	}
+
+	content := agnConfig(baseURL, apiKey, model, summarization, nil)
+	expected := fmt.Sprintf(agnConfigTemplate, baseURL, apiKey, model)
+	if content != expected {
+		t.Fatalf("expected config %q, got %q", expected, content)
+	}
+}
+
 func TestWriteAgnConfigWithMCPServers(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
@@ -82,7 +103,7 @@ func TestWriteAgnConfigWithMCPServers(t *testing.T) {
 	}
 }
 
-func TestWriteAgnConfigWithSummarization(t *testing.T) {
+func TestWriteAgnConfigWithSummarizationThresholds(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
 
@@ -91,13 +112,45 @@ func TestWriteAgnConfigWithSummarization(t *testing.T) {
 	model := "test-model-id"
 	keepTokens := 10
 	maxTokens := 200
-	summarization := &SummarizationConfig{
+	summarization := &summarizationConfig{
 		KeepTokens: &keepTokens,
 		MaxTokens:  &maxTokens,
-		LLM: &SummarizationLLMConfig{
+	}
+	_, configPath, err := writeAgnConfig(baseURL, apiKey, model, summarization, nil)
+	if err != nil {
+		t.Fatalf("expected config to be written, got %v", err)
+	}
+
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("expected config to be readable, got %v", err)
+	}
+
+	expected := fmt.Sprintf(agnConfigTemplate, baseURL, apiKey, model) +
+		"summarization:\n" +
+		"  keep_tokens: 10\n" +
+		"  max_tokens: 200\n"
+	if string(content) != expected {
+		t.Fatalf("expected config %q, got %q", expected, string(content))
+	}
+}
+
+func TestWriteAgnConfigWithSummarizationLLMAPIKey(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	baseURL := "https://example.com"
+	apiKey := "test-api-key"
+	model := "test-model-id"
+	keepTokens := 10
+	maxTokens := 200
+	summarization := &summarizationConfig{
+		KeepTokens: &keepTokens,
+		MaxTokens:  &maxTokens,
+		LLM: &summarizationLLMConfig{
 			Endpoint: "https://summarization.example.com",
-			Auth: SummarizationAuthConfig{
-				APIKeyEnv: "SUMMARIZE_KEY",
+			Auth: summarizationAuthConfig{
+				APIKey: "sum-key",
 			},
 			Model: "gpt-4.1-mini",
 		},
@@ -115,6 +168,50 @@ func TestWriteAgnConfigWithSummarization(t *testing.T) {
 	expectedPath := filepath.Join(expectedDir, "config.yaml")
 	if configPath != expectedPath {
 		t.Fatalf("expected config path %q, got %q", expectedPath, configPath)
+	}
+
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("expected config to be readable, got %v", err)
+	}
+
+	expected := fmt.Sprintf(agnConfigTemplate, baseURL, apiKey, model) +
+		"summarization:\n" +
+		"  keep_tokens: 10\n" +
+		"  max_tokens: 200\n" +
+		"  llm:\n" +
+		"    endpoint: https://summarization.example.com\n" +
+		"    auth:\n" +
+		"      api_key: sum-key\n" +
+		"    model: gpt-4.1-mini\n"
+	if string(content) != expected {
+		t.Fatalf("expected config %q, got %q", expected, string(content))
+	}
+}
+
+func TestWriteAgnConfigWithSummarizationLLMAPIKeyEnv(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	baseURL := "https://example.com"
+	apiKey := "test-api-key"
+	model := "test-model-id"
+	keepTokens := 10
+	maxTokens := 200
+	summarization := &summarizationConfig{
+		KeepTokens: &keepTokens,
+		MaxTokens:  &maxTokens,
+		LLM: &summarizationLLMConfig{
+			Endpoint: "https://summarization.example.com",
+			Auth: summarizationAuthConfig{
+				APIKeyEnv: "SUMMARIZE_KEY",
+			},
+			Model: "gpt-4.1-mini",
+		},
+	}
+	_, configPath, err := writeAgnConfig(baseURL, apiKey, model, summarization, nil)
+	if err != nil {
+		t.Fatalf("expected config to be written, got %v", err)
 	}
 
 	content, err := os.ReadFile(configPath)


### PR DESCRIPTION
## Summary
- parse agent configuration JSON for summarization settings and validate auth
- include summarization block in generated agn YAML config
- add unit tests for summarization parsing/output

## Testing
- GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go test ./...
- GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go vet ./...

Fixes #63