### PR TITLE
fix: pass Claude model env vars

### DIFF
--- a/internal/daemon/claude.go
+++ b/internal/daemon/claude.go
@@ -48,6 +48,10 @@ func newClaudeDaemon(ctx context.Context, cfg config.Config, version string) (*D
 	}
 	if model := strings.TrimSpace(setup.agent.GetModel()); model != "" {
 		options.Model = model
+		options.Env = append(options.Env,
+			"ANTHROPIC_MODEL="+model,
+			"ANTHROPIC_CUSTOM_MODEL_OPTION="+model,
+		)
 	}
 	if role := strings.TrimSpace(setup.agent.GetRole()); role != "" {
 		options.SystemPrompt = role


### PR DESCRIPTION
## Summary
- pass ANTHROPIC_MODEL and ANTHROPIC_CUSTOM_MODEL_OPTION when a model UUID is provided

## Testing
- env GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go vet ./...
- env GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go test ./...
- env GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go build ./...

## Issue
- #84