### PR TITLE
feat(platform): scope unacked polling

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -294,7 +294,7 @@ func (d *Daemon) syncMessages(ctx context.Context) error {
 	d.syncMu.Lock()
 	defer d.syncMu.Unlock()
 
-	return d.consumer.Sync(ctx, d.cfg.AgentID.String(), func(message platform.Message) error {
+	return d.consumer.Sync(ctx, d.cfg.AgentID.String(), d.cfg.ThreadID, func(message platform.Message) error {
 		return d.handleMessage(ctx, message)
 	})
 }

--- a/internal/platform/consumer.go
+++ b/internal/platform/consumer.go
@@ -17,7 +17,7 @@ func NewConsumer(threads *Threads, pageSize int32, requestTimeout time.Duration)
 	return &Consumer{threads: threads, pageSize: pageSize, requestTimeout: requestTimeout}
 }
 
-func (c *Consumer) Sync(ctx context.Context, participantID string, handle func(Message) error) error {
+func (c *Consumer) Sync(ctx context.Context, participantID string, threadID string, handle func(Message) error) error {
 	if handle == nil {
 		return fmt.Errorf("handle function is required")
 	}
@@ -28,7 +28,7 @@ func (c *Consumer) Sync(ctx context.Context, participantID string, handle func(M
 		if c.requestTimeout > 0 {
 			pageCtx, cancel = context.WithTimeout(ctx, c.requestTimeout)
 		}
-		messages, nextToken, err := c.threads.GetUnackedMessages(pageCtx, participantID, c.pageSize, pageToken)
+		messages, nextToken, err := c.threads.GetUnackedMessages(pageCtx, participantID, threadID, c.pageSize, pageToken)
 		if cancel != nil {
 			cancel()
 		}

--- a/internal/platform/consumer_test.go
+++ b/internal/platform/consumer_test.go
@@ -15,6 +15,7 @@ import (
 type fakeThreadsClient struct {
 	responses []*threadsv1.GetUnackedMessagesResponse
 	index     int
+	requests  []*threadsv1.GetUnackedMessagesRequest
 }
 
 var _ gatewayv1.ThreadsGatewayClient = (*fakeThreadsClient)(nil)
@@ -47,6 +48,7 @@ func (f *fakeThreadsClient) GetUnackedMessages(ctx context.Context, in *threadsv
 	if f.index >= len(f.responses) {
 		return nil, fmt.Errorf("unexpected GetUnackedMessages call")
 	}
+	f.requests = append(f.requests, in)
 	resp := f.responses[f.index]
 	f.index++
 	return resp, nil
@@ -89,7 +91,7 @@ func TestConsumerSyncSortsMessages(t *testing.T) {
 	consumer := NewConsumer(threads, 100, 0)
 
 	var got []Message
-	err := consumer.Sync(context.Background(), "participant-1", func(message Message) error {
+	err := consumer.Sync(context.Background(), "participant-1", "thread-1", func(message Message) error {
 		got = append(got, message)
 		return nil
 	})
@@ -101,5 +103,37 @@ func TestConsumerSyncSortsMessages(t *testing.T) {
 	}
 	if got[0].ID != "a" || got[1].ID != "c" || got[2].ID != "b" {
 		t.Fatalf("unexpected sort order: %q, %q, %q", got[0].ID, got[1].ID, got[2].ID)
+	}
+	if len(fake.requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(fake.requests))
+	}
+	if fake.requests[0].ThreadId == nil || *fake.requests[0].ThreadId != "thread-1" {
+		t.Fatalf("expected thread id filter to be set")
+	}
+}
+
+func TestConsumerSyncNoThreadFilter(t *testing.T) {
+	fake := &fakeThreadsClient{
+		responses: []*threadsv1.GetUnackedMessagesResponse{{}},
+	}
+	threads := &Threads{client: fake}
+	consumer := NewConsumer(threads, 100, 0)
+
+	called := false
+	err := consumer.Sync(context.Background(), "participant-1", "", func(message Message) error {
+		called = true
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if called {
+		t.Fatal("expected no messages to be handled")
+	}
+	if len(fake.requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(fake.requests))
+	}
+	if fake.requests[0].ThreadId != nil {
+		t.Fatalf("expected no thread filter, got %q", fake.requests[0].GetThreadId())
 	}
 }

--- a/internal/platform/threads.go
+++ b/internal/platform/threads.go
@@ -26,14 +26,19 @@ func NewThreads(client gatewayv1.ThreadsGatewayClient) *Threads {
 	return &Threads{client: client}
 }
 
-func (t *Threads) GetUnackedMessages(ctx context.Context, participantID string, pageSize int32, pageToken string) ([]Message, string, error) {
+func (t *Threads) GetUnackedMessages(ctx context.Context, participantID string, threadID string, pageSize int32, pageToken string) ([]Message, string, error) {
 	if participantID == "" {
 		return nil, "", fmt.Errorf("participant id is required")
+	}
+	var threadFilter *string
+	if threadID != "" {
+		threadFilter = &threadID
 	}
 	resp, err := t.client.GetUnackedMessages(ctx, &threadsv1.GetUnackedMessagesRequest{
 		ParticipantId: participantID,
 		PageSize:      pageSize,
 		PageToken:     pageToken,
+		ThreadId:      threadFilter,
 	})
 	if err != nil {
 		return nil, "", fmt.Errorf("get unacked messages: %w", err)


### PR DESCRIPTION
## Summary
- scope unacked message polling to the configured thread when provided
- plumb thread id through consumer sync and daemon flow
- add coverage for thread-filtered polling behavior

## Testing
- GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go vet ./...
- GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go test ./...

Refs #132