### PR TITLE
fix(daemon): skip idle workload touches

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	agnsdk "github.com/agynio/agn-sdk-go"
@@ -58,7 +59,8 @@ type Daemon struct {
 	claudeReadyMu sync.Mutex
 	claudeReady   bool
 
-	syncMu sync.Mutex
+	processing atomic.Bool
+	syncMu     sync.Mutex
 }
 
 type platformConn interface {
@@ -310,7 +312,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 
 func (d *Daemon) syncMessages(ctx context.Context) error {
 	d.syncMu.Lock()
-	defer d.syncMu.Unlock()
+	d.processing.Store(true)
+	defer func() {
+		d.processing.Store(false)
+		d.syncMu.Unlock()
+	}()
 
 	return d.consumer.Sync(ctx, d.cfg.AgentID.String(), d.cfg.ThreadID, func(message platform.Message) error {
 		return d.handleMessage(ctx, message)

--- a/internal/daemon/keepalive.go
+++ b/internal/daemon/keepalive.go
@@ -41,6 +41,9 @@ func (d *Daemon) runKeepalive(ctx context.Context) {
 }
 
 func (d *Daemon) touchActiveWorkload(ctx context.Context, threadID string) (bool, error) {
+	if !d.processing.Load() {
+		return false, nil
+	}
 	workload, ok, err := d.findActiveWorkload(ctx, threadID)
 	if err != nil {
 		return false, err

--- a/internal/daemon/keepalive_test.go
+++ b/internal/daemon/keepalive_test.go
@@ -101,6 +101,7 @@ func TestTouchActiveWorkloadCallsTouch(t *testing.T) {
 		cfg:     config.Config{AgentID: uuid.MustParse(testAgentID)},
 		runners: fake,
 	}
+	daemon.processing.Store(true)
 	touched, err := daemon.touchActiveWorkload(context.Background(), "thread-1")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
@@ -109,6 +110,31 @@ func TestTouchActiveWorkloadCallsTouch(t *testing.T) {
 		t.Fatal("expected workload to be touched")
 	}
 	if len(fake.touchCalls) != 1 || fake.touchCalls[0] != workload.ID {
+		t.Fatalf("unexpected touch calls: %v", fake.touchCalls)
+	}
+}
+
+func TestTouchActiveWorkloadSkipsWhenIdle(t *testing.T) {
+	base := time.Date(2024, 7, 1, 12, 0, 0, 0, time.UTC)
+	workload := platform.Workload{
+		ID:        "workload-1",
+		AgentID:   testAgentID,
+		Status:    runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
+		CreatedAt: base,
+	}
+	fake := &fakeRunnersClient{listResponses: []listResponse{{workloads: []platform.Workload{workload}}}}
+	daemon := &Daemon{
+		cfg:     config.Config{AgentID: uuid.MustParse(testAgentID)},
+		runners: fake,
+	}
+	touched, err := daemon.touchActiveWorkload(context.Background(), "thread-1")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if touched {
+		t.Fatal("expected no workload to be touched")
+	}
+	if len(fake.touchCalls) != 0 {
 		t.Fatalf("unexpected touch calls: %v", fake.touchCalls)
 	}
 }
@@ -128,6 +154,7 @@ func TestTouchActiveWorkloadSkipsNonRunning(t *testing.T) {
 		cfg:     config.Config{AgentID: uuid.MustParse(testAgentID)},
 		runners: fake,
 	}
+	daemon.processing.Store(true)
 	touched, err := daemon.touchActiveWorkload(context.Background(), "thread-1")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)


### PR DESCRIPTION
## Summary
- add processing state to gate workload keepalive touches
- skip touching workloads when the daemon is idle
- add tests covering processing vs idle keepalive behavior

## Testing
- buf generate buf.build/agynio/api --path agynio/api/gateway/v1 --include-imports
- go test ./...
- go vet ./...

Closes #97