### PR TITLE
fix: defer Claude MCP wait

### DIFF
--- a/internal/daemon/claude.go
+++ b/internal/daemon/claude.go
@@ -26,11 +26,6 @@ func newClaudeDaemon(ctx context.Context, cfg config.Config, version string) (*D
 		return nil, err
 	}
 
-	if err := waitForMCPServers(ctx, cfg.MCPServers, mcpReadyTimeout); err != nil {
-		_ = setup.gatewayConn.Close()
-		return nil, err
-	}
-
 	tracingProxy, err := tracingproxy.Start(ctx, tracingproxy.Config{
 		TracingAddress: cfg.TracingAddress,
 		ThreadID:       cfg.ThreadID,
@@ -77,6 +72,19 @@ func newClaudeDaemon(ctx context.Context, cfg config.Config, version string) (*D
 	}, nil
 }
 
+func (d *Daemon) ensureClaudeReady(ctx context.Context) error {
+	d.claudeReadyMu.Lock()
+	defer d.claudeReadyMu.Unlock()
+	if d.claudeReady {
+		return nil
+	}
+	if err := waitForMCPServers(ctx, d.cfg.MCPServers, mcpReadyTimeout); err != nil {
+		return err
+	}
+	d.claudeReady = true
+	return nil
+}
+
 func (d *Daemon) handleClaudeMessage(ctx context.Context, message platform.Message) error {
 	threadID := strings.TrimSpace(message.ThreadID)
 	if threadID == "" {
@@ -84,6 +92,9 @@ func (d *Daemon) handleClaudeMessage(ctx context.Context, message platform.Messa
 	}
 	inputText, err := buildInput(message)
 	if err != nil {
+		return err
+	}
+	if err := d.ensureClaudeReady(ctx); err != nil {
 		return err
 	}
 	turnCtx, cancel := context.WithTimeout(ctx, turnCompletionTimeout)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -54,6 +54,8 @@ type Daemon struct {
 	claude       claudeClient
 	agent        *agentsv1.Agent
 	tracingProxy *tracingproxy.Proxy
+	claudeReadyMu sync.Mutex
+	claudeReady   bool
 
 	syncMu sync.Mutex
 }


### PR DESCRIPTION
## Summary
- move MCP server readiness check to Claude message handling
- track Claude MCP readiness to avoid repeated waits

## Testing
- GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go build ./...
- GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go vet ./...
- GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go test ./...

Closes #76