### PR TITLE
fix: add sandbox env for Claude

### DIFF
--- a/internal/daemon/claude.go
+++ b/internal/daemon/claude.go
@@ -47,6 +47,7 @@ func newClaudeDaemon(ctx context.Context, cfg config.Config, version string) (*D
 		Env: []string{
 			"LD_LIBRARY_PATH=/agyn-bin/lib",
 			"OTEL_EXPORTER_OTLP_ENDPOINT=" + otlpEndpoint,
+			"IS_SANDBOX=1",
 		},
 	}
 	if model := strings.TrimSpace(setup.agent.GetModel()); model != "" {


### PR DESCRIPTION
## Summary
- add IS_SANDBOX env var when launching Claude

## Testing
- GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go build ./...
- GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go vet ./...
- GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go test ./...

Closes #74