### PR TITLE
feat(codex): remove legacy mapping

### DIFF
--- a/internal/codexbridge/thread_mapping_store.go
+++ b/internal/codexbridge/thread_mapping_store.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -49,7 +48,6 @@ func (r ThreadMappingRecord) validate() error {
 
 type ThreadMappingStore struct {
 	dir        string
-	legacyDir  string
 	createTemp func(dir, pattern string) (*os.File, error)
 	rename     func(oldpath, newpath string) error
 }
@@ -57,7 +55,6 @@ type ThreadMappingStore struct {
 func NewThreadMappingStore(homeDir string) *ThreadMappingStore {
 	return &ThreadMappingStore{
 		dir:        filepath.Join(homeDir, ".agyn", "codex", "thread-mapping"),
-		legacyDir:  filepath.Join(homeDir, ".codex", "agynd", "thread-mapping"),
 		createTemp: os.CreateTemp,
 		rename:     os.Rename,
 	}
@@ -68,41 +65,14 @@ func (s *ThreadMappingStore) Load(platformThreadID string) (ThreadMappingRecord,
 	if err != nil {
 		return ThreadMappingRecord{}, false, err
 	}
-	legacyPath, err := s.legacyMappingPath(platformThreadID)
+	record, ok, err := s.readRecord(path, platformThreadID)
 	if err != nil {
 		return ThreadMappingRecord{}, false, err
 	}
-	newRecord, ok, err := s.readRecord(path, platformThreadID)
-	if err != nil {
-		return ThreadMappingRecord{}, false, err
-	}
-	if ok {
-		legacyRecord, legacyOk, err := s.readRecord(legacyPath, platformThreadID)
-		if err != nil {
-			log.Printf("codex mapping: legacy read failed for %s: %v", platformThreadID, err)
-			return newRecord, true, nil
-		}
-		if legacyOk && legacyRecord.CodexThreadID != newRecord.CodexThreadID {
-			log.Printf(
-				"codex mapping: legacy codex thread %s differs from current %s for platform %s",
-				legacyRecord.CodexThreadID,
-				newRecord.CodexThreadID,
-				platformThreadID,
-			)
-		}
-		return newRecord, true, nil
-	}
-	legacyRecord, legacyOk, err := s.readRecord(legacyPath, platformThreadID)
-	if err != nil {
-		return ThreadMappingRecord{}, false, err
-	}
-	if !legacyOk {
+	if !ok {
 		return ThreadMappingRecord{}, false, nil
 	}
-	if err := s.Save(legacyRecord); err != nil {
-		return ThreadMappingRecord{}, false, err
-	}
-	return legacyRecord, true, nil
+	return record, true, nil
 }
 
 func (s *ThreadMappingStore) Save(record ThreadMappingRecord) error {
@@ -152,10 +122,6 @@ func (s *ThreadMappingStore) Save(record ThreadMappingRecord) error {
 
 func (s *ThreadMappingStore) mappingPath(platformThreadID string) (string, error) {
 	return mappingPath(s.dir, platformThreadID)
-}
-
-func (s *ThreadMappingStore) legacyMappingPath(platformThreadID string) (string, error) {
-	return mappingPath(s.legacyDir, platformThreadID)
 }
 
 func (s *ThreadMappingStore) readRecord(path, platformThreadID string) (ThreadMappingRecord, bool, error) {

--- a/internal/codexbridge/thread_mapping_store_test.go
+++ b/internal/codexbridge/thread_mapping_store_test.go
@@ -1,29 +1,12 @@
 package codexbridge
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
 )
-
-func writeMappingFile(t *testing.T, path string, record ThreadMappingRecord) {
-	t.Helper()
-	payload, err := json.Marshal(record)
-	if err != nil {
-		t.Fatalf("marshal mapping: %v", err)
-	}
-	if err := os.MkdirAll(filepath.Dir(path), threadMappingDirMode); err != nil {
-		t.Fatalf("mkdir mapping dir: %v", err)
-	}
-	if err := os.WriteFile(path, payload, threadMappingFileMode); err != nil {
-		t.Fatalf("write mapping: %v", err)
-	}
-}
 
 func TestThreadMappingStoreSaveLoad(t *testing.T) {
 	homeDir := t.TempDir()
@@ -122,85 +105,5 @@ func TestThreadMappingStoreSaveAtomic(t *testing.T) {
 	}
 	if len(entries) != 1 {
 		t.Fatalf("expected no temp files, found %d entries", len(entries))
-	}
-}
-
-func TestThreadMappingStoreLoadLegacyMigrates(t *testing.T) {
-	homeDir := t.TempDir()
-	store := NewThreadMappingStore(homeDir)
-	legacyRecord := ThreadMappingRecord{
-		PlatformThreadID: "platform-legacy",
-		CodexThreadID:    "codex-legacy",
-		CreatedAtUnixMs:  1700000000000,
-		LastUsedAtUnixMs: 1700000000100,
-	}
-	legacyPath, err := store.legacyMappingPath(legacyRecord.PlatformThreadID)
-	if err != nil {
-		t.Fatalf("expected legacy path, got %v", err)
-	}
-	writeMappingFile(t, legacyPath, legacyRecord)
-	got, ok, err := store.Load(legacyRecord.PlatformThreadID)
-	if err != nil {
-		t.Fatalf("expected load to succeed, got %v", err)
-	}
-	if !ok {
-		t.Fatal("expected legacy mapping to load")
-	}
-	if !reflect.DeepEqual(got, legacyRecord) {
-		t.Fatalf("unexpected record: %#v", got)
-	}
-	newPath, err := store.mappingPath(legacyRecord.PlatformThreadID)
-	if err != nil {
-		t.Fatalf("expected new path, got %v", err)
-	}
-	if _, err := os.Stat(newPath); err != nil {
-		t.Fatalf("expected migrated mapping to exist, got %v", err)
-	}
-	if _, err := os.Stat(legacyPath); err != nil {
-		t.Fatalf("expected legacy mapping to remain, got %v", err)
-	}
-}
-
-func TestThreadMappingStoreLoadPrefersNew(t *testing.T) {
-	homeDir := t.TempDir()
-	store := NewThreadMappingStore(homeDir)
-	newRecord := ThreadMappingRecord{
-		PlatformThreadID: "platform-dual",
-		CodexThreadID:    "codex-new",
-		CreatedAtUnixMs:  1700000000000,
-		LastUsedAtUnixMs: 1700000000100,
-	}
-	legacyRecord := ThreadMappingRecord{
-		PlatformThreadID: "platform-dual",
-		CodexThreadID:    "codex-legacy",
-		CreatedAtUnixMs:  1700000000000,
-		LastUsedAtUnixMs: 1700000000200,
-	}
-	newPath, err := store.mappingPath(newRecord.PlatformThreadID)
-	if err != nil {
-		t.Fatalf("expected new path, got %v", err)
-	}
-	legacyPath, err := store.legacyMappingPath(newRecord.PlatformThreadID)
-	if err != nil {
-		t.Fatalf("expected legacy path, got %v", err)
-	}
-	writeMappingFile(t, newPath, newRecord)
-	writeMappingFile(t, legacyPath, legacyRecord)
-	var buffer bytes.Buffer
-	originalOutput := log.Writer()
-	log.SetOutput(&buffer)
-	t.Cleanup(func() { log.SetOutput(originalOutput) })
-	got, ok, err := store.Load(newRecord.PlatformThreadID)
-	if err != nil {
-		t.Fatalf("expected load to succeed, got %v", err)
-	}
-	if !ok {
-		t.Fatal("expected mapping to load")
-	}
-	if !reflect.DeepEqual(got, newRecord) {
-		t.Fatalf("expected new record to win, got %#v", got)
-	}
-	if !bytes.Contains(buffer.Bytes(), []byte("legacy codex thread")) {
-		t.Fatalf("expected warning about legacy mismatch, got %q", buffer.String())
 	}
 }


### PR DESCRIPTION
## Summary
- remove legacy CODEX_HOME fallback/migration logic from thread mapping store
- simplify mapping load tests to only cover the new .agyn path

## Testing
- env GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go test ./...
- env GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go vet ./...

Closes #68