### PR TITLE
feat(daemon): stream init script logs

### DIFF
--- a/internal/daemon/init_scripts.go
+++ b/internal/daemon/init_scripts.go
@@ -1,11 +1,11 @@
 package daemon
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"log"
+	"os"
 	"os/exec"
 	"sort"
 	"strings"
@@ -22,9 +22,10 @@ type initScriptsClient interface {
 }
 
 type initScript struct {
-	ID        string
-	CreatedAt time.Time
-	Script    string
+	ID          string
+	CreatedAt   time.Time
+	Script      string
+	Description string
 }
 
 func runInitScripts(ctx context.Context, client initScriptsClient, agentID string, workDir string) error {
@@ -100,27 +101,41 @@ func initScriptFromProto(script *agentsv1.InitScript) (initScript, error) {
 	if strings.TrimSpace(rawScript) == "" {
 		return initScript{}, fmt.Errorf("init script script is required")
 	}
+	description := strings.TrimSpace(script.GetDescription())
 	return initScript{
-		ID:        id,
-		CreatedAt: createdAt.AsTime(),
-		Script:    rawScript,
+		ID:          id,
+		CreatedAt:   createdAt.AsTime(),
+		Script:      rawScript,
+		Description: description,
 	}, nil
 }
 
 func executeInitScript(ctx context.Context, script initScript, workDir string) error {
+	logInitScriptStart(script)
 	cmd := exec.CommandContext(ctx, "/bin/sh", "-lc", script.Script)
 	if strings.TrimSpace(workDir) != "" {
 		cmd.Dir = workDir
 	}
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return err
+		}
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
-			log.Printf("init script %s failed: %s", script.ID, strings.TrimSpace(stderr.String()))
+			log.Printf("init script %s exited with code %d", script.ID, exitErr.ExitCode())
 			return nil
 		}
 		return fmt.Errorf("run init script %s: %w", script.ID, err)
 	}
 	return nil
+}
+
+func logInitScriptStart(script initScript) {
+	if script.Description == "" {
+		log.Printf("running init script %s", script.ID)
+		return
+	}
+	log.Printf("running init script %s: %s", script.ID, script.Description)
 }

--- a/internal/daemon/init_scripts_test.go
+++ b/internal/daemon/init_scripts_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"bytes"
 	"context"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -41,7 +42,8 @@ func TestInitScriptFromProtoValid(t *testing.T) {
 			Id:        "script-1",
 			CreatedAt: timestamppb.New(createdAt),
 		},
-		Script: "echo ok",
+		Script:      "echo ok",
+		Description: " setup description ",
 	}
 	script, err := initScriptFromProto(proto)
 	if err != nil {
@@ -55,6 +57,9 @@ func TestInitScriptFromProtoValid(t *testing.T) {
 	}
 	if script.Script != "echo ok" {
 		t.Fatalf("unexpected script: %q", script.Script)
+	}
+	if script.Description != "setup description" {
+		t.Fatalf("unexpected description: %q", script.Description)
 	}
 }
 
@@ -170,15 +175,54 @@ func TestExecuteInitScriptNonZeroLogsAndContinues(t *testing.T) {
 		log.SetFlags(previousFlags)
 	}()
 
+	captureOutput := captureStdoutStderr(t)
+
 	script := initScript{
-		ID:        "script-err",
-		CreatedAt: time.Now(),
-		Script:    "echo bad 1>&2; exit 2",
+		ID:          "script-err",
+		CreatedAt:   time.Now(),
+		Description: "setup step",
+		Script:      "echo ok; echo bad 1>&2; exit 2",
 	}
 	if err := executeInitScript(context.Background(), script, t.TempDir()); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if !strings.Contains(buffer.String(), "init script script-err failed: bad") {
-		t.Fatalf("unexpected log output: %q", buffer.String())
+	output := captureOutput()
+	if !strings.Contains(output, "ok") || !strings.Contains(output, "bad") {
+		t.Fatalf("unexpected command output: %q", output)
+	}
+	logOutput := buffer.String()
+	if !strings.Contains(logOutput, "running init script script-err: setup step") {
+		t.Fatalf("unexpected start log output: %q", logOutput)
+	}
+	if !strings.Contains(logOutput, "init script script-err exited with code 2") {
+		t.Fatalf("unexpected exit log output: %q", logOutput)
+	}
+}
+
+func captureStdoutStderr(t *testing.T) func() string {
+	t.Helper()
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("expected pipe creation to succeed, got %v", err)
+	}
+	previousStdout := os.Stdout
+	previousStderr := os.Stderr
+	os.Stdout = writer
+	os.Stderr = writer
+
+	return func() string {
+		os.Stdout = previousStdout
+		os.Stderr = previousStderr
+		if err := writer.Close(); err != nil {
+			t.Fatalf("expected pipe close to succeed, got %v", err)
+		}
+		output, err := io.ReadAll(reader)
+		if err != nil {
+			t.Fatalf("expected pipe read to succeed, got %v", err)
+		}
+		if err := reader.Close(); err != nil {
+			t.Fatalf("expected pipe close to succeed, got %v", err)
+		}
+		return string(output)
 	}
 }

--- a/internal/daemon/init_scripts_test.go
+++ b/internal/daemon/init_scripts_test.go
@@ -209,10 +209,24 @@ func captureStdoutStderr(t *testing.T) func() string {
 	previousStderr := os.Stderr
 	os.Stdout = writer
 	os.Stderr = writer
+	closed := false
 
-	return func() string {
+	restore := func() {
 		os.Stdout = previousStdout
 		os.Stderr = previousStderr
+	}
+
+	t.Cleanup(func() {
+		restore()
+		if closed {
+			return
+		}
+		_ = writer.Close()
+		_ = reader.Close()
+	})
+
+	return func() string {
+		restore()
 		if err := writer.Close(); err != nil {
 			t.Fatalf("expected pipe close to succeed, got %v", err)
 		}
@@ -223,6 +237,7 @@ func captureStdoutStderr(t *testing.T) func() string {
 		if err := reader.Close(); err != nil {
 			t.Fatalf("expected pipe close to succeed, got %v", err)
 		}
+		closed = true
 		return string(output)
 	}
 }


### PR DESCRIPTION
## Summary
- log init script start with id/description and stream stdout/stderr
- continue on non-zero exit while logging exit code
- update tests to cover logging and output streaming

## Testing
- go test ./...
- go vet ./...

Refs #94