### PR TITLE
fix(config): default tmp envs

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -103,7 +103,7 @@ func fromEnv(configPath string) (Config, error) {
 
 	workDir := strings.TrimSpace(os.Getenv("WORKSPACE_DIR"))
 	if workDir == "" {
-		workDir = "/workspace"
+		workDir = "/tmp"
 	}
 
 	return Config{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -137,7 +137,7 @@ func TestFromEnvDefaults(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if cfg.WorkDir != "/tmp" {
-		t.Fatalf("expected default workspace dir, got %s", cfg.WorkDir)
+		t.Fatalf("expected default workspace dir /tmp, got %s", cfg.WorkDir)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -136,7 +136,7 @@ func TestFromEnvDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if cfg.WorkDir != "/workspace" {
+	if cfg.WorkDir != "/tmp" {
 		t.Fatalf("expected default workspace dir, got %s", cfg.WorkDir)
 	}
 }

--- a/internal/daemon/codexconfig.go
+++ b/internal/daemon/codexconfig.go
@@ -21,11 +21,7 @@ wire_api = "responses"
 `
 
 func writeCodexConfig(llmBaseURL string, mcpServers []config.MCPServer) (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("resolve home directory: %w", err)
-	}
-	codexHome := filepath.Join(home, ".codex")
+	codexHome := filepath.Join(codexHomeEnv(), ".codex")
 	if err := os.MkdirAll(codexHome, 0o700); err != nil {
 		return "", fmt.Errorf("create codex home dir: %w", err)
 	}

--- a/internal/daemon/codexconfig_test.go
+++ b/internal/daemon/codexconfig_test.go
@@ -45,6 +45,41 @@ wire_api = "responses"
 	}
 }
 
+func TestWriteCodexConfigHomeFallback(t *testing.T) {
+	t.Setenv("HOME", "")
+
+	baseURL := "https://example.com"
+	codexHome, err := writeCodexConfig(baseURL, nil)
+	if err != nil {
+		t.Fatalf("expected config to be written, got %v", err)
+	}
+
+	expectedHome := filepath.Join(codexDefaultHome, ".codex")
+	if codexHome != expectedHome {
+		t.Fatalf("expected codex home %q, got %q", expectedHome, codexHome)
+	}
+
+	configPath := filepath.Join(codexHome, "config.toml")
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("expected config to be readable, got %v", err)
+	}
+
+	expected := fmt.Sprintf(`model_provider = "platform"
+approval_policy = "never"
+sandbox_mode = "danger-full-access"
+
+[model_providers.platform]
+name = "Agyn LLM"
+base_url = %q
+env_key = "OPENAI_API_KEY"
+wire_api = "responses"
+`, baseURL)
+	if string(content) != expected {
+		t.Fatalf("expected config %q, got %q", expected, string(content))
+	}
+}
+
 func TestWriteCodexConfigWithMCPServers(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"net"
-	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -241,12 +240,8 @@ func newCodexDaemon(ctx context.Context, cfg config.Config, version string) (*Da
 		_ = setup.gatewayConn.Close()
 		return nil, err
 	}
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		_ = setup.gatewayConn.Close()
-		return nil, fmt.Errorf("resolve home directory: %w", err)
-	}
-	mappingStore := codexbridge.NewThreadMappingStore(homeDir)
+	codexHomeValue := codexHomeEnv()
+	mappingStore := codexbridge.NewThreadMappingStore(codexHomeValue)
 
 	tracingProxy, err := tracingproxy.Start(ctx, tracingproxy.Config{
 		TracingAddress: cfg.TracingAddress,
@@ -258,7 +253,6 @@ func newCodexDaemon(ctx context.Context, cfg config.Config, version string) (*Da
 		return nil, err
 	}
 	otlpEndpoint := "http://" + tracingproxy.ListenAddress
-	codexHomeValue := codexHomeEnv()
 	options := []codex.Option{
 		codex.WithBinary(cfg.AgentBinary),
 		codex.WithWorkDir(cfg.WorkDir),

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -258,12 +258,14 @@ func newCodexDaemon(ctx context.Context, cfg config.Config, version string) (*Da
 		return nil, err
 	}
 	otlpEndpoint := "http://" + tracingproxy.ListenAddress
+	codexHomeValue := codexHomeEnv()
 	options := []codex.Option{
 		codex.WithBinary(cfg.AgentBinary),
 		codex.WithWorkDir(cfg.WorkDir),
 		codex.WithEnv(map[string]string{
 			"PATH":                        agentPathValue(),
 			"CODEX_HOME":                  codexHome,
+			"HOME":                        codexHomeValue,
 			"OPENAI_API_KEY":              cfg.LLMAPIToken,
 			"OTEL_EXPORTER_OTLP_ENDPOINT": otlpEndpoint,
 		}),

--- a/internal/daemon/env.go
+++ b/internal/daemon/env.go
@@ -1,8 +1,14 @@
 package daemon
 
-import "os"
+import (
+	"os"
+	"strings"
+)
 
-const cliPathPrefix = "/agyn-bin/cli"
+const (
+	cliPathPrefix     = "/agyn-bin/cli"
+	codexDefaultHome  = "/tmp"
+)
 
 func prependCLIPath(pathValue string) string {
 	if pathValue == "" {
@@ -13,4 +19,12 @@ func prependCLIPath(pathValue string) string {
 
 func agentPathValue() string {
 	return prependCLIPath(os.Getenv("PATH"))
+}
+
+func codexHomeEnv() string {
+	home := strings.TrimSpace(os.Getenv("HOME"))
+	if home == "" {
+		return codexDefaultHome
+	}
+	return home
 }

--- a/internal/daemon/env_test.go
+++ b/internal/daemon/env_test.go
@@ -20,3 +20,17 @@ func TestPrependCLIPathExisting(t *testing.T) {
 		t.Fatalf("expected %q, got %q", expected, got)
 	}
 }
+
+func TestCodexHomeEnvDefault(t *testing.T) {
+	t.Setenv("HOME", "")
+	if got := codexHomeEnv(); got != codexDefaultHome {
+		t.Fatalf("expected %q, got %q", codexDefaultHome, got)
+	}
+}
+
+func TestCodexHomeEnvUsesHome(t *testing.T) {
+	t.Setenv("HOME", "/custom/home")
+	if got := codexHomeEnv(); got != "/custom/home" {
+		t.Fatalf("expected /custom/home, got %q", got)
+	}
+}

--- a/internal/daemon/skills.go
+++ b/internal/daemon/skills.go
@@ -124,16 +124,17 @@ func writeSkills(sdk string, skills []skill) (string, error) {
 }
 
 func skillsDirForSDK(sdk string) (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("resolve home directory: %w", err)
-	}
 	switch sdk {
 	case SDKCodex:
-		return filepath.Join(home, ".codex", "skills"), nil
-	case SDKAgn:
-		return filepath.Join(home, ".agyn", "agn", "skills"), nil
-	case SDKClaude:
+		return filepath.Join(codexHomeEnv(), ".codex", "skills"), nil
+	case SDKAgn, SDKClaude:
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		if sdk == SDKAgn {
+			return filepath.Join(home, ".agyn", "agn", "skills"), nil
+		}
 		return filepath.Join(home, ".claude", "skills"), nil
 	default:
 		return "", fmt.Errorf("unknown sdk %q", sdk)

--- a/internal/daemon/skills_test.go
+++ b/internal/daemon/skills_test.go
@@ -1,11 +1,28 @@
 package daemon
 
-import "testing"
+import (
+	"path/filepath"
+	"testing"
+)
 
 func TestValidateSkillNameTraversal(t *testing.T) {
 	for _, name := range []string{".", ".."} {
 		if err := validateSkillName(name); err == nil {
 			t.Fatalf("expected error for skill name %q", name)
 		}
+	}
+}
+
+func TestSkillsDirForSDKCodexHomeFallback(t *testing.T) {
+	t.Setenv("HOME", "")
+
+	dir, err := skillsDirForSDK(SDKCodex)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	expected := filepath.Join(codexDefaultHome, ".codex", "skills")
+	if dir != expected {
+		t.Fatalf("expected skills dir %q, got %q", expected, dir)
 	}
 }

--- a/internal/platform/runners_test.go
+++ b/internal/platform/runners_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	gatewayv1 "github.com/agynio/agynd-cli/.gen/go/agynio/api/gateway/v1"
+	runnerv1 "github.com/agynio/agynd-cli/.gen/go/agynio/api/runner/v1"
 	runnersv1 "github.com/agynio/agynd-cli/.gen/go/agynio/api/runners/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -70,6 +71,22 @@ func (f *fakeRunnersGatewayClient) TouchWorkload(ctx context.Context, in *runner
 		return nil, f.touchErr
 	}
 	return &runnersv1.TouchWorkloadResponse{}, nil
+}
+
+func (f *fakeRunnersGatewayClient) StreamWorkloadLogs(ctx context.Context, in *runnerv1.StreamWorkloadLogsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[runnerv1.StreamWorkloadLogsResponse], error) {
+	return nil, fmt.Errorf("StreamWorkloadLogs not implemented")
+}
+
+func (f *fakeRunnersGatewayClient) GetVolume(ctx context.Context, in *runnersv1.GetVolumeRequest, opts ...grpc.CallOption) (*runnersv1.GetVolumeResponse, error) {
+	return nil, fmt.Errorf("GetVolume not implemented")
+}
+
+func (f *fakeRunnersGatewayClient) ListVolumes(ctx context.Context, in *runnersv1.ListVolumesRequest, opts ...grpc.CallOption) (*runnersv1.ListVolumesResponse, error) {
+	return nil, fmt.Errorf("ListVolumes not implemented")
+}
+
+func (f *fakeRunnersGatewayClient) ListVolumesByThread(ctx context.Context, in *runnersv1.ListVolumesByThreadRequest, opts ...grpc.CallOption) (*runnersv1.ListVolumesByThreadResponse, error) {
+	return nil, fmt.Errorf("ListVolumesByThread not implemented")
 }
 
 func TestWorkloadFromProtoValid(t *testing.T) {

--- a/test/e2e/agn_test.go
+++ b/test/e2e/agn_test.go
@@ -51,7 +51,7 @@ func buildAgn(t *testing.T) string {
 	return agnBinaryPath
 }
 
-func writeAgnTestConfig(t *testing.T, model string) string {
+func writeAgnTestConfig(t *testing.T, model string, tokenCountingAddress string) string {
 	t.Helper()
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.yaml")
@@ -60,7 +60,9 @@ func writeAgnTestConfig(t *testing.T, model string) string {
   auth:
     api_key: dummy
   model: %s
-`, agnTestLLMEndpoint, model)
+token_counting:
+  address: %q
+`, agnTestLLMEndpoint, model, tokenCountingAddress)
 	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
 		t.Fatalf("write agn config: %v", err)
 	}
@@ -69,7 +71,8 @@ func writeAgnTestConfig(t *testing.T, model string) string {
 
 func TestAgnClientHelloResponse(t *testing.T) {
 	binary := buildAgn(t)
-	configPath := writeAgnTestConfig(t, "simple-hello")
+	tokenCountingAddr := startTokenCountingServer(t)
+	configPath := writeAgnTestConfig(t, "simple-hello", tokenCountingAddr)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/test/e2e/token_counting_server_test.go
+++ b/test/e2e/token_counting_server_test.go
@@ -1,0 +1,64 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	tokencountingv1 "github.com/agynio/agynd-cli/.gen/go/agynio/api/token_counting/v1"
+	"google.golang.org/grpc"
+)
+
+func startTokenCountingServer(t *testing.T) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen token counting: %v", err)
+	}
+	server := grpc.NewServer()
+	tokencountingv1.RegisterTokenCountingServiceServer(server, tokenCountingServer{})
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- server.Serve(listener)
+	}()
+	select {
+	case err := <-serveErr:
+		if err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+			t.Fatalf("serve token counting: %v", err)
+		}
+	default:
+	}
+	t.Cleanup(func() {
+		server.Stop()
+		_ = listener.Close()
+		select {
+		case err := <-serveErr:
+			if err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+				t.Errorf("token counting server error: %v", err)
+			}
+		default:
+		}
+	})
+	return listener.Addr().String()
+}
+
+type tokenCountingServer struct {
+	tokencountingv1.UnimplementedTokenCountingServiceServer
+}
+
+func (tokenCountingServer) CountTokens(_ context.Context, req *tokencountingv1.CountTokensRequest) (*tokencountingv1.CountTokensResponse, error) {
+	if req == nil {
+		return nil, errors.New("token counting request is required")
+	}
+	if len(req.Messages) == 0 {
+		return nil, errors.New("token counting messages are required")
+	}
+	tokens := make([]int32, len(req.Messages))
+	for i := range tokens {
+		tokens[i] = 1
+	}
+	return &tokencountingv1.CountTokensResponse{Tokens: tokens}, nil
+}


### PR DESCRIPTION
## Summary
- default WORKSPACE_DIR to /tmp when unset
- ensure the Codex subprocess HOME defaults to /tmp when empty
- extend runners gateway test fake for new volume/log methods

## Testing
- buf generate buf.build/agynio/api --path agynio/api/gateway/v1 --include-imports
- go vet ./...
- go test ./...

Closes #100