### PR TITLE
Fix thread filtering for subscriber wakeups

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,6 +57,11 @@ func fromEnv(configPath string) (Config, error) {
 		tracingAddress = "tracing.ziti:443"
 	}
 	threadID := strings.TrimSpace(os.Getenv("THREAD_ID"))
+	threadUUID, err := uuidutil.ParseUUID(threadID, "THREAD_ID")
+	if err != nil {
+		return Config{}, err
+	}
+	threadID = threadUUID.String()
 	llmBaseURL := strings.TrimSpace(os.Getenv("LLM_BASE_URL"))
 	if llmBaseURL == "" {
 		llmBaseURL = "http://llm-proxy.ziti:443/v1"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -8,11 +8,15 @@ import (
 	"testing"
 )
 
-const validAgentID = "550e8400-e29b-41d4-a716-446655440000"
+const (
+	validAgentID  = "550e8400-e29b-41d4-a716-446655440000"
+	validThreadID = "3f7fd7e3-5c6c-4a1e-8f4e-69c0030d3ed7"
+)
 
 func setRequiredEnv(t *testing.T) {
 	t.Helper()
 	t.Setenv("AGENT_ID", validAgentID)
+	t.Setenv("THREAD_ID", validThreadID)
 }
 
 func writeAgentConfig(t *testing.T, sdk, bin string) string {
@@ -37,7 +41,7 @@ func TestFromEnvValid(t *testing.T) {
 	t.Setenv("WORKSPACE_DIR", "/tmp/workdir")
 	t.Setenv("GATEWAY_ADDRESS", "gateway:1234")
 	t.Setenv("TRACING_ADDRESS", "tracing:5678")
-	t.Setenv("THREAD_ID", "thread-123")
+	t.Setenv("THREAD_ID", "9d06fe19-695b-48ac-83ba-2cd82472f7c8")
 	t.Setenv("LLM_BASE_URL", "https://llm.example")
 	t.Setenv("LLM_API_TOKEN", "token-123")
 
@@ -54,7 +58,7 @@ func TestFromEnvValid(t *testing.T) {
 	if cfg.TracingAddress != "tracing:5678" {
 		t.Fatalf("unexpected tracing address: %s", cfg.TracingAddress)
 	}
-	if cfg.ThreadID != "thread-123" {
+	if cfg.ThreadID != "9d06fe19-695b-48ac-83ba-2cd82472f7c8" {
 		t.Fatalf("unexpected thread id: %s", cfg.ThreadID)
 	}
 	if cfg.LLMBaseURL != "https://llm.example" {
@@ -95,6 +99,7 @@ func TestFromEnvMissingRequired(t *testing.T) {
 		expected string
 	}{
 		{name: "agent-id", missing: "AGENT_ID", expected: "AGENT_ID"},
+		{name: "thread-id", missing: "THREAD_ID", expected: "THREAD_ID"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -171,13 +176,13 @@ func TestFromEnvTracingAddressCustom(t *testing.T) {
 func TestFromEnvThreadID(t *testing.T) {
 	setRequiredEnv(t)
 	configPath := writeAgentConfig(t, "codex", "/opt/bin/codex")
-	t.Setenv("THREAD_ID", "  thread-abc ")
+	t.Setenv("THREAD_ID", "  9E54A9CE-F2E1-4B5F-9C91-8F4C77554C30 ")
 
 	cfg, err := fromEnv(configPath)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if cfg.ThreadID != "thread-abc" {
+	if cfg.ThreadID != "9e54a9ce-f2e1-4b5f-9c91-8f4c77554c30" {
 		t.Fatalf("unexpected thread id: %q", cfg.ThreadID)
 	}
 }
@@ -187,12 +192,26 @@ func TestFromEnvThreadIDEmpty(t *testing.T) {
 	configPath := writeAgentConfig(t, "codex", "/opt/bin/codex")
 	t.Setenv("THREAD_ID", "")
 
-	cfg, err := fromEnv(configPath)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
+	_, err := fromEnv(configPath)
+	if err == nil {
+		t.Fatal("expected error for missing THREAD_ID")
 	}
-	if cfg.ThreadID != "" {
-		t.Fatalf("expected empty thread id, got %q", cfg.ThreadID)
+	if !strings.Contains(err.Error(), "THREAD_ID") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestFromEnvThreadIDInvalid(t *testing.T) {
+	setRequiredEnv(t)
+	configPath := writeAgentConfig(t, "codex", "/opt/bin/codex")
+	t.Setenv("THREAD_ID", "not-a-uuid")
+
+	_, err := fromEnv(configPath)
+	if err == nil {
+		t.Fatal("expected error for invalid THREAD_ID")
+	}
+	if !strings.Contains(err.Error(), "THREAD_ID") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/daemon/agn.go
+++ b/internal/daemon/agn.go
@@ -75,7 +75,7 @@ func newAgnDaemon(ctx context.Context, cfg config.Config, version string) (*Daem
 		threads:      setup.threads,
 		agents:       setup.agents,
 		runners:      setup.runners,
-		subscriber:   subscriber.New(setup.notifications, cfg.AgentID.String()),
+		subscriber:   subscriber.New(setup.notifications, cfg.AgentID.String(), cfg.ThreadID),
 		consumer:     platform.NewConsumer(setup.threads, pageSize, pageTimeout),
 		agn:          agnClient,
 		agent:        setup.agent,

--- a/internal/daemon/claude.go
+++ b/internal/daemon/claude.go
@@ -70,7 +70,7 @@ func newClaudeDaemon(ctx context.Context, cfg config.Config, version string) (*D
 		threads:      setup.threads,
 		agents:       setup.agents,
 		runners:      setup.runners,
-		subscriber:   subscriber.New(setup.notifications, cfg.AgentID.String()),
+		subscriber:   subscriber.New(setup.notifications, cfg.AgentID.String(), cfg.ThreadID),
 		consumer:     platform.NewConsumer(setup.threads, pageSize, pageTimeout),
 		claude:       claudeClient,
 		agent:        setup.agent,

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -249,7 +249,7 @@ func newCodexDaemon(ctx context.Context, cfg config.Config, version string) (*Da
 		threads:      setup.threads,
 		agents:       setup.agents,
 		runners:      setup.runners,
-		subscriber:   subscriber.New(setup.notifications, cfg.AgentID.String()),
+		subscriber:   subscriber.New(setup.notifications, cfg.AgentID.String(), cfg.ThreadID),
 		consumer:     platform.NewConsumer(setup.threads, pageSize, pageTimeout),
 		codex:        codexClient,
 		mapping:      threadsMapping,

--- a/internal/subscriber/subscriber.go
+++ b/internal/subscriber/subscriber.go
@@ -5,21 +5,29 @@ import (
 	"errors"
 	"io"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/agynio/agynd-cli/internal/platform"
+	"github.com/google/uuid"
+	structpb "google.golang.org/protobuf/types/known/structpb"
 )
 
 const messageCreatedEvent = "message.created"
 
 type Subscriber struct {
-	client  *platform.Notifications
-	agentID string
-	wake    chan struct{}
+	client   notificationsClient
+	agentID  string
+	threadID string
+	wake     chan struct{}
 }
 
-func New(client *platform.Notifications, agentID string) *Subscriber {
-	return &Subscriber{client: client, agentID: agentID, wake: make(chan struct{}, 1)}
+type notificationsClient interface {
+	Subscribe(ctx context.Context, agentID string) (platform.SubscribeStream, error)
+}
+
+func New(client notificationsClient, agentID string, threadID string) *Subscriber {
+	return &Subscriber{client: client, agentID: agentID, threadID: threadID, wake: make(chan struct{}, 1)}
 }
 
 func (s *Subscriber) Run(ctx context.Context) error {
@@ -60,11 +68,16 @@ func (s *Subscriber) Run(ctx context.Context) error {
 			if envelope == nil {
 				continue
 			}
-			if envelope.GetEvent() == messageCreatedEvent {
-				select {
-				case s.wake <- struct{}{}:
-				default:
-				}
+			if envelope.GetEvent() != messageCreatedEvent {
+				continue
+			}
+			payloadThreadID, ok := payloadThreadID(envelope.GetPayload())
+			if !ok || payloadThreadID != s.threadID {
+				continue
+			}
+			select {
+			case s.wake <- struct{}{}:
+			default:
 			}
 		}
 	}
@@ -97,4 +110,27 @@ func nextBackoff(current time.Duration) time.Duration {
 		return 30 * time.Second
 	}
 	return next
+}
+
+func payloadThreadID(payload *structpb.Struct) (string, bool) {
+	if payload == nil {
+		return "", false
+	}
+	fields := payload.GetFields()
+	if fields == nil {
+		return "", false
+	}
+	value, ok := fields["thread_id"]
+	if !ok || value == nil {
+		return "", false
+	}
+	raw := strings.TrimSpace(value.GetStringValue())
+	if raw == "" {
+		return "", false
+	}
+	parsed, err := uuid.Parse(raw)
+	if err != nil {
+		return "", false
+	}
+	return parsed.String(), true
 }

--- a/internal/subscriber/subscriber_test.go
+++ b/internal/subscriber/subscriber_test.go
@@ -60,6 +60,62 @@ func waitForRun(t *testing.T, done <-chan error) {
 	}
 }
 
+func TestPayloadThreadID(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload *structpb.Struct
+		want    string
+		ok      bool
+	}{
+		{name: "nil-payload", payload: nil, want: "", ok: false},
+		{name: "nil-fields", payload: &structpb.Struct{}, want: "", ok: false},
+		{
+			name: "missing-thread-id",
+			payload: &structpb.Struct{Fields: map[string]*structpb.Value{
+				"other": structpb.NewStringValue("value"),
+			}},
+			want: "",
+			ok:   false,
+		},
+		{
+			name: "empty-thread-id",
+			payload: &structpb.Struct{Fields: map[string]*structpb.Value{
+				"thread_id": structpb.NewStringValue(" "),
+			}},
+			want: "",
+			ok:   false,
+		},
+		{
+			name: "invalid-thread-id",
+			payload: &structpb.Struct{Fields: map[string]*structpb.Value{
+				"thread_id": structpb.NewStringValue("not-a-uuid"),
+			}},
+			want: "",
+			ok:   false,
+		},
+		{
+			name: "valid-thread-id",
+			payload: &structpb.Struct{Fields: map[string]*structpb.Value{
+				"thread_id": structpb.NewStringValue("  9E54A9CE-F2E1-4B5F-9C91-8F4C77554C30 "),
+			}},
+			want: "9e54a9ce-f2e1-4b5f-9c91-8f4c77554c30",
+			ok:   true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, ok := payloadThreadID(test.payload)
+			if ok != test.ok {
+				t.Fatalf("expected ok=%v, got %v", test.ok, ok)
+			}
+			if got != test.want {
+				t.Fatalf("expected %q, got %q", test.want, got)
+			}
+		})
+	}
+}
+
 func TestSubscriberWakeOnMatchingThread(t *testing.T) {
 	threadID := "9d06fe19-695b-48ac-83ba-2cd82472f7c8"
 	responses := make(chan *notificationsv1.SubscribeResponse, 1)

--- a/internal/subscriber/subscriber_test.go
+++ b/internal/subscriber/subscriber_test.go
@@ -1,9 +1,117 @@
 package subscriber
 
 import (
+	"context"
+	"errors"
+	"io"
 	"testing"
 	"time"
+
+	notificationsv1 "github.com/agynio/agynd-cli/.gen/go/agynio/api/notifications/v1"
+	"github.com/agynio/agynd-cli/internal/platform"
+	structpb "google.golang.org/protobuf/types/known/structpb"
 )
+
+type fakeNotifications struct {
+	stream  platform.SubscribeStream
+	agentID string
+	called  int
+}
+
+func (f *fakeNotifications) Subscribe(_ context.Context, agentID string) (platform.SubscribeStream, error) {
+	f.called++
+	f.agentID = agentID
+	return f.stream, nil
+}
+
+type fakeStream struct {
+	responses chan *notificationsv1.SubscribeResponse
+}
+
+func (f *fakeStream) Recv() (*notificationsv1.SubscribeResponse, error) {
+	resp, ok := <-f.responses
+	if !ok {
+		return nil, io.EOF
+	}
+	return resp, nil
+}
+
+func makeThreadPayload(threadID string) *structpb.Struct {
+	return &structpb.Struct{
+		Fields: map[string]*structpb.Value{
+			"thread_id": structpb.NewStringValue(threadID),
+		},
+	}
+}
+
+func makeMessageCreated(threadID string) *notificationsv1.SubscribeResponse {
+	return &notificationsv1.SubscribeResponse{
+		Envelope: &notificationsv1.NotificationEnvelope{
+			Event:   messageCreatedEvent,
+			Payload: makeThreadPayload(threadID),
+		},
+	}
+}
+
+func waitForRun(t *testing.T, done <-chan error) {
+	t.Helper()
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled, got %v", err)
+	}
+}
+
+func TestSubscriberWakeOnMatchingThread(t *testing.T) {
+	threadID := "9d06fe19-695b-48ac-83ba-2cd82472f7c8"
+	responses := make(chan *notificationsv1.SubscribeResponse, 1)
+	stream := &fakeStream{responses: responses}
+	client := &fakeNotifications{stream: stream}
+	sub := New(client, "agent-1", threadID)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- sub.Run(ctx)
+	}()
+
+	responses <- makeMessageCreated(threadID)
+
+	select {
+	case <-sub.Wake():
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected wake signal")
+	}
+
+	cancel()
+	close(responses)
+	waitForRun(t, done)
+}
+
+func TestSubscriberIgnoreOtherThread(t *testing.T) {
+	threadID := "9d06fe19-695b-48ac-83ba-2cd82472f7c8"
+	otherThreadID := "1f5a4e5c-350a-4f3a-8dda-0ef049b89d09"
+	responses := make(chan *notificationsv1.SubscribeResponse, 1)
+	stream := &fakeStream{responses: responses}
+	client := &fakeNotifications{stream: stream}
+	sub := New(client, "agent-1", threadID)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- sub.Run(ctx)
+	}()
+
+	responses <- makeMessageCreated(otherThreadID)
+
+	select {
+	case <-sub.Wake():
+		t.Fatal("unexpected wake signal")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	cancel()
+	close(responses)
+	waitForRun(t, done)
+}
 
 func TestNextBackoffProgression(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary
- require THREAD_ID env values to be valid UUIDs and normalize them in config
- filter subscriber wakeups by payload thread_id for defense-in-depth
- add unit coverage for thread ID config validation and subscriber filtering

## Testing
- `GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go test ./...`
- `GOPRIVATE=github.com/agynio/* GONOSUMDB=github.com/agynio/* GONOPROXY=github.com/agynio/* go vet ./...`

Closes #89