### PR TITLE
fix(daemon): add Claude env flags

### DIFF
--- a/internal/daemon/claudeconfig.go
+++ b/internal/daemon/claudeconfig.go
@@ -57,8 +57,10 @@ func writeClaudeSettings(llmBaseURL, apiKey string, mcpServers []config.MCPServe
 			Deny: []string{},
 		},
 		Env: map[string]string{
-			"ANTHROPIC_BASE_URL": llmBaseURL,
-			"ANTHROPIC_API_KEY":  apiKey,
+			"ANTHROPIC_BASE_URL":                       llmBaseURL,
+			"ANTHROPIC_API_KEY":                        apiKey,
+			"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+			"DISABLE_AUTOUPDATER":                      "1",
 		},
 	}
 	if len(mcpServers) > 0 {

--- a/internal/daemon/claudeconfig_test.go
+++ b/internal/daemon/claudeconfig_test.go
@@ -52,8 +52,10 @@ func TestWriteClaudeSettings(t *testing.T) {
 			Deny: []string{},
 		},
 		Env: map[string]string{
-			"ANTHROPIC_BASE_URL": baseURL,
-			"ANTHROPIC_API_KEY":  apiKey,
+			"ANTHROPIC_BASE_URL":                       baseURL,
+			"ANTHROPIC_API_KEY":                        apiKey,
+			"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+			"DISABLE_AUTOUPDATER":                      "1",
 		},
 	}
 	if !reflect.DeepEqual(got, expected) {
@@ -107,8 +109,10 @@ func TestWriteClaudeSettingsWithMCPServers(t *testing.T) {
 			Deny: []string{},
 		},
 		Env: map[string]string{
-			"ANTHROPIC_BASE_URL": baseURL,
-			"ANTHROPIC_API_KEY":  apiKey,
+			"ANTHROPIC_BASE_URL":                       baseURL,
+			"ANTHROPIC_API_KEY":                        apiKey,
+			"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+			"DISABLE_AUTOUPDATER":                      "1",
 		},
 		MCPServers: map[string]claudeMCPServer{
 			"memory": {Type: "http", URL: "http://localhost:8100/mcp"},


### PR DESCRIPTION
## Summary
- add Claude Code env flags to settings.json
- extend settings tests to cover new env values

## Testing
- GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go vet ./...
- GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go test ./...

#70