### PR TITLE
feat: add workload keepalive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
 
       - name: Generate protobuf bindings
         run: |
-          buf generate buf.build/agynio/api \
-            --path agynio/api/gateway/v1 \
+          buf generate https://github.com/agynio/api.git#commit=ec008b1e2dfacec3e4d85776729fe1c3d5f2c42d \
+            --path proto/agynio/api/gateway/v1 \
             --include-imports
 
       - name: Run tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download
 
 COPY buf.gen.yaml buf.yaml ./
-RUN buf generate buf.build/agynio/api \
-    --path agynio/api/gateway/v1 \
+RUN buf generate https://github.com/agynio/api.git#commit=ec008b1e2dfacec3e4d85776729fe1c3d5f2c42d \
+    --path proto/agynio/api/gateway/v1 \
     --include-imports
 
 COPY . .

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -52,8 +52,8 @@ functions:
                     sleep 1; elapsed=$((elapsed + 1))
                     [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
                   done
-                  buf generate buf.build/agynio/api \
-                    --path agynio/api/gateway/v1 \
+                  buf generate https://github.com/agynio/api.git#commit=ec008b1e2dfacec3e4d85776729fe1c3d5f2c42d \
+                    --path proto/agynio/api/gateway/v1 \
                     --include-imports
                   exec go run ./cmd/agynd
               volumeMounts:

--- a/internal/daemon/agn.go
+++ b/internal/daemon/agn.go
@@ -74,6 +74,7 @@ func newAgnDaemon(ctx context.Context, cfg config.Config, version string) (*Daem
 		gatewayConn:  setup.gatewayConn,
 		threads:      setup.threads,
 		agents:       setup.agents,
+		runners:      setup.runners,
 		subscriber:   subscriber.New(setup.notifications, cfg.AgentID.String()),
 		consumer:     platform.NewConsumer(setup.threads, pageSize, pageTimeout),
 		agn:          agnClient,

--- a/internal/daemon/claude.go
+++ b/internal/daemon/claude.go
@@ -69,6 +69,7 @@ func newClaudeDaemon(ctx context.Context, cfg config.Config, version string) (*D
 		gatewayConn:  setup.gatewayConn,
 		threads:      setup.threads,
 		agents:       setup.agents,
+		runners:      setup.runners,
 		subscriber:   subscriber.New(setup.notifications, cfg.AgentID.String()),
 		consumer:     platform.NewConsumer(setup.threads, pageSize, pageTimeout),
 		claude:       claudeClient,

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -44,6 +44,7 @@ type Daemon struct {
 	gatewayConn   platformConn
 	threads       *platform.Threads
 	agents        gatewayv1.AgentsGatewayClient
+	runners       runnersClient
 	subscriber    *subscriber.Subscriber
 	consumer      *platform.Consumer
 	codex         codexClient
@@ -76,11 +77,17 @@ type claudeClient interface {
 	Close() error
 }
 
+type runnersClient interface {
+	ListWorkloadsByThread(ctx context.Context, threadID string, pageSize int32, pageToken string) ([]platform.Workload, string, error)
+	TouchWorkload(ctx context.Context, workloadID string) error
+}
+
 type platformSetup struct {
 	gatewayConn   platformConn
 	threads       *platform.Threads
 	notifications *platform.Notifications
 	agents        gatewayv1.AgentsGatewayClient
+	runners       *platform.Runners
 	agent         *agentsv1.Agent
 }
 
@@ -158,9 +165,11 @@ func tryConnectPlatform(ctx context.Context, cfg config.Config) (*platformSetup,
 	threadsGateway := gatewayv1.NewThreadsGatewayClient(gatewayConn)
 	notificationsGateway := gatewayv1.NewNotificationsGatewayClient(gatewayConn)
 	agentsClient := gatewayv1.NewAgentsGatewayClient(gatewayConn)
+	runnersGateway := gatewayv1.NewRunnersGatewayClient(gatewayConn)
 
 	threadsClient := platform.NewThreads(threadsGateway)
 	notificationsClient := platform.NewNotifications(notificationsGateway)
+	runnersClient := platform.NewRunners(runnersGateway)
 
 	agentResp, err := agentsClient.GetAgent(ctx, &agentsv1.GetAgentRequest{Id: cfg.AgentID.String()})
 	if err != nil {
@@ -178,6 +187,7 @@ func tryConnectPlatform(ctx context.Context, cfg config.Config) (*platformSetup,
 		threads:       threadsClient,
 		notifications: notificationsClient,
 		agents:        agentsClient,
+		runners:       runnersClient,
 		agent:         agent,
 	}, nil
 }
@@ -238,6 +248,7 @@ func newCodexDaemon(ctx context.Context, cfg config.Config, version string) (*Da
 		gatewayConn:  setup.gatewayConn,
 		threads:      setup.threads,
 		agents:       setup.agents,
+		runners:      setup.runners,
 		subscriber:   subscriber.New(setup.notifications, cfg.AgentID.String()),
 		consumer:     platform.NewConsumer(setup.threads, pageSize, pageTimeout),
 		codex:        codexClient,
@@ -277,6 +288,8 @@ func (d *Daemon) Run(ctx context.Context) error {
 			log.Printf("subscriber stopped: %v", err)
 		}
 	}()
+
+	go d.runKeepalive(ctx)
 
 	for {
 		select {

--- a/internal/daemon/keepalive.go
+++ b/internal/daemon/keepalive.go
@@ -1,0 +1,95 @@
+package daemon
+
+import (
+	"context"
+	"log"
+	"strings"
+	"time"
+
+	runnersv1 "github.com/agynio/agynd-cli/.gen/go/agynio/api/runners/v1"
+	"github.com/agynio/agynd-cli/internal/platform"
+)
+
+const (
+	workloadKeepaliveInterval = 10 * time.Second
+	workloadKeepaliveTimeout  = 5 * time.Second
+	workloadListTimeout       = 5 * time.Second
+)
+
+func (d *Daemon) runKeepalive(ctx context.Context) {
+	threadID := strings.TrimSpace(d.cfg.ThreadID)
+	if threadID == "" {
+		return
+	}
+
+	if _, err := d.touchActiveWorkload(ctx, threadID); err != nil && ctx.Err() == nil {
+		log.Printf("workload keepalive failed: %v", err)
+	}
+
+	ticker := time.NewTicker(workloadKeepaliveInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if _, err := d.touchActiveWorkload(ctx, threadID); err != nil && ctx.Err() == nil {
+				log.Printf("workload keepalive failed: %v", err)
+			}
+		}
+	}
+}
+
+func (d *Daemon) touchActiveWorkload(ctx context.Context, threadID string) (bool, error) {
+	workload, ok, err := d.findActiveWorkload(ctx, threadID)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		return false, nil
+	}
+	touchCtx, cancel := context.WithTimeout(ctx, workloadKeepaliveTimeout)
+	err = d.runners.TouchWorkload(touchCtx, workload.ID)
+	cancel()
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (d *Daemon) findActiveWorkload(ctx context.Context, threadID string) (platform.Workload, bool, error) {
+	pageToken := ""
+	var selected platform.Workload
+	found := false
+	for {
+		listCtx, cancel := context.WithTimeout(ctx, workloadListTimeout)
+		workloads, nextToken, err := d.runners.ListWorkloadsByThread(listCtx, threadID, pageSize, pageToken)
+		cancel()
+		if err != nil {
+			return platform.Workload{}, false, err
+		}
+		for _, workload := range workloads {
+			if workload.AgentID != d.cfg.AgentID.String() {
+				continue
+			}
+			if workload.Status != runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING {
+				continue
+			}
+			if workload.RemovedAt != nil {
+				continue
+			}
+			if !found || workload.CreatedAt.After(selected.CreatedAt) {
+				selected = workload
+				found = true
+			}
+		}
+		if nextToken == "" {
+			break
+		}
+		pageToken = nextToken
+	}
+	if !found {
+		return platform.Workload{}, false, nil
+	}
+	return selected, true, nil
+}

--- a/internal/daemon/keepalive_test.go
+++ b/internal/daemon/keepalive_test.go
@@ -1,0 +1,141 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	runnersv1 "github.com/agynio/agynd-cli/.gen/go/agynio/api/runners/v1"
+	"github.com/agynio/agynd-cli/internal/config"
+	"github.com/agynio/agynd-cli/internal/platform"
+	"github.com/google/uuid"
+)
+
+type listResponse struct {
+	workloads []platform.Workload
+	nextToken string
+	err       error
+}
+
+type fakeRunnersClient struct {
+	listResponses []listResponse
+	listCalls     int
+	listTokens    []string
+	listThreads   []string
+	listSizes     []int32
+
+	touchCalls []string
+}
+
+func (f *fakeRunnersClient) ListWorkloadsByThread(_ context.Context, threadID string, pageSize int32, pageToken string) ([]platform.Workload, string, error) {
+	f.listCalls++
+	f.listThreads = append(f.listThreads, threadID)
+	f.listSizes = append(f.listSizes, pageSize)
+	f.listTokens = append(f.listTokens, pageToken)
+	if f.listCalls > len(f.listResponses) {
+		return nil, "", fmt.Errorf("unexpected list call")
+	}
+	resp := f.listResponses[f.listCalls-1]
+	return resp.workloads, resp.nextToken, resp.err
+}
+
+func (f *fakeRunnersClient) TouchWorkload(_ context.Context, workloadID string) error {
+	f.touchCalls = append(f.touchCalls, workloadID)
+	return nil
+}
+
+func TestFindActiveWorkloadSelectsLatestRunning(t *testing.T) {
+	base := time.Date(2024, 7, 1, 12, 0, 0, 0, time.UTC)
+	first := platform.Workload{
+		ID:        "workload-1",
+		AgentID:   testAgentID,
+		Status:    runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
+		CreatedAt: base,
+	}
+	second := platform.Workload{
+		ID:        "workload-2",
+		AgentID:   testAgentID,
+		Status:    runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
+		CreatedAt: base.Add(5 * time.Minute),
+	}
+	other := platform.Workload{
+		ID:        "workload-3",
+		AgentID:   "other-agent",
+		Status:    runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
+		CreatedAt: base.Add(10 * time.Minute),
+	}
+	fake := &fakeRunnersClient{listResponses: []listResponse{
+		{workloads: []platform.Workload{first, other}, nextToken: "next"},
+		{workloads: []platform.Workload{second}, nextToken: ""},
+	}}
+	daemon := &Daemon{
+		cfg:     config.Config{AgentID: uuid.MustParse(testAgentID)},
+		runners: fake,
+	}
+	workload, ok, err := daemon.findActiveWorkload(context.Background(), "thread-1")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !ok {
+		t.Fatal("expected active workload")
+	}
+	if workload.ID != second.ID {
+		t.Fatalf("expected %q, got %q", second.ID, workload.ID)
+	}
+	if fake.listCalls != 2 {
+		t.Fatalf("expected 2 list calls, got %d", fake.listCalls)
+	}
+}
+
+func TestTouchActiveWorkloadCallsTouch(t *testing.T) {
+	base := time.Date(2024, 7, 1, 12, 0, 0, 0, time.UTC)
+	workload := platform.Workload{
+		ID:        "workload-1",
+		AgentID:   testAgentID,
+		Status:    runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
+		CreatedAt: base,
+	}
+	fake := &fakeRunnersClient{listResponses: []listResponse{{workloads: []platform.Workload{workload}}}}
+	daemon := &Daemon{
+		cfg:     config.Config{AgentID: uuid.MustParse(testAgentID)},
+		runners: fake,
+	}
+	touched, err := daemon.touchActiveWorkload(context.Background(), "thread-1")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !touched {
+		t.Fatal("expected workload to be touched")
+	}
+	if len(fake.touchCalls) != 1 || fake.touchCalls[0] != workload.ID {
+		t.Fatalf("unexpected touch calls: %v", fake.touchCalls)
+	}
+}
+
+func TestTouchActiveWorkloadSkipsNonRunning(t *testing.T) {
+	base := time.Date(2024, 7, 1, 12, 0, 0, 0, time.UTC)
+	removedAt := base.Add(1 * time.Hour)
+	workload := platform.Workload{
+		ID:        "workload-1",
+		AgentID:   testAgentID,
+		Status:    runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPED,
+		CreatedAt: base,
+		RemovedAt: &removedAt,
+	}
+	fake := &fakeRunnersClient{listResponses: []listResponse{{workloads: []platform.Workload{workload}}}}
+	daemon := &Daemon{
+		cfg:     config.Config{AgentID: uuid.MustParse(testAgentID)},
+		runners: fake,
+	}
+	touched, err := daemon.touchActiveWorkload(context.Background(), "thread-1")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if touched {
+		t.Fatal("expected no workload to be touched")
+	}
+	if len(fake.touchCalls) != 0 {
+		t.Fatalf("unexpected touch calls: %v", fake.touchCalls)
+	}
+}

--- a/internal/platform/runners.go
+++ b/internal/platform/runners.go
@@ -1,0 +1,100 @@
+package platform
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	gatewayv1 "github.com/agynio/agynd-cli/.gen/go/agynio/api/gateway/v1"
+	runnersv1 "github.com/agynio/agynd-cli/.gen/go/agynio/api/runners/v1"
+)
+
+type Workload struct {
+	ID        string
+	AgentID   string
+	Status    runnersv1.WorkloadStatus
+	CreatedAt time.Time
+	RemovedAt *time.Time
+}
+
+type Runners struct {
+	client gatewayv1.RunnersGatewayClient
+}
+
+func NewRunners(client gatewayv1.RunnersGatewayClient) *Runners {
+	return &Runners{client: client}
+}
+
+func (r *Runners) ListWorkloadsByThread(ctx context.Context, threadID string, pageSize int32, pageToken string) ([]Workload, string, error) {
+	threadID = strings.TrimSpace(threadID)
+	if threadID == "" {
+		return nil, "", fmt.Errorf("thread id is required")
+	}
+	resp, err := r.client.ListWorkloadsByThread(ctx, &runnersv1.ListWorkloadsByThreadRequest{
+		ThreadId:  threadID,
+		PageSize:  pageSize,
+		PageToken: pageToken,
+	})
+	if err != nil {
+		return nil, "", err
+	}
+	workloads := make([]Workload, 0, len(resp.GetWorkloads()))
+	for _, workload := range resp.GetWorkloads() {
+		converted, err := workloadFromProto(workload)
+		if err != nil {
+			return nil, "", err
+		}
+		workloads = append(workloads, converted)
+	}
+	return workloads, resp.GetNextPageToken(), nil
+}
+
+func (r *Runners) TouchWorkload(ctx context.Context, workloadID string) error {
+	workloadID = strings.TrimSpace(workloadID)
+	if workloadID == "" {
+		return fmt.Errorf("workload id is required")
+	}
+	_, err := r.client.TouchWorkload(ctx, &runnersv1.TouchWorkloadRequest{Id: workloadID})
+	return err
+}
+
+func workloadFromProto(workload *runnersv1.Workload) (Workload, error) {
+	if workload == nil {
+		return Workload{}, fmt.Errorf("workload is required")
+	}
+	meta := workload.GetMeta()
+	if meta == nil {
+		return Workload{}, fmt.Errorf("workload meta is required")
+	}
+	workloadID := strings.TrimSpace(meta.GetId())
+	if workloadID == "" {
+		return Workload{}, fmt.Errorf("workload id is required")
+	}
+	agentID := strings.TrimSpace(workload.GetAgentId())
+	if agentID == "" {
+		return Workload{}, fmt.Errorf("workload agent id is required")
+	}
+	status := workload.GetStatus()
+	if status == runnersv1.WorkloadStatus_WORKLOAD_STATUS_UNSPECIFIED {
+		return Workload{}, fmt.Errorf("workload status is required")
+	}
+	createdAt := meta.GetCreatedAt()
+	if createdAt == nil {
+		return Workload{}, fmt.Errorf("workload created at is required")
+	}
+	createdAtTime := createdAt.AsTime()
+	var removedAt *time.Time
+	if workload.RemovedAt != nil {
+		removedTime := workload.GetRemovedAt().AsTime()
+		removedAt = &removedTime
+	}
+
+	return Workload{
+		ID:        workloadID,
+		AgentID:   agentID,
+		Status:    status,
+		CreatedAt: createdAtTime,
+		RemovedAt: removedAt,
+	}, nil
+}

--- a/internal/platform/runners_test.go
+++ b/internal/platform/runners_test.go
@@ -1,0 +1,215 @@
+package platform
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	gatewayv1 "github.com/agynio/agynd-cli/.gen/go/agynio/api/gateway/v1"
+	runnersv1 "github.com/agynio/agynd-cli/.gen/go/agynio/api/runners/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type fakeRunnersGatewayClient struct {
+	listReq  *runnersv1.ListWorkloadsByThreadRequest
+	listResp *runnersv1.ListWorkloadsByThreadResponse
+	listErr  error
+
+	touchReq *runnersv1.TouchWorkloadRequest
+	touchErr error
+}
+
+var _ gatewayv1.RunnersGatewayClient = (*fakeRunnersGatewayClient)(nil)
+
+func (f *fakeRunnersGatewayClient) RegisterRunner(ctx context.Context, in *runnersv1.RegisterRunnerRequest, opts ...grpc.CallOption) (*runnersv1.RegisterRunnerResponse, error) {
+	return nil, fmt.Errorf("RegisterRunner not implemented")
+}
+
+func (f *fakeRunnersGatewayClient) GetRunner(ctx context.Context, in *runnersv1.GetRunnerRequest, opts ...grpc.CallOption) (*runnersv1.GetRunnerResponse, error) {
+	return nil, fmt.Errorf("GetRunner not implemented")
+}
+
+func (f *fakeRunnersGatewayClient) ListRunners(ctx context.Context, in *runnersv1.ListRunnersRequest, opts ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
+	return nil, fmt.Errorf("ListRunners not implemented")
+}
+
+func (f *fakeRunnersGatewayClient) UpdateRunner(ctx context.Context, in *runnersv1.UpdateRunnerRequest, opts ...grpc.CallOption) (*runnersv1.UpdateRunnerResponse, error) {
+	return nil, fmt.Errorf("UpdateRunner not implemented")
+}
+
+func (f *fakeRunnersGatewayClient) DeleteRunner(ctx context.Context, in *runnersv1.DeleteRunnerRequest, opts ...grpc.CallOption) (*runnersv1.DeleteRunnerResponse, error) {
+	return nil, fmt.Errorf("DeleteRunner not implemented")
+}
+
+func (f *fakeRunnersGatewayClient) EnrollRunner(ctx context.Context, in *runnersv1.EnrollRunnerRequest, opts ...grpc.CallOption) (*runnersv1.EnrollRunnerResponse, error) {
+	return nil, fmt.Errorf("EnrollRunner not implemented")
+}
+
+func (f *fakeRunnersGatewayClient) ListWorkloads(ctx context.Context, in *runnersv1.ListWorkloadsRequest, opts ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
+	return nil, fmt.Errorf("ListWorkloads not implemented")
+}
+
+func (f *fakeRunnersGatewayClient) ListWorkloadsByThread(ctx context.Context, in *runnersv1.ListWorkloadsByThreadRequest, opts ...grpc.CallOption) (*runnersv1.ListWorkloadsByThreadResponse, error) {
+	f.listReq = in
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.listResp, nil
+}
+
+func (f *fakeRunnersGatewayClient) GetWorkload(ctx context.Context, in *runnersv1.GetWorkloadRequest, opts ...grpc.CallOption) (*runnersv1.GetWorkloadResponse, error) {
+	return nil, fmt.Errorf("GetWorkload not implemented")
+}
+
+func (f *fakeRunnersGatewayClient) TouchWorkload(ctx context.Context, in *runnersv1.TouchWorkloadRequest, opts ...grpc.CallOption) (*runnersv1.TouchWorkloadResponse, error) {
+	f.touchReq = in
+	if f.touchErr != nil {
+		return nil, f.touchErr
+	}
+	return &runnersv1.TouchWorkloadResponse{}, nil
+}
+
+func TestWorkloadFromProtoValid(t *testing.T) {
+	createdAt := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	removedAt := time.Date(2024, 6, 1, 13, 0, 0, 0, time.UTC)
+	proto := &runnersv1.Workload{
+		Meta: &runnersv1.EntityMeta{
+			Id:        "workload-1",
+			CreatedAt: timestamppb.New(createdAt),
+		},
+		AgentId:   "agent-1",
+		Status:    runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
+		RemovedAt: timestamppb.New(removedAt),
+	}
+	workload, err := workloadFromProto(proto)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if workload.ID != "workload-1" {
+		t.Fatalf("unexpected id: %s", workload.ID)
+	}
+	if workload.AgentID != "agent-1" {
+		t.Fatalf("unexpected agent id: %s", workload.AgentID)
+	}
+	if workload.Status != runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING {
+		t.Fatalf("unexpected status: %v", workload.Status)
+	}
+	if !workload.CreatedAt.Equal(createdAt) {
+		t.Fatalf("unexpected created at: %v", workload.CreatedAt)
+	}
+	if workload.RemovedAt == nil || !workload.RemovedAt.Equal(removedAt) {
+		t.Fatalf("unexpected removed at: %v", workload.RemovedAt)
+	}
+}
+
+func TestWorkloadFromProtoMissingFields(t *testing.T) {
+	createdAt := timestamppb.New(time.Now())
+	validMeta := &runnersv1.EntityMeta{Id: "workload-1", CreatedAt: createdAt}
+	valid := &runnersv1.Workload{
+		Meta:    validMeta,
+		AgentId: "agent-1",
+		Status:  runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
+	}
+
+	tests := []struct {
+		name     string
+		workload *runnersv1.Workload
+	}{
+		{name: "nil", workload: nil},
+		{name: "missing-meta", workload: &runnersv1.Workload{AgentId: valid.AgentId, Status: valid.Status}},
+		{name: "missing-id", workload: &runnersv1.Workload{Meta: &runnersv1.EntityMeta{CreatedAt: createdAt}, AgentId: valid.AgentId, Status: valid.Status}},
+		{name: "missing-created-at", workload: &runnersv1.Workload{Meta: &runnersv1.EntityMeta{Id: validMeta.Id}, AgentId: valid.AgentId, Status: valid.Status}},
+		{name: "missing-agent-id", workload: &runnersv1.Workload{Meta: validMeta, Status: valid.Status}},
+		{name: "missing-status", workload: &runnersv1.Workload{Meta: validMeta, AgentId: valid.AgentId}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := workloadFromProto(test.workload)
+			if err == nil {
+				t.Fatal("expected error for missing fields")
+			}
+		})
+	}
+}
+
+func TestRunnersListWorkloadsByThread(t *testing.T) {
+	createdAt := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	resp := &runnersv1.ListWorkloadsByThreadResponse{
+		Workloads: []*runnersv1.Workload{{
+			Meta:    &runnersv1.EntityMeta{Id: "workload-1", CreatedAt: timestamppb.New(createdAt)},
+			AgentId: "agent-1",
+			Status:  runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
+		}},
+		NextPageToken: "next",
+	}
+	fake := &fakeRunnersGatewayClient{listResp: resp}
+	client := NewRunners(fake)
+	workloads, next, err := client.ListWorkloadsByThread(context.Background(), "thread-1", 50, "token")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if fake.listReq == nil {
+		t.Fatal("expected list request")
+	}
+	if fake.listReq.GetThreadId() != "thread-1" || fake.listReq.GetPageSize() != 50 || fake.listReq.GetPageToken() != "token" {
+		t.Fatalf("unexpected list request: %+v", fake.listReq)
+	}
+	if next != "next" {
+		t.Fatalf("unexpected next token: %q", next)
+	}
+	if len(workloads) != 1 {
+		t.Fatalf("unexpected workload count: %d", len(workloads))
+	}
+	if workloads[0].ID != "workload-1" || workloads[0].AgentID != "agent-1" {
+		t.Fatalf("unexpected workload: %+v", workloads[0])
+	}
+}
+
+func TestRunnersListWorkloadsByThreadValidation(t *testing.T) {
+	client := NewRunners(&fakeRunnersGatewayClient{})
+	_, _, err := client.ListWorkloadsByThread(context.Background(), "", 10, "")
+	if err == nil {
+		t.Fatal("expected error for missing thread id")
+	}
+}
+
+func TestRunnersTouchWorkload(t *testing.T) {
+	fake := &fakeRunnersGatewayClient{}
+	client := NewRunners(fake)
+	if err := client.TouchWorkload(context.Background(), "workload-1"); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if fake.touchReq == nil || fake.touchReq.GetId() != "workload-1" {
+		t.Fatalf("unexpected touch request: %+v", fake.touchReq)
+	}
+}
+
+func TestRunnersTouchWorkloadValidation(t *testing.T) {
+	client := NewRunners(&fakeRunnersGatewayClient{})
+	if err := client.TouchWorkload(context.Background(), " "); err == nil {
+		t.Fatal("expected error for missing workload id")
+	}
+}
+
+func TestWorkloadFromProtoRemovedAtNil(t *testing.T) {
+	createdAt := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	proto := &runnersv1.Workload{
+		Meta:    &runnersv1.EntityMeta{Id: "workload-1", CreatedAt: timestamppb.New(createdAt)},
+		AgentId: "agent-1",
+		Status:  runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
+	}
+	workload, err := workloadFromProto(proto)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if workload.RemovedAt != nil {
+		t.Fatalf("expected nil removed at, got %v", workload.RemovedAt)
+	}
+	if !reflect.DeepEqual(workload.CreatedAt, createdAt) {
+		t.Fatalf("unexpected created at: %v", workload.CreatedAt)
+	}
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -30,12 +30,17 @@ func TestCodexClientHelloResponse(t *testing.T) {
 	codexHome := t.TempDir()
 	writeCodexConfig(t, codexHome)
 
+	workDir, err := os.MkdirTemp("", "codex-workdir-")
+	if err != nil {
+		t.Fatalf("create workdir: %v", err)
+	}
+
 	handler := &turnCompletedHandler{completed: make(chan *codex.TurnCompletedNotification, 1)}
 	ctx := context.Background()
 	client, err := codex.NewClient(ctx,
 		codex.WithBinary("codex"),
 		codex.WithArgs("app-server"),
-		codex.WithWorkDir(t.TempDir()),
+		codex.WithWorkDir(workDir),
 		codex.WithEnv(map[string]string{
 			"CODEX_HOME":     codexHome,
 			"OPENAI_API_KEY": "test-key",
@@ -45,10 +50,14 @@ func TestCodexClientHelloResponse(t *testing.T) {
 		codex.WithClientInfo("e2e-test", "0.1.0"),
 	)
 	if err != nil {
+		_ = os.RemoveAll(workDir)
 		t.Fatalf("start codex client: %v", err)
 	}
 	t.Cleanup(func() {
 		_ = client.Close()
+		if err := removeAllWithRetry(workDir, 10, 200*time.Millisecond); err != nil {
+			t.Fatalf("cleanup workdir: %v", err)
+		}
 	})
 
 	model := "simple-hello"
@@ -111,6 +120,19 @@ supports_websockets = false
 	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
 		t.Fatalf("write config.toml: %v", err)
 	}
+}
+
+func removeAllWithRetry(path string, attempts int, delay time.Duration) error {
+	var lastErr error
+	for i := 0; i < attempts; i++ {
+		if err := os.RemoveAll(path); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+		time.Sleep(delay)
+	}
+	return lastErr
 }
 
 func findAgentMessage(items []codex.ThreadItem) (string, bool) {


### PR DESCRIPTION
## Summary
- generate gateway stubs from api commit ec008b1 for TouchWorkload
- add runners platform wrapper and keepalive loop touching active workloads
- cover workload selection and conversion in unit tests

## Testing
- go vet ./...
- go test ./...

Refs #20