### PR TITLE
feat: update agynd startup preparation

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,12 +31,14 @@ type Config struct {
 	GatewayAddress string
 	TracingAddress string
 	ThreadID       string
+	WorkloadID     string
 	LLMBaseURL     string
 	LLMAPIToken    string
 	SDK            string
 	AgentBinary    string
 	WorkDir        string
 	MCPServers     []MCPServer
+	MCPPort        *int
 }
 
 func FromEnv() (Config, error) {
@@ -62,6 +64,12 @@ func fromEnv(configPath string) (Config, error) {
 		return Config{}, err
 	}
 	threadID = threadUUID.String()
+	workloadID := strings.TrimSpace(os.Getenv("WORKLOAD_ID"))
+	workloadUUID, err := uuidutil.ParseUUID(workloadID, "WORKLOAD_ID")
+	if err != nil {
+		return Config{}, err
+	}
+	workloadID = workloadUUID.String()
 	llmBaseURL := strings.TrimSpace(os.Getenv("LLM_BASE_URL"))
 	if llmBaseURL == "" {
 		llmBaseURL = "http://llm-proxy.ziti:443/v1"
@@ -72,6 +80,10 @@ func fromEnv(configPath string) (Config, error) {
 	}
 
 	mcpServers, err := parseMCPServers(os.Getenv("AGENT_MCP_SERVERS"))
+	if err != nil {
+		return Config{}, err
+	}
+	mcpPort, err := parseMCPPort(os.Getenv("MCP_PORT"))
 	if err != nil {
 		return Config{}, err
 	}
@@ -99,12 +111,14 @@ func fromEnv(configPath string) (Config, error) {
 		GatewayAddress: gatewayAddress,
 		TracingAddress: tracingAddress,
 		ThreadID:       threadID,
+		WorkloadID:     workloadID,
 		LLMBaseURL:     llmBaseURL,
 		LLMAPIToken:    llmAPIToken,
 		SDK:            sdk,
 		AgentBinary:    agentBinary,
 		WorkDir:        workDir,
 		MCPServers:     mcpServers,
+		MCPPort:        mcpPort,
 	}, nil
 }
 
@@ -154,4 +168,16 @@ func parseMCPServers(raw string) ([]MCPServer, error) {
 		servers = append(servers, MCPServer{Name: name, Port: port})
 	}
 	return servers, nil
+}
+
+func parseMCPPort(raw string) (*int, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return nil, nil
+	}
+	port, err := strconv.Atoi(value)
+	if err != nil || port <= 0 || port > 65535 {
+		return nil, fmt.Errorf("MCP_PORT has invalid port %q", value)
+	}
+	return &port, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9,14 +9,17 @@ import (
 )
 
 const (
-	validAgentID  = "550e8400-e29b-41d4-a716-446655440000"
-	validThreadID = "3f7fd7e3-5c6c-4a1e-8f4e-69c0030d3ed7"
+	validAgentID    = "550e8400-e29b-41d4-a716-446655440000"
+	validThreadID   = "3f7fd7e3-5c6c-4a1e-8f4e-69c0030d3ed7"
+	validWorkloadID = "7e5dc613-7822-4f48-9f55-6ce6d72a0a2e"
 )
 
 func setRequiredEnv(t *testing.T) {
 	t.Helper()
 	t.Setenv("AGENT_ID", validAgentID)
 	t.Setenv("THREAD_ID", validThreadID)
+	t.Setenv("WORKLOAD_ID", validWorkloadID)
+	t.Setenv("MCP_PORT", "")
 }
 
 func writeAgentConfig(t *testing.T, sdk, bin string) string {
@@ -61,6 +64,9 @@ func TestFromEnvValid(t *testing.T) {
 	if cfg.ThreadID != "9d06fe19-695b-48ac-83ba-2cd82472f7c8" {
 		t.Fatalf("unexpected thread id: %s", cfg.ThreadID)
 	}
+	if cfg.WorkloadID != validWorkloadID {
+		t.Fatalf("unexpected workload id: %s", cfg.WorkloadID)
+	}
 	if cfg.LLMBaseURL != "https://llm.example" {
 		t.Fatalf("unexpected LLM base URL: %s", cfg.LLMBaseURL)
 	}
@@ -75,6 +81,9 @@ func TestFromEnvValid(t *testing.T) {
 	}
 	if cfg.WorkDir != "/tmp/workdir" {
 		t.Fatalf("unexpected work dir: %s", cfg.WorkDir)
+	}
+	if cfg.MCPPort != nil {
+		t.Fatalf("expected no MCP port, got %v", *cfg.MCPPort)
 	}
 }
 
@@ -100,6 +109,7 @@ func TestFromEnvMissingRequired(t *testing.T) {
 	}{
 		{name: "agent-id", missing: "AGENT_ID", expected: "AGENT_ID"},
 		{name: "thread-id", missing: "THREAD_ID", expected: "THREAD_ID"},
+		{name: "workload-id", missing: "WORKLOAD_ID", expected: "WORKLOAD_ID"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -187,6 +197,48 @@ func TestFromEnvThreadID(t *testing.T) {
 	}
 }
 
+func TestFromEnvWorkloadID(t *testing.T) {
+	setRequiredEnv(t)
+	configPath := writeAgentConfig(t, "codex", "/opt/bin/codex")
+	t.Setenv("WORKLOAD_ID", "  94F0F199-7F3A-4B7C-9B2E-9E8C4200BA87 ")
+
+	cfg, err := fromEnv(configPath)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if cfg.WorkloadID != "94f0f199-7f3a-4b7c-9b2e-9e8c4200ba87" {
+		t.Fatalf("unexpected workload id: %q", cfg.WorkloadID)
+	}
+}
+
+func TestFromEnvWorkloadIDEmpty(t *testing.T) {
+	setRequiredEnv(t)
+	configPath := writeAgentConfig(t, "codex", "/opt/bin/codex")
+	t.Setenv("WORKLOAD_ID", "")
+
+	_, err := fromEnv(configPath)
+	if err == nil {
+		t.Fatal("expected error for missing WORKLOAD_ID")
+	}
+	if !strings.Contains(err.Error(), "WORKLOAD_ID") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestFromEnvWorkloadIDInvalid(t *testing.T) {
+	setRequiredEnv(t)
+	configPath := writeAgentConfig(t, "codex", "/opt/bin/codex")
+	t.Setenv("WORKLOAD_ID", "not-a-uuid")
+
+	_, err := fromEnv(configPath)
+	if err == nil {
+		t.Fatal("expected error for invalid WORKLOAD_ID")
+	}
+	if !strings.Contains(err.Error(), "WORKLOAD_ID") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestFromEnvThreadIDEmpty(t *testing.T) {
 	setRequiredEnv(t)
 	configPath := writeAgentConfig(t, "codex", "/opt/bin/codex")
@@ -240,6 +292,21 @@ func TestFromEnvMCPServersEmpty(t *testing.T) {
 	}
 	if cfg.MCPServers != nil {
 		t.Fatalf("expected nil MCP servers, got %#v", cfg.MCPServers)
+	}
+}
+
+func TestFromEnvMCPPort(t *testing.T) {
+	setRequiredEnv(t)
+	configPath := writeAgentConfig(t, "codex", "/opt/bin/codex")
+	t.Setenv("AGENT_MCP_SERVERS", "")
+	t.Setenv("MCP_PORT", "8123")
+
+	cfg, err := fromEnv(configPath)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if cfg.MCPPort == nil || *cfg.MCPPort != 8123 {
+		t.Fatalf("unexpected MCP port: %#v", cfg.MCPPort)
 	}
 }
 
@@ -308,6 +375,20 @@ func TestFromEnvMCPServersMalformed(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 		})
+	}
+}
+
+func TestFromEnvMCPPortInvalid(t *testing.T) {
+	setRequiredEnv(t)
+	configPath := writeAgentConfig(t, "codex", "/opt/bin/codex")
+	t.Setenv("MCP_PORT", "70000")
+
+	_, err := fromEnv(configPath)
+	if err == nil {
+		t.Fatal("expected error for invalid MCP_PORT")
+	}
+	if !strings.Contains(err.Error(), "MCP_PORT") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/daemon/agn.go
+++ b/internal/daemon/agn.go
@@ -16,12 +16,13 @@ func newAgnDaemon(ctx context.Context, cfg config.Config, version string) (*Daem
 	// version is unused: the agn SDK has no client-info metadata.
 	_ = version
 
-	setup, err := connectPlatform(ctx, cfg)
+	setup, updatedCfg, err := connectPlatform(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
+	cfg = updatedCfg
 
-	if err := runInitScripts(ctx, setup.agents, cfg.AgentID.String(), cfg.WorkDir); err != nil {
+	if _, err := writeSkills(cfg.SDK, setup.skills); err != nil {
 		_ = setup.gatewayConn.Close()
 		return nil, err
 	}
@@ -31,15 +32,22 @@ func newAgnDaemon(ctx context.Context, cfg config.Config, version string) (*Daem
 		_ = setup.gatewayConn.Close()
 		return nil, err
 	}
+	systemPrompt := buildSystemPrompt(setup.agent.GetRole(), setup.skills)
 
 	_, configPath, err := writeAgnConfig(
 		cfg.LLMBaseURL,
 		cfg.LLMAPIToken,
 		setup.agent.GetModel(),
+		systemPrompt,
 		summarization,
 		cfg.MCPServers,
 	)
 	if err != nil {
+		_ = setup.gatewayConn.Close()
+		return nil, err
+	}
+
+	if err := runInitScripts(ctx, setup.agents, cfg.AgentID.String(), cfg.WorkDir); err != nil {
 		_ = setup.gatewayConn.Close()
 		return nil, err
 	}
@@ -52,6 +60,7 @@ func newAgnDaemon(ctx context.Context, cfg config.Config, version string) (*Daem
 	tracingProxy, err := tracingproxy.Start(ctx, tracingproxy.Config{
 		TracingAddress: cfg.TracingAddress,
 		ThreadID:       cfg.ThreadID,
+		WorkloadID:     cfg.WorkloadID,
 	})
 	if err != nil {
 		_ = setup.gatewayConn.Close()

--- a/internal/daemon/agnconfig.go
+++ b/internal/daemon/agnconfig.go
@@ -16,7 +16,7 @@ const agnConfigTemplate = `llm:
   model: %s
 `
 
-func writeAgnConfig(llmBaseURL, apiKey, model string, summarization *summarizationConfig, mcpServers []config.MCPServer) (string, string, error) {
+func writeAgnConfig(llmBaseURL, apiKey, model, systemPrompt string, summarization *summarizationConfig, mcpServers []config.MCPServer) (string, string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", "", fmt.Errorf("resolve home directory: %w", err)
@@ -26,16 +26,17 @@ func writeAgnConfig(llmBaseURL, apiKey, model string, summarization *summarizati
 		return "", "", fmt.Errorf("create agn config dir: %w", err)
 	}
 	configPath := filepath.Join(agnDir, "config.yaml")
-	payload := agnConfig(llmBaseURL, apiKey, model, summarization, mcpServers)
+	payload := agnConfig(llmBaseURL, apiKey, model, systemPrompt, summarization, mcpServers)
 	if err := os.WriteFile(configPath, []byte(payload), 0o600); err != nil {
 		return "", "", fmt.Errorf("write agn config: %w", err)
 	}
 	return agnDir, configPath, nil
 }
 
-func agnConfig(llmBaseURL, apiKey, model string, summarization *summarizationConfig, mcpServers []config.MCPServer) string {
+func agnConfig(llmBaseURL, apiKey, model, systemPrompt string, summarization *summarizationConfig, mcpServers []config.MCPServer) string {
 	payload := fmt.Sprintf(agnConfigTemplate, llmBaseURL, apiKey, model)
-	if summarization == nil && len(mcpServers) == 0 {
+	cleanPrompt := strings.TrimSpace(systemPrompt)
+	if summarization == nil && len(mcpServers) == 0 && cleanPrompt == "" {
 		return payload
 	}
 	var builder strings.Builder
@@ -49,6 +50,9 @@ func agnConfig(llmBaseURL, apiKey, model string, summarization *summarizationCon
 			url := fmt.Sprintf("http://localhost:%d/mcp", server.Port)
 			fmt.Fprintf(&builder, "    %s:\n      url: %s\n", server.Name, url)
 		}
+	}
+	if cleanPrompt != "" {
+		appendSystemPrompt(&builder, cleanPrompt)
 	}
 	return builder.String()
 }
@@ -74,4 +78,11 @@ func appendSummarizationConfig(builder *strings.Builder, summarization *summariz
 		fmt.Fprintf(builder, "      api_key_env: %s\n", summarization.LLM.Auth.APIKeyEnv)
 	}
 	fmt.Fprintf(builder, "    model: %s\n", summarization.LLM.Model)
+}
+
+func appendSystemPrompt(builder *strings.Builder, prompt string) {
+	builder.WriteString("system_prompt: |\n")
+	for _, line := range strings.Split(prompt, "\n") {
+		fmt.Fprintf(builder, "  %s\n", line)
+	}
 }

--- a/internal/daemon/agnconfig_test.go
+++ b/internal/daemon/agnconfig_test.go
@@ -16,7 +16,7 @@ func TestWriteAgnConfig(t *testing.T) {
 	baseURL := "https://example.com"
 	apiKey := "test-api-key"
 	model := "test-model-id"
-	agnDir, configPath, err := writeAgnConfig(baseURL, apiKey, model, nil, nil)
+	agnDir, configPath, err := writeAgnConfig(baseURL, apiKey, model, "", nil, nil)
 	if err != nil {
 		t.Fatalf("expected config to be written, got %v", err)
 	}
@@ -56,7 +56,7 @@ func TestAgnConfigNoSummarizationInJSON(t *testing.T) {
 		t.Fatalf("expected nil summarization, got %#v", summarization)
 	}
 
-	content := agnConfig(baseURL, apiKey, model, summarization, nil)
+	content := agnConfig(baseURL, apiKey, model, "", summarization, nil)
 	expected := fmt.Sprintf(agnConfigTemplate, baseURL, apiKey, model)
 	if content != expected {
 		t.Fatalf("expected config %q, got %q", expected, content)
@@ -74,7 +74,7 @@ func TestWriteAgnConfigWithMCPServers(t *testing.T) {
 		{Name: "memory", Port: 8100},
 		{Name: "filesystem", Port: 8200},
 	}
-	agnDir, configPath, err := writeAgnConfig(baseURL, apiKey, model, nil, mcpServers)
+	agnDir, configPath, err := writeAgnConfig(baseURL, apiKey, model, "", nil, mcpServers)
 	if err != nil {
 		t.Fatalf("expected config to be written, got %v", err)
 	}
@@ -116,7 +116,7 @@ func TestWriteAgnConfigWithSummarizationThresholds(t *testing.T) {
 		KeepTokens: &keepTokens,
 		MaxTokens:  &maxTokens,
 	}
-	_, configPath, err := writeAgnConfig(baseURL, apiKey, model, summarization, nil)
+	_, configPath, err := writeAgnConfig(baseURL, apiKey, model, "", summarization, nil)
 	if err != nil {
 		t.Fatalf("expected config to be written, got %v", err)
 	}
@@ -155,7 +155,7 @@ func TestWriteAgnConfigWithSummarizationLLMAPIKey(t *testing.T) {
 			Model: "gpt-4.1-mini",
 		},
 	}
-	agnDir, configPath, err := writeAgnConfig(baseURL, apiKey, model, summarization, nil)
+	agnDir, configPath, err := writeAgnConfig(baseURL, apiKey, model, "", summarization, nil)
 	if err != nil {
 		t.Fatalf("expected config to be written, got %v", err)
 	}
@@ -209,7 +209,7 @@ func TestWriteAgnConfigWithSummarizationLLMAPIKeyEnv(t *testing.T) {
 			Model: "gpt-4.1-mini",
 		},
 	}
-	_, configPath, err := writeAgnConfig(baseURL, apiKey, model, summarization, nil)
+	_, configPath, err := writeAgnConfig(baseURL, apiKey, model, "", summarization, nil)
 	if err != nil {
 		t.Fatalf("expected config to be written, got %v", err)
 	}
@@ -228,6 +228,33 @@ func TestWriteAgnConfigWithSummarizationLLMAPIKeyEnv(t *testing.T) {
 		"    auth:\n" +
 		"      api_key_env: SUMMARIZE_KEY\n" +
 		"    model: gpt-4.1-mini\n"
+	if string(content) != expected {
+		t.Fatalf("expected config %q, got %q", expected, string(content))
+	}
+}
+
+func TestWriteAgnConfigWithSystemPrompt(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	baseURL := "https://example.com"
+	apiKey := "test-api-key"
+	model := "test-model-id"
+	systemPrompt := "You are a helpful agent.\nFollow the guidelines."
+	_, configPath, err := writeAgnConfig(baseURL, apiKey, model, systemPrompt, nil, nil)
+	if err != nil {
+		t.Fatalf("expected config to be written, got %v", err)
+	}
+
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("expected config to be readable, got %v", err)
+	}
+
+	expected := fmt.Sprintf(agnConfigTemplate, baseURL, apiKey, model) +
+		"system_prompt: |\n" +
+		"  You are a helpful agent.\n" +
+		"  Follow the guidelines.\n"
 	if string(content) != expected {
 		t.Fatalf("expected config %q, got %q", expected, string(content))
 	}

--- a/internal/daemon/claude.go
+++ b/internal/daemon/claude.go
@@ -16,12 +16,13 @@ func newClaudeDaemon(ctx context.Context, cfg config.Config, version string) (*D
 	// version is unused: the Claude SDK has no client-info metadata.
 	_ = version
 
-	setup, err := connectPlatform(ctx, cfg)
+	setup, updatedCfg, err := connectPlatform(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
+	cfg = updatedCfg
 
-	if err := runInitScripts(ctx, setup.agents, cfg.AgentID.String(), cfg.WorkDir); err != nil {
+	if _, err := writeSkills(cfg.SDK, setup.skills); err != nil {
 		_ = setup.gatewayConn.Close()
 		return nil, err
 	}
@@ -31,9 +32,15 @@ func newClaudeDaemon(ctx context.Context, cfg config.Config, version string) (*D
 		return nil, err
 	}
 
+	if err := runInitScripts(ctx, setup.agents, cfg.AgentID.String(), cfg.WorkDir); err != nil {
+		_ = setup.gatewayConn.Close()
+		return nil, err
+	}
+
 	tracingProxy, err := tracingproxy.Start(ctx, tracingproxy.Config{
 		TracingAddress: cfg.TracingAddress,
 		ThreadID:       cfg.ThreadID,
+		WorkloadID:     cfg.WorkloadID,
 	})
 	if err != nil {
 		_ = setup.gatewayConn.Close()

--- a/internal/daemon/claude_test.go
+++ b/internal/daemon/claude_test.go
@@ -71,6 +71,14 @@ func (f *fakeClaudeThreadsClient) GetThreads(ctx context.Context, in *threadsv1.
 	return nil, fmt.Errorf("GetThreads not implemented")
 }
 
+func (f *fakeClaudeThreadsClient) GetOrganizationThreads(ctx context.Context, in *threadsv1.GetOrganizationThreadsRequest, opts ...grpc.CallOption) (*threadsv1.GetOrganizationThreadsResponse, error) {
+	return nil, fmt.Errorf("GetOrganizationThreads not implemented")
+}
+
+func (f *fakeClaudeThreadsClient) GetThread(ctx context.Context, in *threadsv1.GetThreadRequest, opts ...grpc.CallOption) (*threadsv1.GetThreadResponse, error) {
+	return nil, fmt.Errorf("GetThread not implemented")
+}
+
 func (f *fakeClaudeThreadsClient) GetMessages(ctx context.Context, in *threadsv1.GetMessagesRequest, opts ...grpc.CallOption) (*threadsv1.GetMessagesResponse, error) {
 	return nil, fmt.Errorf("GetMessages not implemented")
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -80,7 +80,6 @@ type claudeClient interface {
 }
 
 type runnersClient interface {
-	ListWorkloadsByThread(ctx context.Context, threadID string, pageSize int32, pageToken string) ([]platform.Workload, string, error)
 	TouchWorkload(ctx context.Context, workloadID string) error
 }
 
@@ -91,6 +90,7 @@ type platformSetup struct {
 	agents        gatewayv1.AgentsGatewayClient
 	runners       *platform.Runners
 	agent         *agentsv1.Agent
+	skills        []skill
 }
 
 func New(ctx context.Context, cfg config.Config, version string) (*Daemon, error) {
@@ -106,7 +106,7 @@ func New(ctx context.Context, cfg config.Config, version string) (*Daemon, error
 	}
 }
 
-func connectPlatform(ctx context.Context, cfg config.Config) (*platformSetup, error) {
+func connectPlatform(ctx context.Context, cfg config.Config) (*platformSetup, config.Config, error) {
 	backoff := []time.Duration{
 		1 * time.Second,
 		1 * time.Second,
@@ -123,11 +123,11 @@ func connectPlatform(ctx context.Context, cfg config.Config) (*platformSetup, er
 	var lastErr error
 	for i, delay := range backoff {
 		if err := ctx.Err(); err != nil {
-			return nil, err
+			return nil, config.Config{}, err
 		}
-		setup, err := tryConnectPlatform(ctx, cfg)
+		setup, updatedCfg, err := tryConnectPlatform(ctx, cfg)
 		if err == nil {
-			return setup, nil
+			return setup, updatedCfg, nil
 		}
 		lastErr = err
 		log.Printf(
@@ -139,29 +139,29 @@ func connectPlatform(ctx context.Context, cfg config.Config) (*platformSetup, er
 		)
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, config.Config{}, ctx.Err()
 		case <-time.After(delay):
 		}
 	}
 	if err := ctx.Err(); err != nil {
-		return nil, err
+		return nil, config.Config{}, err
 	}
-	setup, err := tryConnectPlatform(ctx, cfg)
+	setup, updatedCfg, err := tryConnectPlatform(ctx, cfg)
 	if err != nil {
-		return nil, fmt.Errorf(
+		return nil, config.Config{}, fmt.Errorf(
 			"platform connect failed after %d attempts: %w (previous: %v)",
 			len(backoff)+1,
 			err,
 			lastErr,
 		)
 	}
-	return setup, nil
+	return setup, updatedCfg, nil
 }
 
-func tryConnectPlatform(ctx context.Context, cfg config.Config) (*platformSetup, error) {
+func tryConnectPlatform(ctx context.Context, cfg config.Config) (*platformSetup, config.Config, error) {
 	gatewayConn, err := platform.DialGateway(cfg.GatewayAddress)
 	if err != nil {
-		return nil, fmt.Errorf("dial gateway: %w", err)
+		return nil, config.Config{}, fmt.Errorf("dial gateway: %w", err)
 	}
 
 	threadsGateway := gatewayv1.NewThreadsGatewayClient(gatewayConn)
@@ -176,13 +176,34 @@ func tryConnectPlatform(ctx context.Context, cfg config.Config) (*platformSetup,
 	agentResp, err := agentsClient.GetAgent(ctx, &agentsv1.GetAgentRequest{Id: cfg.AgentID.String()})
 	if err != nil {
 		_ = gatewayConn.Close()
-		return nil, fmt.Errorf("get agent: %w", err)
+		return nil, config.Config{}, fmt.Errorf("get agent: %w", err)
 	}
 	agent := agentResp.GetAgent()
 	if agent == nil {
 		_ = gatewayConn.Close()
-		return nil, fmt.Errorf("agent not found")
+		return nil, config.Config{}, fmt.Errorf("agent not found")
 	}
+
+	skills, err := listSkills(ctx, agentsClient, cfg.AgentID.String())
+	if err != nil {
+		_ = gatewayConn.Close()
+		return nil, config.Config{}, fmt.Errorf("list skills: %w", err)
+	}
+
+	mcpDefinitions, err := listMCPs(ctx, agentsClient, cfg.AgentID.String())
+	if err != nil {
+		_ = gatewayConn.Close()
+		return nil, config.Config{}, fmt.Errorf("list MCPs: %w", err)
+	}
+
+	resolvedMCPs, err := resolveMCPServers(mcpDefinitions, cfg.MCPServers, cfg.MCPPort)
+	if err != nil {
+		_ = gatewayConn.Close()
+		return nil, config.Config{}, err
+	}
+	updatedCfg := cfg
+	updatedCfg.MCPServers = resolvedMCPs
+	updatedCfg.MCPPort = nil
 
 	return &platformSetup{
 		gatewayConn:   gatewayConn,
@@ -191,16 +212,18 @@ func tryConnectPlatform(ctx context.Context, cfg config.Config) (*platformSetup,
 		agents:        agentsClient,
 		runners:       runnersClient,
 		agent:         agent,
-	}, nil
+		skills:        skills,
+	}, updatedCfg, nil
 }
 
 func newCodexDaemon(ctx context.Context, cfg config.Config, version string) (*Daemon, error) {
-	setup, err := connectPlatform(ctx, cfg)
+	setup, updatedCfg, err := connectPlatform(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
+	cfg = updatedCfg
 
-	if err := runInitScripts(ctx, setup.agents, cfg.AgentID.String(), cfg.WorkDir); err != nil {
+	if _, err := writeSkills(cfg.SDK, setup.skills); err != nil {
 		_ = setup.gatewayConn.Close()
 		return nil, err
 	}
@@ -210,6 +233,11 @@ func newCodexDaemon(ctx context.Context, cfg config.Config, version string) (*Da
 	threadsMapping := codexbridge.NewThreadMapping()
 	codexHome, err := writeCodexConfig(cfg.LLMBaseURL, cfg.MCPServers)
 	if err != nil {
+		_ = setup.gatewayConn.Close()
+		return nil, err
+	}
+
+	if err := runInitScripts(ctx, setup.agents, cfg.AgentID.String(), cfg.WorkDir); err != nil {
 		_ = setup.gatewayConn.Close()
 		return nil, err
 	}
@@ -223,6 +251,7 @@ func newCodexDaemon(ctx context.Context, cfg config.Config, version string) (*Da
 	tracingProxy, err := tracingproxy.Start(ctx, tracingproxy.Config{
 		TracingAddress: cfg.TracingAddress,
 		ThreadID:       cfg.ThreadID,
+		WorkloadID:     cfg.WorkloadID,
 	})
 	if err != nil {
 		_ = setup.gatewayConn.Close()

--- a/internal/daemon/keepalive.go
+++ b/internal/daemon/keepalive.go
@@ -15,6 +15,7 @@ const (
 func (d *Daemon) runKeepalive(ctx context.Context) {
 	workloadID := strings.TrimSpace(d.cfg.WorkloadID)
 	if workloadID == "" {
+		log.Printf("workload keepalive disabled: missing WORKLOAD_ID")
 		return
 	}
 

--- a/internal/daemon/keepalive.go
+++ b/internal/daemon/keepalive.go
@@ -5,24 +5,20 @@ import (
 	"log"
 	"strings"
 	"time"
-
-	runnersv1 "github.com/agynio/agynd-cli/.gen/go/agynio/api/runners/v1"
-	"github.com/agynio/agynd-cli/internal/platform"
 )
 
 const (
 	workloadKeepaliveInterval = 10 * time.Second
 	workloadKeepaliveTimeout  = 5 * time.Second
-	workloadListTimeout       = 5 * time.Second
 )
 
 func (d *Daemon) runKeepalive(ctx context.Context) {
-	threadID := strings.TrimSpace(d.cfg.ThreadID)
-	if threadID == "" {
+	workloadID := strings.TrimSpace(d.cfg.WorkloadID)
+	if workloadID == "" {
 		return
 	}
 
-	if _, err := d.touchActiveWorkload(ctx, threadID); err != nil && ctx.Err() == nil {
+	if _, err := d.touchActiveWorkload(ctx, workloadID); err != nil && ctx.Err() == nil {
 		log.Printf("workload keepalive failed: %v", err)
 	}
 
@@ -33,66 +29,26 @@ func (d *Daemon) runKeepalive(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			if _, err := d.touchActiveWorkload(ctx, threadID); err != nil && ctx.Err() == nil {
+			if _, err := d.touchActiveWorkload(ctx, workloadID); err != nil && ctx.Err() == nil {
 				log.Printf("workload keepalive failed: %v", err)
 			}
 		}
 	}
 }
 
-func (d *Daemon) touchActiveWorkload(ctx context.Context, threadID string) (bool, error) {
+func (d *Daemon) touchActiveWorkload(ctx context.Context, workloadID string) (bool, error) {
 	if !d.processing.Load() {
 		return false, nil
 	}
-	workload, ok, err := d.findActiveWorkload(ctx, threadID)
-	if err != nil {
-		return false, err
-	}
-	if !ok {
+	workloadID = strings.TrimSpace(workloadID)
+	if workloadID == "" {
 		return false, nil
 	}
 	touchCtx, cancel := context.WithTimeout(ctx, workloadKeepaliveTimeout)
-	err = d.runners.TouchWorkload(touchCtx, workload.ID)
+	err := d.runners.TouchWorkload(touchCtx, workloadID)
 	cancel()
 	if err != nil {
 		return false, err
 	}
 	return true, nil
-}
-
-func (d *Daemon) findActiveWorkload(ctx context.Context, threadID string) (platform.Workload, bool, error) {
-	pageToken := ""
-	var selected platform.Workload
-	found := false
-	for {
-		listCtx, cancel := context.WithTimeout(ctx, workloadListTimeout)
-		workloads, nextToken, err := d.runners.ListWorkloadsByThread(listCtx, threadID, pageSize, pageToken)
-		cancel()
-		if err != nil {
-			return platform.Workload{}, false, err
-		}
-		for _, workload := range workloads {
-			if workload.AgentID != d.cfg.AgentID.String() {
-				continue
-			}
-			if workload.Status != runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING {
-				continue
-			}
-			if workload.RemovedAt != nil {
-				continue
-			}
-			if !found || workload.CreatedAt.After(selected.CreatedAt) {
-				selected = workload
-				found = true
-			}
-		}
-		if nextToken == "" {
-			break
-		}
-		pageToken = nextToken
-	}
-	if !found {
-		return platform.Workload{}, false, nil
-	}
-	return selected, true, nil
 }

--- a/internal/daemon/keepalive_test.go
+++ b/internal/daemon/keepalive_test.go
@@ -2,42 +2,14 @@ package daemon
 
 import (
 	"context"
-	"fmt"
 	"testing"
-	"time"
 
-	runnersv1 "github.com/agynio/agynd-cli/.gen/go/agynio/api/runners/v1"
 	"github.com/agynio/agynd-cli/internal/config"
-	"github.com/agynio/agynd-cli/internal/platform"
 	"github.com/google/uuid"
 )
 
-type listResponse struct {
-	workloads []platform.Workload
-	nextToken string
-	err       error
-}
-
 type fakeRunnersClient struct {
-	listResponses []listResponse
-	listCalls     int
-	listTokens    []string
-	listThreads   []string
-	listSizes     []int32
-
 	touchCalls []string
-}
-
-func (f *fakeRunnersClient) ListWorkloadsByThread(_ context.Context, threadID string, pageSize int32, pageToken string) ([]platform.Workload, string, error) {
-	f.listCalls++
-	f.listThreads = append(f.listThreads, threadID)
-	f.listSizes = append(f.listSizes, pageSize)
-	f.listTokens = append(f.listTokens, pageToken)
-	if f.listCalls > len(f.listResponses) {
-		return nil, "", fmt.Errorf("unexpected list call")
-	}
-	resp := f.listResponses[f.listCalls-1]
-	return resp.workloads, resp.nextToken, resp.err
 }
 
 func (f *fakeRunnersClient) TouchWorkload(_ context.Context, workloadID string) error {
@@ -45,89 +17,32 @@ func (f *fakeRunnersClient) TouchWorkload(_ context.Context, workloadID string) 
 	return nil
 }
 
-func TestFindActiveWorkloadSelectsLatestRunning(t *testing.T) {
-	base := time.Date(2024, 7, 1, 12, 0, 0, 0, time.UTC)
-	first := platform.Workload{
-		ID:        "workload-1",
-		AgentID:   testAgentID,
-		Status:    runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
-		CreatedAt: base,
-	}
-	second := platform.Workload{
-		ID:        "workload-2",
-		AgentID:   testAgentID,
-		Status:    runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
-		CreatedAt: base.Add(5 * time.Minute),
-	}
-	other := platform.Workload{
-		ID:        "workload-3",
-		AgentID:   "other-agent",
-		Status:    runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
-		CreatedAt: base.Add(10 * time.Minute),
-	}
-	fake := &fakeRunnersClient{listResponses: []listResponse{
-		{workloads: []platform.Workload{first, other}, nextToken: "next"},
-		{workloads: []platform.Workload{second}, nextToken: ""},
-	}}
-	daemon := &Daemon{
-		cfg:     config.Config{AgentID: uuid.MustParse(testAgentID)},
-		runners: fake,
-	}
-	workload, ok, err := daemon.findActiveWorkload(context.Background(), "thread-1")
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if !ok {
-		t.Fatal("expected active workload")
-	}
-	if workload.ID != second.ID {
-		t.Fatalf("expected %q, got %q", second.ID, workload.ID)
-	}
-	if fake.listCalls != 2 {
-		t.Fatalf("expected 2 list calls, got %d", fake.listCalls)
-	}
-}
-
 func TestTouchActiveWorkloadCallsTouch(t *testing.T) {
-	base := time.Date(2024, 7, 1, 12, 0, 0, 0, time.UTC)
-	workload := platform.Workload{
-		ID:        "workload-1",
-		AgentID:   testAgentID,
-		Status:    runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
-		CreatedAt: base,
-	}
-	fake := &fakeRunnersClient{listResponses: []listResponse{{workloads: []platform.Workload{workload}}}}
+	fake := &fakeRunnersClient{}
 	daemon := &Daemon{
-		cfg:     config.Config{AgentID: uuid.MustParse(testAgentID)},
+		cfg:     config.Config{AgentID: uuid.MustParse(testAgentID), WorkloadID: "workload-1"},
 		runners: fake,
 	}
 	daemon.processing.Store(true)
-	touched, err := daemon.touchActiveWorkload(context.Background(), "thread-1")
+	touched, err := daemon.touchActiveWorkload(context.Background(), "workload-1")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if !touched {
 		t.Fatal("expected workload to be touched")
 	}
-	if len(fake.touchCalls) != 1 || fake.touchCalls[0] != workload.ID {
+	if len(fake.touchCalls) != 1 || fake.touchCalls[0] != "workload-1" {
 		t.Fatalf("unexpected touch calls: %v", fake.touchCalls)
 	}
 }
 
 func TestTouchActiveWorkloadSkipsWhenIdle(t *testing.T) {
-	base := time.Date(2024, 7, 1, 12, 0, 0, 0, time.UTC)
-	workload := platform.Workload{
-		ID:        "workload-1",
-		AgentID:   testAgentID,
-		Status:    runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
-		CreatedAt: base,
-	}
-	fake := &fakeRunnersClient{listResponses: []listResponse{{workloads: []platform.Workload{workload}}}}
+	fake := &fakeRunnersClient{}
 	daemon := &Daemon{
-		cfg:     config.Config{AgentID: uuid.MustParse(testAgentID)},
+		cfg:     config.Config{AgentID: uuid.MustParse(testAgentID), WorkloadID: "workload-1"},
 		runners: fake,
 	}
-	touched, err := daemon.touchActiveWorkload(context.Background(), "thread-1")
+	touched, err := daemon.touchActiveWorkload(context.Background(), "workload-1")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -138,24 +53,14 @@ func TestTouchActiveWorkloadSkipsWhenIdle(t *testing.T) {
 		t.Fatalf("unexpected touch calls: %v", fake.touchCalls)
 	}
 }
-
-func TestTouchActiveWorkloadSkipsNonRunning(t *testing.T) {
-	base := time.Date(2024, 7, 1, 12, 0, 0, 0, time.UTC)
-	removedAt := base.Add(1 * time.Hour)
-	workload := platform.Workload{
-		ID:        "workload-1",
-		AgentID:   testAgentID,
-		Status:    runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPED,
-		CreatedAt: base,
-		RemovedAt: &removedAt,
-	}
-	fake := &fakeRunnersClient{listResponses: []listResponse{{workloads: []platform.Workload{workload}}}}
+func TestTouchActiveWorkloadSkipsWhenMissingWorkloadID(t *testing.T) {
+	fake := &fakeRunnersClient{}
 	daemon := &Daemon{
-		cfg:     config.Config{AgentID: uuid.MustParse(testAgentID)},
+		cfg:     config.Config{AgentID: uuid.MustParse(testAgentID), WorkloadID: ""},
 		runners: fake,
 	}
 	daemon.processing.Store(true)
-	touched, err := daemon.touchActiveWorkload(context.Background(), "thread-1")
+	touched, err := daemon.touchActiveWorkload(context.Background(), "")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/internal/daemon/mcps.go
+++ b/internal/daemon/mcps.go
@@ -1,0 +1,141 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	agentsv1 "github.com/agynio/agynd-cli/.gen/go/agynio/api/agents/v1"
+	"github.com/agynio/agynd-cli/internal/config"
+	"google.golang.org/grpc"
+)
+
+const mcpsPageSize int32 = 100
+
+type mcpsClient interface {
+	ListMcps(ctx context.Context, in *agentsv1.ListMcpsRequest, opts ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error)
+}
+
+type mcpDefinition struct {
+	ID        string
+	Name      string
+	CreatedAt time.Time
+}
+
+func listMCPs(ctx context.Context, client mcpsClient, agentID string) ([]mcpDefinition, error) {
+	if client == nil {
+		return nil, fmt.Errorf("mcps client is required")
+	}
+	agentID = strings.TrimSpace(agentID)
+	if agentID == "" {
+		return nil, fmt.Errorf("agent id is required")
+	}
+	var mcps []mcpDefinition
+	pageToken := ""
+	for {
+		resp, err := client.ListMcps(ctx, &agentsv1.ListMcpsRequest{
+			AgentId:   agentID,
+			PageSize:  mcpsPageSize,
+			PageToken: pageToken,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, entry := range resp.GetMcps() {
+			parsed, err := mcpFromProto(entry)
+			if err != nil {
+				return nil, err
+			}
+			mcps = append(mcps, parsed)
+		}
+		pageToken = strings.TrimSpace(resp.GetNextPageToken())
+		if pageToken == "" {
+			break
+		}
+	}
+	sort.Slice(mcps, func(i, j int) bool {
+		if mcps[i].CreatedAt.Equal(mcps[j].CreatedAt) {
+			return mcps[i].ID < mcps[j].ID
+		}
+		return mcps[i].CreatedAt.Before(mcps[j].CreatedAt)
+	})
+	return mcps, nil
+}
+
+func mcpFromProto(entry *agentsv1.Mcp) (mcpDefinition, error) {
+	if entry == nil {
+		return mcpDefinition{}, fmt.Errorf("mcp is required")
+	}
+	meta := entry.GetMeta()
+	if meta == nil {
+		return mcpDefinition{}, fmt.Errorf("mcp meta is required")
+	}
+	id := strings.TrimSpace(meta.GetId())
+	if id == "" {
+		return mcpDefinition{}, fmt.Errorf("mcp id is required")
+	}
+	createdAt := meta.GetCreatedAt()
+	if createdAt == nil {
+		return mcpDefinition{}, fmt.Errorf("mcp created at is required")
+	}
+	name := strings.TrimSpace(entry.GetName())
+	if name == "" {
+		return mcpDefinition{}, fmt.Errorf("mcp name is required")
+	}
+	return mcpDefinition{
+		ID:        id,
+		Name:      name,
+		CreatedAt: createdAt.AsTime(),
+	}, nil
+}
+
+func resolveMCPServers(definitions []mcpDefinition, envServers []config.MCPServer, fallbackPort *int) ([]config.MCPServer, error) {
+	if len(definitions) == 0 {
+		if len(envServers) > 0 {
+			return nil, fmt.Errorf("AGENT_MCP_SERVERS provided but no MCPs configured")
+		}
+		if fallbackPort != nil {
+			return nil, fmt.Errorf("MCP_PORT provided but no MCPs configured")
+		}
+		return nil, nil
+	}
+	portByName := make(map[string]int, len(envServers))
+	for _, server := range envServers {
+		if server.Name == "" {
+			return nil, fmt.Errorf("MCP server name is required")
+		}
+		if _, ok := portByName[server.Name]; ok {
+			return nil, fmt.Errorf("duplicate MCP server name %q", server.Name)
+		}
+		portByName[server.Name] = server.Port
+	}
+	if len(portByName) == 0 {
+		if fallbackPort == nil {
+			return nil, fmt.Errorf("AGENT_MCP_SERVERS is required for %d MCPs", len(definitions))
+		}
+		if len(definitions) != 1 {
+			return nil, fmt.Errorf("MCP_PORT set but %d MCPs configured", len(definitions))
+		}
+		return []config.MCPServer{{Name: definitions[0].Name, Port: *fallbackPort}}, nil
+	}
+	seen := make(map[string]struct{}, len(definitions))
+	resolved := make([]config.MCPServer, 0, len(definitions))
+	for _, definition := range definitions {
+		port, ok := portByName[definition.Name]
+		if !ok {
+			return nil, fmt.Errorf("missing MCP port for %q", definition.Name)
+		}
+		seen[definition.Name] = struct{}{}
+		resolved = append(resolved, config.MCPServer{Name: definition.Name, Port: port})
+	}
+	if len(seen) != len(portByName) {
+		for name := range portByName {
+			if _, ok := seen[name]; !ok {
+				return nil, fmt.Errorf("AGENT_MCP_SERVERS has unknown MCP %q", name)
+			}
+		}
+	}
+	return resolved, nil
+}

--- a/internal/daemon/skills.go
+++ b/internal/daemon/skills.go
@@ -144,6 +144,9 @@ func validateSkillName(name string) error {
 	if name == "" {
 		return fmt.Errorf("skill name is required")
 	}
+	if name == "." || name == ".." {
+		return fmt.Errorf("skill name %q is not allowed", name)
+	}
 	if strings.Contains(name, "/") || strings.Contains(name, "\\") {
 		return fmt.Errorf("skill name %q contains path separator", name)
 	}

--- a/internal/daemon/skills.go
+++ b/internal/daemon/skills.go
@@ -1,0 +1,170 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	agentsv1 "github.com/agynio/agynd-cli/.gen/go/agynio/api/agents/v1"
+	"google.golang.org/grpc"
+)
+
+const skillsPageSize int32 = 100
+
+type skillsClient interface {
+	ListSkills(ctx context.Context, in *agentsv1.ListSkillsRequest, opts ...grpc.CallOption) (*agentsv1.ListSkillsResponse, error)
+}
+
+type skill struct {
+	ID        string
+	Name      string
+	Body      string
+	CreatedAt time.Time
+}
+
+func listSkills(ctx context.Context, client skillsClient, agentID string) ([]skill, error) {
+	if client == nil {
+		return nil, fmt.Errorf("skills client is required")
+	}
+	agentID = strings.TrimSpace(agentID)
+	if agentID == "" {
+		return nil, fmt.Errorf("agent id is required")
+	}
+	var skills []skill
+	pageToken := ""
+	for {
+		resp, err := client.ListSkills(ctx, &agentsv1.ListSkillsRequest{
+			AgentId:   agentID,
+			PageSize:  skillsPageSize,
+			PageToken: pageToken,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, entry := range resp.GetSkills() {
+			parsed, err := skillFromProto(entry)
+			if err != nil {
+				return nil, err
+			}
+			skills = append(skills, parsed)
+		}
+		pageToken = strings.TrimSpace(resp.GetNextPageToken())
+		if pageToken == "" {
+			break
+		}
+	}
+	sort.Slice(skills, func(i, j int) bool {
+		if skills[i].CreatedAt.Equal(skills[j].CreatedAt) {
+			return skills[i].ID < skills[j].ID
+		}
+		return skills[i].CreatedAt.Before(skills[j].CreatedAt)
+	})
+	return skills, nil
+}
+
+func skillFromProto(entry *agentsv1.Skill) (skill, error) {
+	if entry == nil {
+		return skill{}, fmt.Errorf("skill is required")
+	}
+	meta := entry.GetMeta()
+	if meta == nil {
+		return skill{}, fmt.Errorf("skill meta is required")
+	}
+	id := strings.TrimSpace(meta.GetId())
+	if id == "" {
+		return skill{}, fmt.Errorf("skill id is required")
+	}
+	createdAt := meta.GetCreatedAt()
+	if createdAt == nil {
+		return skill{}, fmt.Errorf("skill created at is required")
+	}
+	name := strings.TrimSpace(entry.GetName())
+	if err := validateSkillName(name); err != nil {
+		return skill{}, err
+	}
+	body := entry.GetBody()
+	if strings.TrimSpace(body) == "" {
+		return skill{}, fmt.Errorf("skill body is required")
+	}
+	return skill{
+		ID:        id,
+		Name:      name,
+		Body:      body,
+		CreatedAt: createdAt.AsTime(),
+	}, nil
+}
+
+func writeSkills(sdk string, skills []skill) (string, error) {
+	if len(skills) == 0 {
+		return "", nil
+	}
+	skillsDir, err := skillsDirForSDK(sdk)
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(skillsDir, 0o700); err != nil {
+		return "", fmt.Errorf("create skills dir: %w", err)
+	}
+	seen := make(map[string]struct{}, len(skills))
+	for _, entry := range skills {
+		if _, ok := seen[entry.Name]; ok {
+			return "", fmt.Errorf("duplicate skill name %q", entry.Name)
+		}
+		seen[entry.Name] = struct{}{}
+		path := filepath.Join(skillsDir, entry.Name)
+		if err := os.WriteFile(path, []byte(entry.Body), 0o600); err != nil {
+			return "", fmt.Errorf("write skill %s: %w", entry.Name, err)
+		}
+	}
+	return skillsDir, nil
+}
+
+func skillsDirForSDK(sdk string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory: %w", err)
+	}
+	switch sdk {
+	case SDKCodex:
+		return filepath.Join(home, ".codex", "skills"), nil
+	case SDKAgn:
+		return filepath.Join(home, ".agyn", "agn", "skills"), nil
+	case SDKClaude:
+		return filepath.Join(home, ".claude", "skills"), nil
+	default:
+		return "", fmt.Errorf("unknown sdk %q", sdk)
+	}
+}
+
+func validateSkillName(name string) error {
+	if name == "" {
+		return fmt.Errorf("skill name is required")
+	}
+	if strings.Contains(name, "/") || strings.Contains(name, "\\") {
+		return fmt.Errorf("skill name %q contains path separator", name)
+	}
+	return nil
+}
+
+func buildSystemPrompt(role string, skills []skill) string {
+	role = strings.TrimSpace(role)
+	if role == "" && len(skills) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(skills)+1)
+	if role != "" {
+		parts = append(parts, role)
+	}
+	for _, entry := range skills {
+		body := strings.TrimSpace(entry.Body)
+		if body == "" {
+			continue
+		}
+		parts = append(parts, body)
+	}
+	return strings.Join(parts, "\n\n")
+}

--- a/internal/daemon/skills_test.go
+++ b/internal/daemon/skills_test.go
@@ -1,0 +1,11 @@
+package daemon
+
+import "testing"
+
+func TestValidateSkillNameTraversal(t *testing.T) {
+	for _, name := range []string{".", ".."} {
+		if err := validateSkillName(name); err == nil {
+			t.Fatalf("expected error for skill name %q", name)
+		}
+	}
+}

--- a/internal/platform/consumer_test.go
+++ b/internal/platform/consumer_test.go
@@ -40,6 +40,14 @@ func (f *fakeThreadsClient) GetThreads(ctx context.Context, in *threadsv1.GetThr
 	return nil, fmt.Errorf("GetThreads not implemented")
 }
 
+func (f *fakeThreadsClient) GetOrganizationThreads(ctx context.Context, in *threadsv1.GetOrganizationThreadsRequest, opts ...grpc.CallOption) (*threadsv1.GetOrganizationThreadsResponse, error) {
+	return nil, fmt.Errorf("GetOrganizationThreads not implemented")
+}
+
+func (f *fakeThreadsClient) GetThread(ctx context.Context, in *threadsv1.GetThreadRequest, opts ...grpc.CallOption) (*threadsv1.GetThreadResponse, error) {
+	return nil, fmt.Errorf("GetThread not implemented")
+}
+
 func (f *fakeThreadsClient) GetMessages(ctx context.Context, in *threadsv1.GetMessagesRequest, opts ...grpc.CallOption) (*threadsv1.GetMessagesResponse, error) {
 	return nil, fmt.Errorf("GetMessages not implemented")
 }

--- a/internal/tracingproxy/proxy.go
+++ b/internal/tracingproxy/proxy.go
@@ -18,22 +18,25 @@ import (
 )
 
 const (
-	ListenAddress        = "localhost:4317"
-	threadIDAttributeKey = "agyn.thread.id"
+	ListenAddress          = "localhost:4317"
+	threadIDAttributeKey   = "agyn.thread.id"
+	workloadIDAttributeKey = "agyn.workload.id"
 )
 
 type Config struct {
 	TracingAddress string
 	ThreadID       string
+	WorkloadID     string
 }
 
 type Proxy struct {
 	collectortracev1.UnimplementedTraceServiceServer
 
-	server   *grpc.Server
-	upstream collectortracev1.TraceServiceClient
-	conn     *grpc.ClientConn
-	threadID string
+	server     *grpc.Server
+	upstream   collectortracev1.TraceServiceClient
+	conn       *grpc.ClientConn
+	threadID   string
+	workloadID string
 }
 
 func Start(ctx context.Context, cfg Config) (*Proxy, error) {
@@ -46,10 +49,11 @@ func Start(ctx context.Context, cfg Config) (*Proxy, error) {
 	}
 	server := grpc.NewServer()
 	proxy := &Proxy{
-		server:   server,
-		upstream: collectortracev1.NewTraceServiceClient(conn),
-		conn:     conn,
-		threadID: cfg.ThreadID,
+		server:     server,
+		upstream:   collectortracev1.NewTraceServiceClient(conn),
+		conn:       conn,
+		threadID:   cfg.ThreadID,
+		workloadID: cfg.WorkloadID,
 	}
 	collectortracev1.RegisterTraceServiceServer(server, proxy)
 
@@ -74,6 +78,9 @@ func (p *Proxy) Export(ctx context.Context, req *collectortracev1.ExportTraceSer
 	}
 	if p.threadID != "" {
 		injectThreadID(req, p.threadID)
+	}
+	if p.workloadID != "" {
+		injectWorkloadID(req, p.workloadID)
 	}
 	return p.upstream.Export(ctx, req)
 }
@@ -102,22 +109,36 @@ func injectThreadID(req *collectortracev1.ExportTraceServiceRequest, threadID st
 			resource = &resourcev1.Resource{}
 			spans.Resource = resource
 		}
-		upsertThreadID(resource, threadID)
+		upsertAttribute(resource, threadIDAttributeKey, threadID)
 	}
 }
 
-func upsertThreadID(resource *resourcev1.Resource, threadID string) {
-	value := &commonv1.AnyValue{
-		Value: &commonv1.AnyValue_StringValue{StringValue: threadID},
+func injectWorkloadID(req *collectortracev1.ExportTraceServiceRequest, workloadID string) {
+	for _, spans := range req.ResourceSpans {
+		if spans == nil {
+			continue
+		}
+		resource := spans.Resource
+		if resource == nil {
+			resource = &resourcev1.Resource{}
+			spans.Resource = resource
+		}
+		upsertAttribute(resource, workloadIDAttributeKey, workloadID)
+	}
+}
+
+func upsertAttribute(resource *resourcev1.Resource, key, value string) {
+	attributeValue := &commonv1.AnyValue{
+		Value: &commonv1.AnyValue_StringValue{StringValue: value},
 	}
 	for _, attribute := range resource.Attributes {
-		if attribute != nil && attribute.Key == threadIDAttributeKey {
-			attribute.Value = value
+		if attribute != nil && attribute.Key == key {
+			attribute.Value = attributeValue
 			return
 		}
 	}
 	resource.Attributes = append(resource.Attributes, &commonv1.KeyValue{
-		Key:   threadIDAttributeKey,
-		Value: value,
+		Key:   key,
+		Value: attributeValue,
 	})
 }

--- a/internal/tracingproxy/proxy_test.go
+++ b/internal/tracingproxy/proxy_test.go
@@ -51,6 +51,33 @@ func TestInjectThreadID(t *testing.T) {
 	}
 }
 
+func TestInjectWorkloadID(t *testing.T) {
+	req := &collectortracev1.ExportTraceServiceRequest{
+		ResourceSpans: []*tracev1.ResourceSpans{
+			{
+				Resource: &resourcev1.Resource{
+					Attributes: []*commonv1.KeyValue{
+						{Key: "existing", Value: stringValue("keep")},
+					},
+				},
+			},
+		},
+	}
+
+	injectWorkloadID(req, "workload-1")
+
+	resource := req.ResourceSpans[0].Resource
+	if value, ok := findAttribute(resource, "existing"); !ok || value.GetStringValue() != "keep" {
+		t.Fatalf("expected existing attribute preserved, got %v", value)
+	}
+	if value, ok := findAttribute(resource, workloadIDAttributeKey); !ok || value.GetStringValue() != "workload-1" {
+		t.Fatalf("expected workload id injected, got %v", value)
+	}
+	if len(resource.Attributes) != 2 {
+		t.Fatalf("expected 2 attributes, got %d", len(resource.Attributes))
+	}
+}
+
 func TestInjectThreadIDOverwritesExisting(t *testing.T) {
 	req := &collectortracev1.ExportTraceServiceRequest{
 		ResourceSpans: []*tracev1.ResourceSpans{
@@ -118,7 +145,7 @@ func TestProxyForwardsToUpstream(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	proxy, err := Start(ctx, Config{TracingAddress: listener.Addr().String(), ThreadID: "thread-4"})
+	proxy, err := Start(ctx, Config{TracingAddress: listener.Addr().String(), ThreadID: "thread-4", WorkloadID: "workload-4"})
 	if err != nil {
 		t.Fatalf("start proxy: %v", err)
 	}
@@ -147,6 +174,10 @@ func TestProxyForwardsToUpstream(t *testing.T) {
 	value, ok := findAttribute(forwarded.ResourceSpans[0].Resource, threadIDAttributeKey)
 	if !ok || value.GetStringValue() != "thread-4" {
 		t.Fatalf("expected forwarded request to include thread id, got %v", value)
+	}
+	value, ok = findAttribute(forwarded.ResourceSpans[0].Resource, workloadIDAttributeKey)
+	if !ok || value.GetStringValue() != "workload-4" {
+		t.Fatalf("expected forwarded request to include workload id, got %v", value)
 	}
 }
 
@@ -182,6 +213,9 @@ func TestProxyNoThreadIDPassthrough(t *testing.T) {
 	forwarded := awaitRequest(t, requests)
 	if _, ok := findAttribute(forwarded.ResourceSpans[0].Resource, threadIDAttributeKey); ok {
 		t.Fatal("expected no thread id injected")
+	}
+	if _, ok := findAttribute(forwarded.ResourceSpans[0].Resource, workloadIDAttributeKey); ok {
+		t.Fatal("expected no workload id injected")
 	}
 	value, ok := findAttribute(forwarded.ResourceSpans[0].Resource, "existing")
 	if !ok || value.GetStringValue() != "keep" {


### PR DESCRIPTION
## Summary
- fetch skills/MCPs on startup, resolve MCP mapping, and write skills to filesystem
- add WORKLOAD_ID handling for keepalive/tracing and remove workload listing
- extend agn config generation with system prompt and update tests/fakes

## Testing
- buf generate buf.build/agynio/api --path agynio/api/gateway/v1 --include-imports
- go vet ./...
- go test ./...

Refs: #136