### PR TITLE
feat(codex): persist thread mapping

### DIFF
--- a/internal/codexbridge/mapping.go
+++ b/internal/codexbridge/mapping.go
@@ -4,29 +4,48 @@ import "sync"
 
 type ThreadMapping struct {
 	mu              sync.RWMutex
-	platformToCodex map[string]string
+	platformToCodex map[string]ThreadMappingRecord
 	codexToPlatform map[string]string
 }
 
 func NewThreadMapping() *ThreadMapping {
 	return &ThreadMapping{
-		platformToCodex: make(map[string]string),
+		platformToCodex: make(map[string]ThreadMappingRecord),
 		codexToPlatform: make(map[string]string),
 	}
 }
 
 func (m *ThreadMapping) Set(platformThreadID, codexThreadID string) {
+	m.SetRecord(ThreadMappingRecord{
+		PlatformThreadID: platformThreadID,
+		CodexThreadID:    codexThreadID,
+	})
+}
+
+func (m *ThreadMapping) SetRecord(record ThreadMappingRecord) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.platformToCodex[platformThreadID] = codexThreadID
-	m.codexToPlatform[codexThreadID] = platformThreadID
+	if existing, ok := m.platformToCodex[record.PlatformThreadID]; ok {
+		if existing.CodexThreadID != record.CodexThreadID {
+			delete(m.codexToPlatform, existing.CodexThreadID)
+		}
+	}
+	m.platformToCodex[record.PlatformThreadID] = record
+	m.codexToPlatform[record.CodexThreadID] = record.PlatformThreadID
+}
+
+func (m *ThreadMapping) RecordForPlatform(platformThreadID string) (ThreadMappingRecord, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	record, ok := m.platformToCodex[platformThreadID]
+	return record, ok
 }
 
 func (m *ThreadMapping) CodexForPlatform(platformThreadID string) (string, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	codexThreadID, ok := m.platformToCodex[platformThreadID]
-	return codexThreadID, ok
+	record, ok := m.platformToCodex[platformThreadID]
+	return record.CodexThreadID, ok
 }
 
 func (m *ThreadMapping) PlatformForCodex(codexThreadID string) (string, bool) {

--- a/internal/codexbridge/mapping.go
+++ b/internal/codexbridge/mapping.go
@@ -15,13 +15,6 @@ func NewThreadMapping() *ThreadMapping {
 	}
 }
 
-func (m *ThreadMapping) Set(platformThreadID, codexThreadID string) {
-	m.SetRecord(ThreadMappingRecord{
-		PlatformThreadID: platformThreadID,
-		CodexThreadID:    codexThreadID,
-	})
-}
-
 func (m *ThreadMapping) SetRecord(record ThreadMappingRecord) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/codexbridge/mapping_test.go
+++ b/internal/codexbridge/mapping_test.go
@@ -2,9 +2,18 @@ package codexbridge
 
 import "testing"
 
+func newMappingRecord(platformID, codexID string, createdAt, lastUsedAt int64) ThreadMappingRecord {
+	return ThreadMappingRecord{
+		PlatformThreadID: platformID,
+		CodexThreadID:    codexID,
+		CreatedAtUnixMs:  createdAt,
+		LastUsedAtUnixMs: lastUsedAt,
+	}
+}
+
 func TestThreadMappingSetGet(t *testing.T) {
 	mapping := NewThreadMapping()
-	mapping.Set("platform-1", "codex-1")
+	mapping.SetRecord(newMappingRecord("platform-1", "codex-1", 1700000000000, 1700000000100))
 	got, ok := mapping.CodexForPlatform("platform-1")
 	if !ok {
 		t.Fatal("expected mapping to exist")
@@ -16,7 +25,7 @@ func TestThreadMappingSetGet(t *testing.T) {
 
 func TestThreadMappingBidirectional(t *testing.T) {
 	mapping := NewThreadMapping()
-	mapping.Set("platform-2", "codex-2")
+	mapping.SetRecord(newMappingRecord("platform-2", "codex-2", 1700000000000, 1700000000200))
 	got, ok := mapping.PlatformForCodex("codex-2")
 	if !ok {
 		t.Fatal("expected reverse mapping to exist")
@@ -38,8 +47,8 @@ func TestThreadMappingMissing(t *testing.T) {
 
 func TestThreadMappingOverwrite(t *testing.T) {
 	mapping := NewThreadMapping()
-	mapping.Set("platform-3", "codex-3")
-	mapping.Set("platform-3", "codex-4")
+	mapping.SetRecord(newMappingRecord("platform-3", "codex-3", 1700000000000, 1700000000300))
+	mapping.SetRecord(newMappingRecord("platform-3", "codex-4", 1700000000000, 1700000000400))
 	got, ok := mapping.CodexForPlatform("platform-3")
 	if !ok {
 		t.Fatal("expected mapping to exist")

--- a/internal/codexbridge/thread_mapping_store.go
+++ b/internal/codexbridge/thread_mapping_store.go
@@ -1,0 +1,142 @@
+package codexbridge
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	threadMappingDirMode  = 0o700
+	threadMappingFileMode = 0o600
+)
+
+type ThreadMappingRecord struct {
+	PlatformThreadID string `json:"platform_thread_id"`
+	CodexThreadID    string `json:"codex_thread_id"`
+	CreatedAtUnixMs  int64  `json:"created_at_unix_ms"`
+	LastUsedAtUnixMs int64  `json:"last_used_at_unix_ms"`
+}
+
+func (r ThreadMappingRecord) validate() error {
+	if r.PlatformThreadID == "" {
+		return fmt.Errorf("platform_thread_id is required")
+	}
+	if r.CodexThreadID == "" {
+		return fmt.Errorf("codex_thread_id is required")
+	}
+	if r.CreatedAtUnixMs <= 0 {
+		return fmt.Errorf("created_at_unix_ms is required")
+	}
+	if r.LastUsedAtUnixMs <= 0 {
+		return fmt.Errorf("last_used_at_unix_ms is required")
+	}
+	if r.LastUsedAtUnixMs < r.CreatedAtUnixMs {
+		return fmt.Errorf("last_used_at_unix_ms precedes created_at_unix_ms")
+	}
+	if strings.TrimSpace(r.PlatformThreadID) != r.PlatformThreadID {
+		return fmt.Errorf("platform_thread_id contains whitespace")
+	}
+	if strings.TrimSpace(r.CodexThreadID) != r.CodexThreadID {
+		return fmt.Errorf("codex_thread_id contains whitespace")
+	}
+	return nil
+}
+
+type ThreadMappingStore struct {
+	dir        string
+	createTemp func(dir, pattern string) (*os.File, error)
+	rename     func(oldpath, newpath string) error
+}
+
+func NewThreadMappingStore(codexHome string) *ThreadMappingStore {
+	return &ThreadMappingStore{
+		dir:        filepath.Join(codexHome, "agynd", "thread-mapping"),
+		createTemp: os.CreateTemp,
+		rename:     os.Rename,
+	}
+}
+
+func (s *ThreadMappingStore) Load(platformThreadID string) (ThreadMappingRecord, bool, error) {
+	path, err := s.mappingPath(platformThreadID)
+	if err != nil {
+		return ThreadMappingRecord{}, false, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return ThreadMappingRecord{}, false, nil
+		}
+		return ThreadMappingRecord{}, false, fmt.Errorf("read mapping: %w", err)
+	}
+	var record ThreadMappingRecord
+	if err := json.Unmarshal(data, &record); err != nil {
+		return ThreadMappingRecord{}, false, fmt.Errorf("parse mapping: %w", err)
+	}
+	if err := record.validate(); err != nil {
+		return ThreadMappingRecord{}, false, fmt.Errorf("invalid mapping: %w", err)
+	}
+	if record.PlatformThreadID != platformThreadID {
+		return ThreadMappingRecord{}, false, fmt.Errorf("mapping platform_thread_id mismatch")
+	}
+	return record, true, nil
+}
+
+func (s *ThreadMappingStore) Save(record ThreadMappingRecord) error {
+	if err := record.validate(); err != nil {
+		return fmt.Errorf("invalid mapping: %w", err)
+	}
+	path, err := s.mappingPath(record.PlatformThreadID)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(s.dir, threadMappingDirMode); err != nil {
+		return fmt.Errorf("create mapping dir: %w", err)
+	}
+	payload, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("marshal mapping: %w", err)
+	}
+	file, err := s.createTemp(s.dir, "tmp-*.json")
+	if err != nil {
+		return fmt.Errorf("create temp mapping: %w", err)
+	}
+	cleanup := func() {
+		_ = file.Close()
+		_ = os.Remove(file.Name())
+	}
+	if _, err := file.Write(payload); err != nil {
+		cleanup()
+		return fmt.Errorf("write mapping: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		cleanup()
+		return fmt.Errorf("sync mapping: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("close mapping: %w", err)
+	}
+	if err := s.rename(file.Name(), path); err != nil {
+		cleanup()
+		return fmt.Errorf("rename mapping: %w", err)
+	}
+	if err := os.Chmod(path, threadMappingFileMode); err != nil {
+		return fmt.Errorf("chmod mapping: %w", err)
+	}
+	return nil
+}
+
+func (s *ThreadMappingStore) mappingPath(platformThreadID string) (string, error) {
+	platformThreadID = strings.TrimSpace(platformThreadID)
+	if platformThreadID == "" {
+		return "", fmt.Errorf("platform thread id is required")
+	}
+	if strings.ContainsRune(platformThreadID, filepath.Separator) || filepath.Base(platformThreadID) != platformThreadID {
+		return "", fmt.Errorf("platform thread id %q is invalid", platformThreadID)
+	}
+	return filepath.Join(s.dir, platformThreadID+".json"), nil
+}

--- a/internal/codexbridge/thread_mapping_store_test.go
+++ b/internal/codexbridge/thread_mapping_store_test.go
@@ -1,0 +1,109 @@
+package codexbridge
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestThreadMappingStoreSaveLoad(t *testing.T) {
+	baseDir := t.TempDir()
+	store := NewThreadMappingStore(baseDir)
+	record := ThreadMappingRecord{
+		PlatformThreadID: "platform-1",
+		CodexThreadID:    "codex-1",
+		CreatedAtUnixMs:  1700000000000,
+		LastUsedAtUnixMs: 1700000001234,
+	}
+	if err := store.Save(record); err != nil {
+		t.Fatalf("expected save to succeed, got %v", err)
+	}
+	got, ok, err := store.Load("platform-1")
+	if err != nil {
+		t.Fatalf("expected load to succeed, got %v", err)
+	}
+	if !ok {
+		t.Fatal("expected mapping to be found")
+	}
+	if !reflect.DeepEqual(got, record) {
+		t.Fatalf("unexpected record: %#v", got)
+	}
+	path, err := store.mappingPath("platform-1")
+	if err != nil {
+		t.Fatalf("expected mapping path, got %v", err)
+	}
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("expected mapping file to exist, got %v", err)
+	}
+	if fileInfo.Mode().Perm() != threadMappingFileMode {
+		t.Fatalf("expected file mode %o, got %o", threadMappingFileMode, fileInfo.Mode().Perm())
+	}
+	dirInfo, err := os.Stat(filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("expected mapping dir to exist, got %v", err)
+	}
+	if dirInfo.Mode().Perm() != threadMappingDirMode {
+		t.Fatalf("expected dir mode %o, got %o", threadMappingDirMode, dirInfo.Mode().Perm())
+	}
+}
+
+func TestThreadMappingStoreLoadMissing(t *testing.T) {
+	store := NewThreadMappingStore(t.TempDir())
+	_, ok, err := store.Load("platform-missing")
+	if err != nil {
+		t.Fatalf("expected missing load to succeed, got %v", err)
+	}
+	if ok {
+		t.Fatal("expected missing mapping to return ok=false")
+	}
+}
+
+func TestThreadMappingStoreSaveAtomic(t *testing.T) {
+	baseDir := t.TempDir()
+	store := NewThreadMappingStore(baseDir)
+	original := ThreadMappingRecord{
+		PlatformThreadID: "platform-atomic",
+		CodexThreadID:    "codex-old",
+		CreatedAtUnixMs:  1700000000000,
+		LastUsedAtUnixMs: 1700000000100,
+	}
+	if err := store.Save(original); err != nil {
+		t.Fatalf("expected initial save to succeed, got %v", err)
+	}
+	store.rename = func(oldpath, newpath string) error {
+		return fmt.Errorf("rename failed")
+	}
+	updated := ThreadMappingRecord{
+		PlatformThreadID: "platform-atomic",
+		CodexThreadID:    "codex-new",
+		CreatedAtUnixMs:  1700000000000,
+		LastUsedAtUnixMs: 1700000000200,
+	}
+	if err := store.Save(updated); err == nil {
+		t.Fatal("expected save to fail when rename fails")
+	}
+	got, ok, err := store.Load("platform-atomic")
+	if err != nil {
+		t.Fatalf("expected load after failed save to succeed, got %v", err)
+	}
+	if !ok {
+		t.Fatal("expected mapping to still exist after failed save")
+	}
+	if got.CodexThreadID != original.CodexThreadID {
+		t.Fatalf("expected original mapping to remain, got %q", got.CodexThreadID)
+	}
+	path, err := store.mappingPath("platform-atomic")
+	if err != nil {
+		t.Fatalf("expected mapping path, got %v", err)
+	}
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("expected mapping dir to be readable, got %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected no temp files, found %d entries", len(entries))
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -351,53 +351,50 @@ func (d *Daemon) handleCodexMessage(ctx context.Context, message platform.Messag
 }
 
 func (d *Daemon) ensureCodexThread(ctx context.Context, platformThreadID string) (string, error) {
+	if d.mappingStore == nil {
+		return "", fmt.Errorf("codex mapping store is not configured")
+	}
 	if record, ok := d.mapping.RecordForPlatform(platformThreadID); ok {
 		updated := record
 		updated.LastUsedAtUnixMs = time.Now().UnixMilli()
 		d.mapping.SetRecord(updated)
-		if d.mappingStore != nil {
-			if err := d.mappingStore.Save(updated); err != nil {
-				return "", err
-			}
+		if err := d.mappingStore.Save(updated); err != nil {
+			return "", err
 		}
 		return record.CodexThreadID, nil
 	}
 	if err := waitForMCPServers(ctx, d.cfg.MCPServers, mcpReadyTimeout); err != nil {
 		return "", err
 	}
-	if d.mappingStore != nil {
-		record, ok, err := d.mappingStore.Load(platformThreadID)
-		if err != nil {
+	record, ok, err := d.mappingStore.Load(platformThreadID)
+	if err != nil {
+		return "", err
+	}
+	if ok {
+		if err := d.resumeCodexThread(ctx, record.CodexThreadID); err != nil {
 			return "", err
 		}
-		if ok {
-			if err := d.resumeCodexThread(ctx, record.CodexThreadID); err != nil {
-				return "", err
-			}
-			record.LastUsedAtUnixMs = time.Now().UnixMilli()
-			d.mapping.SetRecord(record)
-			if err := d.mappingStore.Save(record); err != nil {
-				return "", err
-			}
-			return record.CodexThreadID, nil
+		record.LastUsedAtUnixMs = time.Now().UnixMilli()
+		d.mapping.SetRecord(record)
+		if err := d.mappingStore.Save(record); err != nil {
+			return "", err
 		}
+		return record.CodexThreadID, nil
 	}
 	codexThreadID, err := d.startCodexThread(ctx)
 	if err != nil {
 		return "", err
 	}
 	now := time.Now().UnixMilli()
-	record := codexbridge.ThreadMappingRecord{
+	newRecord := codexbridge.ThreadMappingRecord{
 		PlatformThreadID: platformThreadID,
 		CodexThreadID:    codexThreadID,
 		CreatedAtUnixMs:  now,
 		LastUsedAtUnixMs: now,
 	}
-	d.mapping.SetRecord(record)
-	if d.mappingStore != nil {
-		if err := d.mappingStore.Save(record); err != nil {
-			return "", err
-		}
+	d.mapping.SetRecord(newRecord)
+	if err := d.mappingStore.Save(newRecord); err != nil {
+		return "", err
 	}
 	return codexThreadID, nil
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -44,8 +44,9 @@ type Daemon struct {
 	agents       gatewayv1.AgentsGatewayClient
 	subscriber   *subscriber.Subscriber
 	consumer     *platform.Consumer
-	codex        *codex.Client
+	codex        codexClient
 	mapping      *codexbridge.ThreadMapping
+	mappingStore *codexbridge.ThreadMappingStore
 	tracker      *codexbridge.TurnTracker
 	agn          *agnsdk.Client
 	agent        *agentsv1.Agent
@@ -55,6 +56,13 @@ type Daemon struct {
 }
 
 type platformConn interface {
+	Close() error
+}
+
+type codexClient interface {
+	StartThread(ctx context.Context, params *codex.ThreadStartParams) (*codex.ThreadStartResponse, error)
+	ResumeThread(ctx context.Context, params *codex.ThreadResumeParams) (*codex.ThreadResumeResponse, error)
+	StartTurn(ctx context.Context, params *codex.TurnStartParams) (*codex.TurnStartResponse, error)
 	Close() error
 }
 
@@ -178,6 +186,7 @@ func newCodexDaemon(ctx context.Context, cfg config.Config, version string) (*Da
 		_ = setup.gatewayConn.Close()
 		return nil, err
 	}
+	mappingStore := codexbridge.NewThreadMappingStore(codexHome)
 
 	tracingProxy, err := tracingproxy.Start(ctx, tracingproxy.Config{
 		TracingAddress: cfg.TracingAddress,
@@ -217,6 +226,7 @@ func newCodexDaemon(ctx context.Context, cfg config.Config, version string) (*Da
 		consumer:     platform.NewConsumer(setup.threads, pageSize, pageTimeout),
 		codex:        codexClient,
 		mapping:      threadsMapping,
+		mappingStore: mappingStore,
 		tracker:      tracker,
 		agent:        setup.agent,
 		tracingProxy: tracingProxy,
@@ -290,16 +300,9 @@ func (d *Daemon) handleCodexMessage(ctx context.Context, message platform.Messag
 	if err != nil {
 		return err
 	}
-	codexThreadID, ok := d.mapping.CodexForPlatform(threadID)
-	if !ok {
-		if err := waitForMCPServers(ctx, d.cfg.MCPServers, mcpReadyTimeout); err != nil {
-			return err
-		}
-		codexThreadID, err = d.startCodexThread(ctx)
-		if err != nil {
-			return err
-		}
-		d.mapping.Set(threadID, codexThreadID)
+	codexThreadID, err := d.ensureCodexThread(ctx, threadID)
+	if err != nil {
+		return err
 	}
 	turnCtx, cancel := context.WithTimeout(ctx, turnStartTimeout)
 	turnResp, err := d.codex.StartTurn(turnCtx, &codex.TurnStartParams{
@@ -347,6 +350,58 @@ func (d *Daemon) handleCodexMessage(ctx context.Context, message platform.Messag
 	}
 }
 
+func (d *Daemon) ensureCodexThread(ctx context.Context, platformThreadID string) (string, error) {
+	if record, ok := d.mapping.RecordForPlatform(platformThreadID); ok {
+		updated := record
+		updated.LastUsedAtUnixMs = time.Now().UnixMilli()
+		d.mapping.SetRecord(updated)
+		if d.mappingStore != nil {
+			if err := d.mappingStore.Save(updated); err != nil {
+				return "", err
+			}
+		}
+		return record.CodexThreadID, nil
+	}
+	if err := waitForMCPServers(ctx, d.cfg.MCPServers, mcpReadyTimeout); err != nil {
+		return "", err
+	}
+	if d.mappingStore != nil {
+		record, ok, err := d.mappingStore.Load(platformThreadID)
+		if err != nil {
+			return "", err
+		}
+		if ok {
+			if err := d.resumeCodexThread(ctx, record.CodexThreadID); err != nil {
+				return "", err
+			}
+			record.LastUsedAtUnixMs = time.Now().UnixMilli()
+			d.mapping.SetRecord(record)
+			if err := d.mappingStore.Save(record); err != nil {
+				return "", err
+			}
+			return record.CodexThreadID, nil
+		}
+	}
+	codexThreadID, err := d.startCodexThread(ctx)
+	if err != nil {
+		return "", err
+	}
+	now := time.Now().UnixMilli()
+	record := codexbridge.ThreadMappingRecord{
+		PlatformThreadID: platformThreadID,
+		CodexThreadID:    codexThreadID,
+		CreatedAtUnixMs:  now,
+		LastUsedAtUnixMs: now,
+	}
+	d.mapping.SetRecord(record)
+	if d.mappingStore != nil {
+		if err := d.mappingStore.Save(record); err != nil {
+			return "", err
+		}
+	}
+	return codexThreadID, nil
+}
+
 func waitForMCPServers(ctx context.Context, servers []config.MCPServer, timeout time.Duration) error {
 	if len(servers) == 0 {
 		return nil
@@ -376,21 +431,61 @@ func waitForMCPServers(ctx context.Context, servers []config.MCPServer, timeout 
 	return nil
 }
 
-func (d *Daemon) startCodexThread(ctx context.Context) (string, error) {
-	params := &codex.ThreadStartParams{}
-	model := strings.TrimSpace(d.agent.GetModel())
-	if model != "" {
-		params.Model = &model
+type codexThreadDefaults struct {
+	model                 *string
+	baseInstructions      *string
+	developerInstructions *string
+	cwd                   *string
+}
+
+func (d *Daemon) codexThreadDefaults() codexThreadDefaults {
+	defaults := codexThreadDefaults{}
+	if model := strings.TrimSpace(d.agent.GetModel()); model != "" {
+		defaults.model = &model
 	}
 	if role := strings.TrimSpace(d.agent.GetRole()); role != "" {
-		params.BaseInstructions = &role
+		defaults.baseInstructions = &role
 	}
 	if config := strings.TrimSpace(d.agent.GetConfiguration()); config != "" {
-		params.DeveloperInstructions = &config
+		defaults.developerInstructions = &config
 	}
 	if d.cfg.WorkDir != "" {
-		params.Cwd = &d.cfg.WorkDir
+		workDir := d.cfg.WorkDir
+		defaults.cwd = &workDir
 	}
+	return defaults
+}
+
+func (d *Daemon) resumeCodexThread(ctx context.Context, codexThreadID string) error {
+	params := &codex.ThreadResumeParams{ThreadID: codexThreadID}
+	defaults := d.codexThreadDefaults()
+	params.Model = defaults.model
+	params.BaseInstructions = defaults.baseInstructions
+	params.DeveloperInstructions = defaults.developerInstructions
+	params.Cwd = defaults.cwd
+	resp, err := d.codex.ResumeThread(ctx, params)
+	if err != nil {
+		return fmt.Errorf("resume codex thread: %w", err)
+	}
+	threadID := strings.TrimSpace(resp.Thread.ID)
+	if threadID == "" {
+		return fmt.Errorf("resume codex thread id missing")
+	}
+	if threadID != codexThreadID {
+		return fmt.Errorf("resume codex thread id mismatch")
+	}
+	return nil
+}
+
+func (d *Daemon) startCodexThread(ctx context.Context) (string, error) {
+	params := &codex.ThreadStartParams{}
+	defaults := d.codexThreadDefaults()
+	params.Model = defaults.model
+	params.BaseInstructions = defaults.baseInstructions
+	params.DeveloperInstructions = defaults.developerInstructions
+	params.Cwd = defaults.cwd
+	ephemeral := false
+	params.Ephemeral = &ephemeral
 	resp, err := d.codex.StartThread(ctx, params)
 	if err != nil {
 		return "", fmt.Errorf("start codex thread: %w", err)

--- a/internal/daemon/daemon_codex_test.go
+++ b/internal/daemon/daemon_codex_test.go
@@ -74,3 +74,45 @@ func TestEnsureCodexThreadResumesFromStore(t *testing.T) {
 		t.Fatalf("expected resume params for %q", record.CodexThreadID)
 	}
 }
+
+func TestEnsureCodexThreadStartsNonEphemeral(t *testing.T) {
+	store := codexbridge.NewThreadMappingStore(t.TempDir())
+	client := &fakeCodexClient{}
+	daemon := &Daemon{
+		sdk:          SDKCodex,
+		cfg:          config.Config{WorkDir: "/tmp"},
+		codex:        client,
+		mapping:      codexbridge.NewThreadMapping(),
+		mappingStore: store,
+		agent:        &agentsv1.Agent{},
+	}
+	threadID, err := daemon.ensureCodexThread(context.Background(), "platform-new")
+	if err != nil {
+		t.Fatalf("expected ensureCodexThread to succeed, got %v", err)
+	}
+	if threadID != "codex-started" {
+		t.Fatalf("expected thread id %q, got %q", "codex-started", threadID)
+	}
+	if client.startThreadCalls != 1 {
+		t.Fatalf("expected StartThread to be called once, got %d", client.startThreadCalls)
+	}
+	if client.resumeThreadCalls != 0 {
+		t.Fatalf("expected ResumeThread not to be called, got %d", client.resumeThreadCalls)
+	}
+	if client.startParams == nil || client.startParams.Ephemeral == nil {
+		t.Fatal("expected Ephemeral to be set")
+	}
+	if *client.startParams.Ephemeral {
+		t.Fatal("expected Ephemeral to be false")
+	}
+	stored, ok, err := store.Load("platform-new")
+	if err != nil {
+		t.Fatalf("expected mapping to be saved, got %v", err)
+	}
+	if !ok {
+		t.Fatal("expected mapping to be saved")
+	}
+	if stored.CodexThreadID != "codex-started" {
+		t.Fatalf("expected stored codex id %q, got %q", "codex-started", stored.CodexThreadID)
+	}
+}

--- a/internal/daemon/daemon_codex_test.go
+++ b/internal/daemon/daemon_codex_test.go
@@ -1,0 +1,76 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+
+	agentsv1 "github.com/agynio/agynd-cli/.gen/go/agynio/api/agents/v1"
+	"github.com/agynio/agynd-cli/internal/codexbridge"
+	"github.com/agynio/agynd-cli/internal/config"
+	codex "github.com/agynio/codex-sdk-go"
+)
+
+type fakeCodexClient struct {
+	startThreadCalls  int
+	resumeThreadCalls int
+	startParams       *codex.ThreadStartParams
+	resumeParams      *codex.ThreadResumeParams
+}
+
+func (f *fakeCodexClient) StartThread(_ context.Context, params *codex.ThreadStartParams) (*codex.ThreadStartResponse, error) {
+	f.startThreadCalls++
+	f.startParams = params
+	return &codex.ThreadStartResponse{Thread: codex.Thread{ID: "codex-started"}}, nil
+}
+
+func (f *fakeCodexClient) ResumeThread(_ context.Context, params *codex.ThreadResumeParams) (*codex.ThreadResumeResponse, error) {
+	f.resumeThreadCalls++
+	f.resumeParams = params
+	return &codex.ThreadResumeResponse{Thread: codex.Thread{ID: params.ThreadID}}, nil
+}
+
+func (f *fakeCodexClient) StartTurn(_ context.Context, _ *codex.TurnStartParams) (*codex.TurnStartResponse, error) {
+	return &codex.TurnStartResponse{Turn: codex.Turn{ID: "turn-1"}}, nil
+}
+
+func (f *fakeCodexClient) Close() error {
+	return nil
+}
+
+func TestEnsureCodexThreadResumesFromStore(t *testing.T) {
+	store := codexbridge.NewThreadMappingStore(t.TempDir())
+	record := codexbridge.ThreadMappingRecord{
+		PlatformThreadID: "platform-1",
+		CodexThreadID:    "codex-1",
+		CreatedAtUnixMs:  1700000000000,
+		LastUsedAtUnixMs: 1700000000100,
+	}
+	if err := store.Save(record); err != nil {
+		t.Fatalf("expected mapping save to succeed, got %v", err)
+	}
+	client := &fakeCodexClient{}
+	daemon := &Daemon{
+		sdk:          SDKCodex,
+		cfg:          config.Config{WorkDir: "/tmp"},
+		codex:        client,
+		mapping:      codexbridge.NewThreadMapping(),
+		mappingStore: store,
+		agent:        &agentsv1.Agent{},
+	}
+	threadID, err := daemon.ensureCodexThread(context.Background(), record.PlatformThreadID)
+	if err != nil {
+		t.Fatalf("expected ensureCodexThread to succeed, got %v", err)
+	}
+	if threadID != record.CodexThreadID {
+		t.Fatalf("expected thread id %q, got %q", record.CodexThreadID, threadID)
+	}
+	if client.resumeThreadCalls != 1 {
+		t.Fatalf("expected ResumeThread to be called once, got %d", client.resumeThreadCalls)
+	}
+	if client.startThreadCalls != 0 {
+		t.Fatalf("expected StartThread not to be called, got %d", client.startThreadCalls)
+	}
+	if client.resumeParams == nil || client.resumeParams.ThreadID != record.CodexThreadID {
+		t.Fatalf("expected resume params for %q", record.CodexThreadID)
+	}
+}


### PR DESCRIPTION
## Summary
- persist Codex thread mappings under CODEX_HOME and update last-used timestamps
- resume existing Codex threads on restart with explicit non-ephemeral start
- add unit tests for mapping persistence and daemon resume behavior

## Testing
- env GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go test ./...
- env GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go vet ./...

Closes #65