### PR TITLE
chore: bump claude sdk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/agynio/agn-sdk-go v0.1.0
-	github.com/agynio/claude-sdk-go v0.2.0
+	github.com/agynio/claude-sdk-go v0.2.1
 	github.com/agynio/codex-sdk-go v0.1.0
 	github.com/google/uuid v1.6.0
 	go.opentelemetry.io/proto/otlp v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/agynio/agn-sdk-go v0.1.0 h1:wdLfQdNLVVHrbr+w59zvMOkwiq3RIRbx4j+V3Jhnel0=
 github.com/agynio/agn-sdk-go v0.1.0/go.mod h1:bFwhqvyDv3LWMBYRDEtjH5/RRMjENJ1CTpeS11Vt1rI=
-github.com/agynio/claude-sdk-go v0.2.0 h1:9gNMfCZ1ZA3RfU3lD5f2/aggZO3EZkmxH9tHjMU/r3Q=
-github.com/agynio/claude-sdk-go v0.2.0/go.mod h1:TZHpLY+535K6GUvvZ3z+FSPq52zzjMpbnc1K2EAbemQ=
+github.com/agynio/claude-sdk-go v0.2.1 h1:08VKWyXiN1Td5fqVRLThr/9EQHpsmP6j58MlAH4PxQw=
+github.com/agynio/claude-sdk-go v0.2.1/go.mod h1:RdzMhfP4XpToQkzE7WecDXHINq+B7e/ggU4pWKGdoks=
 github.com/agynio/codex-sdk-go v0.1.0 h1:EqsijEpD9/KnkoipdOf0n8cq2oC//4q2LY3edOVhicE=
 github.com/agynio/codex-sdk-go v0.1.0/go.mod h1:YhNX7IO1zVMcfpFINRD1reQFWTQzCZXQT1aCghtKNok=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=


### PR DESCRIPTION
## Summary
- bump github.com/agynio/claude-sdk-go to v0.2.1
- refresh go.mod/go.sum after the updated tag

## Testing
- GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go build ./...
- GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go vet ./...
- GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go test ./...

Closes #80