### PR TITLE
feat(codex): migrate mapping path

### DIFF
--- a/internal/codexbridge/mapping.go
+++ b/internal/codexbridge/mapping.go
@@ -14,7 +14,6 @@ func NewThreadMapping() *ThreadMapping {
 		codexToPlatform: make(map[string]string),
 	}
 }
-
 func (m *ThreadMapping) SetRecord(record ThreadMappingRecord) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/codexbridge/mapping.go
+++ b/internal/codexbridge/mapping.go
@@ -14,6 +14,7 @@ func NewThreadMapping() *ThreadMapping {
 		codexToPlatform: make(map[string]string),
 	}
 }
+
 func (m *ThreadMapping) SetRecord(record ThreadMappingRecord) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/codexbridge/thread_mapping_store.go
+++ b/internal/codexbridge/thread_mapping_store.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -48,13 +49,15 @@ func (r ThreadMappingRecord) validate() error {
 
 type ThreadMappingStore struct {
 	dir        string
+	legacyDir  string
 	createTemp func(dir, pattern string) (*os.File, error)
 	rename     func(oldpath, newpath string) error
 }
 
-func NewThreadMappingStore(codexHome string) *ThreadMappingStore {
+func NewThreadMappingStore(homeDir string) *ThreadMappingStore {
 	return &ThreadMappingStore{
-		dir:        filepath.Join(codexHome, "agynd", "thread-mapping"),
+		dir:        filepath.Join(homeDir, ".agyn", "codex", "thread-mapping"),
+		legacyDir:  filepath.Join(homeDir, ".codex", "agynd", "thread-mapping"),
 		createTemp: os.CreateTemp,
 		rename:     os.Rename,
 	}
@@ -65,24 +68,41 @@ func (s *ThreadMappingStore) Load(platformThreadID string) (ThreadMappingRecord,
 	if err != nil {
 		return ThreadMappingRecord{}, false, err
 	}
-	data, err := os.ReadFile(path)
+	legacyPath, err := s.legacyMappingPath(platformThreadID)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return ThreadMappingRecord{}, false, nil
+		return ThreadMappingRecord{}, false, err
+	}
+	newRecord, ok, err := s.readRecord(path, platformThreadID)
+	if err != nil {
+		return ThreadMappingRecord{}, false, err
+	}
+	if ok {
+		legacyRecord, legacyOk, err := s.readRecord(legacyPath, platformThreadID)
+		if err != nil {
+			log.Printf("codex mapping: legacy read failed for %s: %v", platformThreadID, err)
+			return newRecord, true, nil
 		}
-		return ThreadMappingRecord{}, false, fmt.Errorf("read mapping: %w", err)
+		if legacyOk && legacyRecord.CodexThreadID != newRecord.CodexThreadID {
+			log.Printf(
+				"codex mapping: legacy codex thread %s differs from current %s for platform %s",
+				legacyRecord.CodexThreadID,
+				newRecord.CodexThreadID,
+				platformThreadID,
+			)
+		}
+		return newRecord, true, nil
 	}
-	var record ThreadMappingRecord
-	if err := json.Unmarshal(data, &record); err != nil {
-		return ThreadMappingRecord{}, false, fmt.Errorf("parse mapping: %w", err)
+	legacyRecord, legacyOk, err := s.readRecord(legacyPath, platformThreadID)
+	if err != nil {
+		return ThreadMappingRecord{}, false, err
 	}
-	if err := record.validate(); err != nil {
-		return ThreadMappingRecord{}, false, fmt.Errorf("invalid mapping: %w", err)
+	if !legacyOk {
+		return ThreadMappingRecord{}, false, nil
 	}
-	if record.PlatformThreadID != platformThreadID {
-		return ThreadMappingRecord{}, false, fmt.Errorf("mapping platform_thread_id mismatch")
+	if err := s.Save(legacyRecord); err != nil {
+		return ThreadMappingRecord{}, false, err
 	}
-	return record, true, nil
+	return legacyRecord, true, nil
 }
 
 func (s *ThreadMappingStore) Save(record ThreadMappingRecord) error {
@@ -131,6 +151,42 @@ func (s *ThreadMappingStore) Save(record ThreadMappingRecord) error {
 }
 
 func (s *ThreadMappingStore) mappingPath(platformThreadID string) (string, error) {
+	return mappingPath(s.dir, platformThreadID)
+}
+
+func (s *ThreadMappingStore) legacyMappingPath(platformThreadID string) (string, error) {
+	return mappingPath(s.legacyDir, platformThreadID)
+}
+
+func (s *ThreadMappingStore) readRecord(path, platformThreadID string) (ThreadMappingRecord, bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return ThreadMappingRecord{}, false, nil
+		}
+		return ThreadMappingRecord{}, false, fmt.Errorf("read mapping: %w", err)
+	}
+	var record ThreadMappingRecord
+	if err := json.Unmarshal(data, &record); err != nil {
+		return ThreadMappingRecord{}, false, fmt.Errorf("parse mapping: %w", err)
+	}
+	if err := record.validate(); err != nil {
+		return ThreadMappingRecord{}, false, fmt.Errorf("invalid mapping: %w", err)
+	}
+	if record.PlatformThreadID != platformThreadID {
+		return ThreadMappingRecord{}, false, fmt.Errorf("mapping platform_thread_id mismatch")
+	}
+	return record, true, nil
+}
+
+func mappingPath(dir, platformThreadID string) (string, error) {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return "", fmt.Errorf("mapping directory is required")
+	}
+	if !filepath.IsAbs(dir) {
+		return "", fmt.Errorf("mapping directory %q must be absolute", dir)
+	}
 	platformThreadID = strings.TrimSpace(platformThreadID)
 	if platformThreadID == "" {
 		return "", fmt.Errorf("platform thread id is required")
@@ -138,5 +194,5 @@ func (s *ThreadMappingStore) mappingPath(platformThreadID string) (string, error
 	if strings.ContainsRune(platformThreadID, filepath.Separator) || filepath.Base(platformThreadID) != platformThreadID {
 		return "", fmt.Errorf("platform thread id %q is invalid", platformThreadID)
 	}
-	return filepath.Join(s.dir, platformThreadID+".json"), nil
+	return filepath.Join(dir, platformThreadID+".json"), nil
 }

--- a/internal/codexbridge/thread_mapping_store_test.go
+++ b/internal/codexbridge/thread_mapping_store_test.go
@@ -1,16 +1,33 @@
 package codexbridge
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
 )
 
+func writeMappingFile(t *testing.T, path string, record ThreadMappingRecord) {
+	t.Helper()
+	payload, err := json.Marshal(record)
+	if err != nil {
+		t.Fatalf("marshal mapping: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), threadMappingDirMode); err != nil {
+		t.Fatalf("mkdir mapping dir: %v", err)
+	}
+	if err := os.WriteFile(path, payload, threadMappingFileMode); err != nil {
+		t.Fatalf("write mapping: %v", err)
+	}
+}
+
 func TestThreadMappingStoreSaveLoad(t *testing.T) {
-	baseDir := t.TempDir()
-	store := NewThreadMappingStore(baseDir)
+	homeDir := t.TempDir()
+	store := NewThreadMappingStore(homeDir)
 	record := ThreadMappingRecord{
 		PlatformThreadID: "platform-1",
 		CodexThreadID:    "codex-1",
@@ -62,8 +79,8 @@ func TestThreadMappingStoreLoadMissing(t *testing.T) {
 }
 
 func TestThreadMappingStoreSaveAtomic(t *testing.T) {
-	baseDir := t.TempDir()
-	store := NewThreadMappingStore(baseDir)
+	homeDir := t.TempDir()
+	store := NewThreadMappingStore(homeDir)
 	original := ThreadMappingRecord{
 		PlatformThreadID: "platform-atomic",
 		CodexThreadID:    "codex-old",
@@ -105,5 +122,85 @@ func TestThreadMappingStoreSaveAtomic(t *testing.T) {
 	}
 	if len(entries) != 1 {
 		t.Fatalf("expected no temp files, found %d entries", len(entries))
+	}
+}
+
+func TestThreadMappingStoreLoadLegacyMigrates(t *testing.T) {
+	homeDir := t.TempDir()
+	store := NewThreadMappingStore(homeDir)
+	legacyRecord := ThreadMappingRecord{
+		PlatformThreadID: "platform-legacy",
+		CodexThreadID:    "codex-legacy",
+		CreatedAtUnixMs:  1700000000000,
+		LastUsedAtUnixMs: 1700000000100,
+	}
+	legacyPath, err := store.legacyMappingPath(legacyRecord.PlatformThreadID)
+	if err != nil {
+		t.Fatalf("expected legacy path, got %v", err)
+	}
+	writeMappingFile(t, legacyPath, legacyRecord)
+	got, ok, err := store.Load(legacyRecord.PlatformThreadID)
+	if err != nil {
+		t.Fatalf("expected load to succeed, got %v", err)
+	}
+	if !ok {
+		t.Fatal("expected legacy mapping to load")
+	}
+	if !reflect.DeepEqual(got, legacyRecord) {
+		t.Fatalf("unexpected record: %#v", got)
+	}
+	newPath, err := store.mappingPath(legacyRecord.PlatformThreadID)
+	if err != nil {
+		t.Fatalf("expected new path, got %v", err)
+	}
+	if _, err := os.Stat(newPath); err != nil {
+		t.Fatalf("expected migrated mapping to exist, got %v", err)
+	}
+	if _, err := os.Stat(legacyPath); err != nil {
+		t.Fatalf("expected legacy mapping to remain, got %v", err)
+	}
+}
+
+func TestThreadMappingStoreLoadPrefersNew(t *testing.T) {
+	homeDir := t.TempDir()
+	store := NewThreadMappingStore(homeDir)
+	newRecord := ThreadMappingRecord{
+		PlatformThreadID: "platform-dual",
+		CodexThreadID:    "codex-new",
+		CreatedAtUnixMs:  1700000000000,
+		LastUsedAtUnixMs: 1700000000100,
+	}
+	legacyRecord := ThreadMappingRecord{
+		PlatformThreadID: "platform-dual",
+		CodexThreadID:    "codex-legacy",
+		CreatedAtUnixMs:  1700000000000,
+		LastUsedAtUnixMs: 1700000000200,
+	}
+	newPath, err := store.mappingPath(newRecord.PlatformThreadID)
+	if err != nil {
+		t.Fatalf("expected new path, got %v", err)
+	}
+	legacyPath, err := store.legacyMappingPath(newRecord.PlatformThreadID)
+	if err != nil {
+		t.Fatalf("expected legacy path, got %v", err)
+	}
+	writeMappingFile(t, newPath, newRecord)
+	writeMappingFile(t, legacyPath, legacyRecord)
+	var buffer bytes.Buffer
+	originalOutput := log.Writer()
+	log.SetOutput(&buffer)
+	t.Cleanup(func() { log.SetOutput(originalOutput) })
+	got, ok, err := store.Load(newRecord.PlatformThreadID)
+	if err != nil {
+		t.Fatalf("expected load to succeed, got %v", err)
+	}
+	if !ok {
+		t.Fatal("expected mapping to load")
+	}
+	if !reflect.DeepEqual(got, newRecord) {
+		t.Fatalf("expected new record to win, got %#v", got)
+	}
+	if !bytes.Contains(buffer.Bytes(), []byte("legacy codex thread")) {
+		t.Fatalf("expected warning about legacy mismatch, got %q", buffer.String())
 	}
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -186,7 +187,12 @@ func newCodexDaemon(ctx context.Context, cfg config.Config, version string) (*Da
 		_ = setup.gatewayConn.Close()
 		return nil, err
 	}
-	mappingStore := codexbridge.NewThreadMappingStore(codexHome)
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		_ = setup.gatewayConn.Close()
+		return nil, fmt.Errorf("resolve home directory: %w", err)
+	}
+	mappingStore := codexbridge.NewThreadMappingStore(homeDir)
 
 	tracingProxy, err := tracingproxy.Start(ctx, tracingproxy.Config{
 		TracingAddress: cfg.TracingAddress,


### PR DESCRIPTION
## Summary
- move Codex thread mapping storage to $HOME/.agyn/codex/thread-mapping
- add legacy fallback + lazy migration with warning on conflicts
- extend mapping store tests for migration behavior

## Testing
- env GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go test ./...
- env GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go vet ./...

Closes #65