### PR TITLE
chore: bump claude sdk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24.x'
+          go-version: '1.26.x'
 
       - name: Install buf
         uses: bufbuild/buf-setup-action@v1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24.x'
+          go-version: '1.26.x'
 
       - name: Install buf
         uses: bufbuild/buf-setup-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.26.x'
 
       - name: Install buf
         uses: bufbuild/buf-setup-action@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.8
-ARG GO_VERSION=1.24
+ARG GO_VERSION=1.26.1
 ARG BUF_VERSION=1.66.0
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS buf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.8
-ARG GO_VERSION=1.26.1
+ARG GO_VERSION=1.26
 ARG BUF_VERSION=1.66.0
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS buf

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,10 @@
 module github.com/agynio/agynd-cli
 
-go 1.24.0
-
-toolchain go1.24.13
+go 1.26.1
 
 require (
 	github.com/agynio/agn-sdk-go v0.1.0
-	github.com/agynio/claude-sdk-go v0.0.0-20260411102619-08a8fbe28a13
+	github.com/agynio/claude-sdk-go v0.2.0
 	github.com/agynio/codex-sdk-go v0.1.0
 	github.com/google/uuid v1.6.0
 	go.opentelemetry.io/proto/otlp v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/agynio/agn-sdk-go v0.1.0 h1:wdLfQdNLVVHrbr+w59zvMOkwiq3RIRbx4j+V3Jhnel0=
 github.com/agynio/agn-sdk-go v0.1.0/go.mod h1:bFwhqvyDv3LWMBYRDEtjH5/RRMjENJ1CTpeS11Vt1rI=
-github.com/agynio/claude-sdk-go v0.0.0-20260411102619-08a8fbe28a13 h1:yOI+yQZpFmeZiU5hhaqGY53q9cbsWcjalKzguEc18eY=
-github.com/agynio/claude-sdk-go v0.0.0-20260411102619-08a8fbe28a13/go.mod h1:RdzMhfP4XpToQkzE7WecDXHINq+B7e/ggU4pWKGdoks=
+github.com/agynio/claude-sdk-go v0.2.0 h1:9gNMfCZ1ZA3RfU3lD5f2/aggZO3EZkmxH9tHjMU/r3Q=
+github.com/agynio/claude-sdk-go v0.2.0/go.mod h1:TZHpLY+535K6GUvvZ3z+FSPq52zzjMpbnc1K2EAbemQ=
 github.com/agynio/codex-sdk-go v0.1.0 h1:EqsijEpD9/KnkoipdOf0n8cq2oC//4q2LY3edOVhicE=
 github.com/agynio/codex-sdk-go v0.1.0/go.mod h1:YhNX7IO1zVMcfpFINRD1reQFWTQzCZXQT1aCghtKNok=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=


### PR DESCRIPTION
## Summary
- bump github.com/agynio/claude-sdk-go to v0.2.0
- Go minimum version bumped from 1.24 to 1.26 as required by claude-sdk-go v0.2.0
- align Go toolchain versions in workflows and Dockerfile

## Testing
- GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go build ./...
- GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go vet ./...
- GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go test ./...

Closes #78