### PR TITLE
Prepend CLI path for agent env

### DIFF
--- a/internal/daemon/agn.go
+++ b/internal/daemon/agn.go
@@ -57,6 +57,7 @@ func newAgnDaemon(ctx context.Context, cfg config.Config, version string) (*Daem
 	agnClient, err := agnsdk.Start(ctx, agnsdk.Options{
 		BinaryPath: cfg.AgentBinary,
 		Env: []string{
+			"PATH=" + agentPathValue(),
 			"AGN_CONFIG_PATH=" + configPath,
 			"OTEL_EXPORTER_OTLP_ENDPOINT=" + otlpEndpoint,
 		},

--- a/internal/daemon/claude.go
+++ b/internal/daemon/claude.go
@@ -40,6 +40,7 @@ func newClaudeDaemon(ctx context.Context, cfg config.Config, version string) (*D
 		BinaryPath: cfg.AgentBinary,
 		WorkDir:    cfg.WorkDir,
 		Env: []string{
+			"PATH=" + agentPathValue(),
 			"LD_LIBRARY_PATH=/agyn-bin/lib",
 			"OTEL_EXPORTER_OTLP_ENDPOINT=" + otlpEndpoint,
 			"IS_SANDBOX=1",

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -39,21 +39,21 @@ const (
 )
 
 type Daemon struct {
-	cfg          config.Config
-	sdk          string
-	gatewayConn  platformConn
-	threads      *platform.Threads
-	agents       gatewayv1.AgentsGatewayClient
-	subscriber   *subscriber.Subscriber
-	consumer     *platform.Consumer
-	codex        codexClient
-	mapping      *codexbridge.ThreadMapping
-	mappingStore *codexbridge.ThreadMappingStore
-	tracker      *codexbridge.TurnTracker
-	agn          *agnsdk.Client
-	claude       claudeClient
-	agent        *agentsv1.Agent
-	tracingProxy *tracingproxy.Proxy
+	cfg           config.Config
+	sdk           string
+	gatewayConn   platformConn
+	threads       *platform.Threads
+	agents        gatewayv1.AgentsGatewayClient
+	subscriber    *subscriber.Subscriber
+	consumer      *platform.Consumer
+	codex         codexClient
+	mapping       *codexbridge.ThreadMapping
+	mappingStore  *codexbridge.ThreadMappingStore
+	tracker       *codexbridge.TurnTracker
+	agn           *agnsdk.Client
+	claude        claudeClient
+	agent         *agentsv1.Agent
+	tracingProxy  *tracingproxy.Proxy
 	claudeReadyMu sync.Mutex
 	claudeReady   bool
 
@@ -216,6 +216,7 @@ func newCodexDaemon(ctx context.Context, cfg config.Config, version string) (*Da
 		codex.WithBinary(cfg.AgentBinary),
 		codex.WithWorkDir(cfg.WorkDir),
 		codex.WithEnv(map[string]string{
+			"PATH":                        agentPathValue(),
 			"CODEX_HOME":                  codexHome,
 			"OPENAI_API_KEY":              cfg.LLMAPIToken,
 			"OTEL_EXPORTER_OTLP_ENDPOINT": otlpEndpoint,

--- a/internal/daemon/env.go
+++ b/internal/daemon/env.go
@@ -1,0 +1,16 @@
+package daemon
+
+import "os"
+
+const cliPathPrefix = "/agyn-bin/cli"
+
+func prependCLIPath(pathValue string) string {
+	if pathValue == "" {
+		return cliPathPrefix
+	}
+	return cliPathPrefix + string(os.PathListSeparator) + pathValue
+}
+
+func agentPathValue() string {
+	return prependCLIPath(os.Getenv("PATH"))
+}

--- a/internal/daemon/env_test.go
+++ b/internal/daemon/env_test.go
@@ -1,0 +1,22 @@
+package daemon
+
+import (
+	"os"
+	"testing"
+)
+
+func TestPrependCLIPathEmpty(t *testing.T) {
+	got := prependCLIPath("")
+	if got != cliPathPrefix {
+		t.Fatalf("expected %q, got %q", cliPathPrefix, got)
+	}
+}
+
+func TestPrependCLIPathExisting(t *testing.T) {
+	basePath := "/usr/local/bin"
+	expected := cliPathPrefix + string(os.PathListSeparator) + basePath
+	got := prependCLIPath(basePath)
+	if got != expected {
+		t.Fatalf("expected %q, got %q", expected, got)
+	}
+}


### PR DESCRIPTION
## Summary
- prepend /agyn-bin/cli to agent subprocess PATH env
- add unit coverage for PATH prefix helper

## Testing
- buf generate buf.build/agynio/api --path agynio/api/gateway/v1 --include-imports
- GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go test ./...
- GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go vet ./...

Ref: #131