### PR TITLE
feat(daemon): run init scripts

### DIFF
--- a/internal/daemon/agn.go
+++ b/internal/daemon/agn.go
@@ -21,6 +21,11 @@ func newAgnDaemon(ctx context.Context, cfg config.Config, version string) (*Daem
 		return nil, err
 	}
 
+	if err := runInitScripts(ctx, setup.agents, cfg.AgentID.String(), cfg.WorkDir); err != nil {
+		_ = setup.gatewayConn.Close()
+		return nil, err
+	}
+
 	summarization, err := parseAgentSummarization(setup.agent.GetConfiguration())
 	if err != nil {
 		_ = setup.gatewayConn.Close()

--- a/internal/daemon/claude.go
+++ b/internal/daemon/claude.go
@@ -21,6 +21,11 @@ func newClaudeDaemon(ctx context.Context, cfg config.Config, version string) (*D
 		return nil, err
 	}
 
+	if err := runInitScripts(ctx, setup.agents, cfg.AgentID.String(), cfg.WorkDir); err != nil {
+		_ = setup.gatewayConn.Close()
+		return nil, err
+	}
+
 	if err := writeClaudeSettings(claudeBaseURL(cfg.LLMBaseURL), cfg.LLMAPIToken, cfg.MCPServers); err != nil {
 		_ = setup.gatewayConn.Close()
 		return nil, err

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -198,6 +198,11 @@ func newCodexDaemon(ctx context.Context, cfg config.Config, version string) (*Da
 		return nil, err
 	}
 
+	if err := runInitScripts(ctx, setup.agents, cfg.AgentID.String(), cfg.WorkDir); err != nil {
+		_ = setup.gatewayConn.Close()
+		return nil, err
+	}
+
 	tracker := codexbridge.NewTurnTracker()
 	bridge := codexbridge.New(tracker)
 	threadsMapping := codexbridge.NewThreadMapping()

--- a/internal/daemon/init_scripts.go
+++ b/internal/daemon/init_scripts.go
@@ -1,0 +1,126 @@
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+
+	agentsv1 "github.com/agynio/agynd-cli/.gen/go/agynio/api/agents/v1"
+	"google.golang.org/grpc"
+)
+
+const initScriptsPageSize int32 = 100
+
+type initScriptsClient interface {
+	ListInitScripts(ctx context.Context, in *agentsv1.ListInitScriptsRequest, opts ...grpc.CallOption) (*agentsv1.ListInitScriptsResponse, error)
+}
+
+type initScript struct {
+	ID        string
+	CreatedAt time.Time
+	Script    string
+}
+
+func runInitScripts(ctx context.Context, client initScriptsClient, agentID string, workDir string) error {
+	scripts, err := listInitScripts(ctx, client, agentID)
+	if err != nil {
+		return err
+	}
+	for _, script := range scripts {
+		if err := executeInitScript(ctx, script, workDir); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func listInitScripts(ctx context.Context, client initScriptsClient, agentID string) ([]initScript, error) {
+	if client == nil {
+		return nil, fmt.Errorf("init scripts client is required")
+	}
+	agentID = strings.TrimSpace(agentID)
+	if agentID == "" {
+		return nil, fmt.Errorf("agent id is required")
+	}
+	var scripts []initScript
+	pageToken := ""
+	for {
+		resp, err := client.ListInitScripts(ctx, &agentsv1.ListInitScriptsRequest{
+			AgentId:   agentID,
+			PageSize:  initScriptsPageSize,
+			PageToken: pageToken,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, script := range resp.GetInitScripts() {
+			parsed, err := initScriptFromProto(script)
+			if err != nil {
+				return nil, err
+			}
+			scripts = append(scripts, parsed)
+		}
+		pageToken = strings.TrimSpace(resp.GetNextPageToken())
+		if pageToken == "" {
+			break
+		}
+	}
+	sort.Slice(scripts, func(i, j int) bool {
+		if scripts[i].CreatedAt.Equal(scripts[j].CreatedAt) {
+			return scripts[i].ID < scripts[j].ID
+		}
+		return scripts[i].CreatedAt.Before(scripts[j].CreatedAt)
+	})
+	return scripts, nil
+}
+
+func initScriptFromProto(script *agentsv1.InitScript) (initScript, error) {
+	if script == nil {
+		return initScript{}, fmt.Errorf("init script is required")
+	}
+	meta := script.GetMeta()
+	if meta == nil {
+		return initScript{}, fmt.Errorf("init script meta is required")
+	}
+	id := strings.TrimSpace(meta.GetId())
+	if id == "" {
+		return initScript{}, fmt.Errorf("init script id is required")
+	}
+	createdAt := meta.GetCreatedAt()
+	if createdAt == nil {
+		return initScript{}, fmt.Errorf("init script created at is required")
+	}
+	rawScript := script.GetScript()
+	if strings.TrimSpace(rawScript) == "" {
+		return initScript{}, fmt.Errorf("init script script is required")
+	}
+	return initScript{
+		ID:        id,
+		CreatedAt: createdAt.AsTime(),
+		Script:    rawScript,
+	}, nil
+}
+
+func executeInitScript(ctx context.Context, script initScript, workDir string) error {
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-lc", script.Script)
+	if strings.TrimSpace(workDir) != "" {
+		cmd.Dir = workDir
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			log.Printf("init script %s failed: %s", script.ID, strings.TrimSpace(stderr.String()))
+			return nil
+		}
+		return fmt.Errorf("run init script %s: %w", script.ID, err)
+	}
+	return nil
+}

--- a/internal/daemon/init_scripts_test.go
+++ b/internal/daemon/init_scripts_test.go
@@ -1,0 +1,184 @@
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	agentsv1 "github.com/agynio/agynd-cli/.gen/go/agynio/api/agents/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type fakeInitScriptsClient struct {
+	responses []*agentsv1.ListInitScriptsResponse
+	requests  []*agentsv1.ListInitScriptsRequest
+	err       error
+}
+
+func (f *fakeInitScriptsClient) ListInitScripts(_ context.Context, in *agentsv1.ListInitScriptsRequest, _ ...grpc.CallOption) (*agentsv1.ListInitScriptsResponse, error) {
+	f.requests = append(f.requests, in)
+	if f.err != nil {
+		return nil, f.err
+	}
+	if len(f.responses) == 0 {
+		return &agentsv1.ListInitScriptsResponse{}, nil
+	}
+	resp := f.responses[0]
+	f.responses = f.responses[1:]
+	return resp, nil
+}
+
+func TestInitScriptFromProtoValid(t *testing.T) {
+	createdAt := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	proto := &agentsv1.InitScript{
+		Meta: &agentsv1.EntityMeta{
+			Id:        "script-1",
+			CreatedAt: timestamppb.New(createdAt),
+		},
+		Script: "echo ok",
+	}
+	script, err := initScriptFromProto(proto)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if script.ID != "script-1" {
+		t.Fatalf("unexpected id: %s", script.ID)
+	}
+	if !script.CreatedAt.Equal(createdAt) {
+		t.Fatalf("unexpected created at: %v", script.CreatedAt)
+	}
+	if script.Script != "echo ok" {
+		t.Fatalf("unexpected script: %q", script.Script)
+	}
+}
+
+func TestInitScriptFromProtoMissingFields(t *testing.T) {
+	createdAt := timestamppb.New(time.Now())
+	validMeta := &agentsv1.EntityMeta{Id: "script-1", CreatedAt: createdAt}
+	valid := &agentsv1.InitScript{Meta: validMeta, Script: "echo ok"}
+
+	tests := []struct {
+		name   string
+		script *agentsv1.InitScript
+	}{
+		{name: "nil", script: nil},
+		{name: "missing-meta", script: &agentsv1.InitScript{Script: valid.Script}},
+		{name: "missing-id", script: &agentsv1.InitScript{Meta: &agentsv1.EntityMeta{CreatedAt: createdAt}, Script: valid.Script}},
+		{name: "missing-created-at", script: &agentsv1.InitScript{Meta: &agentsv1.EntityMeta{Id: validMeta.Id}, Script: valid.Script}},
+		{name: "missing-script", script: &agentsv1.InitScript{Meta: validMeta}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := initScriptFromProto(test.script)
+			if err == nil {
+				t.Fatal("expected error for missing fields")
+			}
+		})
+	}
+}
+
+func TestListInitScriptsOrdersByCreatedAtThenID(t *testing.T) {
+	firstCreated := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
+	secondCreated := time.Date(2024, 6, 1, 11, 0, 0, 0, time.UTC)
+	resp1 := &agentsv1.ListInitScriptsResponse{
+		InitScripts: []*agentsv1.InitScript{
+			{
+				Meta:   &agentsv1.EntityMeta{Id: "c", CreatedAt: timestamppb.New(secondCreated)},
+				Script: "echo third",
+			},
+			{
+				Meta:   &agentsv1.EntityMeta{Id: "b", CreatedAt: timestamppb.New(firstCreated)},
+				Script: "echo second",
+			},
+		},
+		NextPageToken: "next",
+	}
+	resp2 := &agentsv1.ListInitScriptsResponse{
+		InitScripts: []*agentsv1.InitScript{
+			{
+				Meta:   &agentsv1.EntityMeta{Id: "a", CreatedAt: timestamppb.New(firstCreated)},
+				Script: "echo first",
+			},
+		},
+	}
+	fake := &fakeInitScriptsClient{responses: []*agentsv1.ListInitScriptsResponse{resp1, resp2}}
+	scripts, err := listInitScripts(context.Background(), fake, "agent-1")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(fake.requests) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(fake.requests))
+	}
+	if fake.requests[0].GetAgentId() != "agent-1" || fake.requests[0].GetPageSize() != initScriptsPageSize || fake.requests[0].GetPageToken() != "" {
+		t.Fatalf("unexpected first request: %+v", fake.requests[0])
+	}
+	if fake.requests[1].GetPageToken() != "next" {
+		t.Fatalf("unexpected next page token: %q", fake.requests[1].GetPageToken())
+	}
+	if len(scripts) != 3 {
+		t.Fatalf("unexpected script count: %d", len(scripts))
+	}
+	if scripts[0].ID != "a" || scripts[1].ID != "b" || scripts[2].ID != "c" {
+		t.Fatalf("unexpected order: %v", []string{scripts[0].ID, scripts[1].ID, scripts[2].ID})
+	}
+}
+
+func TestRunInitScriptsExecutesInOrder(t *testing.T) {
+	workDir := t.TempDir()
+	outputPath := filepath.Join(workDir, "order.txt")
+	firstCreated := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
+	secondCreated := time.Date(2024, 6, 1, 11, 0, 0, 0, time.UTC)
+	fake := &fakeInitScriptsClient{responses: []*agentsv1.ListInitScriptsResponse{{
+		InitScripts: []*agentsv1.InitScript{
+			{
+				Meta:   &agentsv1.EntityMeta{Id: "later", CreatedAt: timestamppb.New(secondCreated)},
+				Script: "printf 'second\n' >> order.txt",
+			},
+			{
+				Meta:   &agentsv1.EntityMeta{Id: "early", CreatedAt: timestamppb.New(firstCreated)},
+				Script: "printf 'first\n' >> order.txt",
+			},
+		},
+	}}}
+	if err := runInitScripts(context.Background(), fake, "agent-1", workDir); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("expected output file to exist, got %v", err)
+	}
+	if string(data) != "first\nsecond\n" {
+		t.Fatalf("unexpected output: %q", string(data))
+	}
+}
+
+func TestExecuteInitScriptNonZeroLogsAndContinues(t *testing.T) {
+	var buffer bytes.Buffer
+	previousWriter := log.Writer()
+	previousFlags := log.Flags()
+	log.SetOutput(&buffer)
+	log.SetFlags(0)
+	defer func() {
+		log.SetOutput(previousWriter)
+		log.SetFlags(previousFlags)
+	}()
+
+	script := initScript{
+		ID:        "script-err",
+		CreatedAt: time.Now(),
+		Script:    "echo bad 1>&2; exit 2",
+	}
+	if err := executeInitScript(context.Background(), script, t.TempDir()); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !strings.Contains(buffer.String(), "init script script-err failed: bad") {
+		t.Fatalf("unexpected log output: %q", buffer.String())
+	}
+}


### PR DESCRIPTION
## Summary
- call ListInitScripts and execute init scripts before agent startup
- validate/order scripts by created_at/id with /bin/sh -lc execution
- add tests for parsing, ordering, and logging behavior

## Testing
- go test ./...
- go vet ./...

Refs #91