### PR TITLE
fix(daemon): set token counting address

### DIFF
--- a/internal/daemon/agnconfig.go
+++ b/internal/daemon/agnconfig.go
@@ -14,7 +14,6 @@ import (
 const (
 	agynAPIAddressEnvVar          = "AGYN_API_ADDRESS"
 	agnTokenCountingAddressEnvVar = "AGN_TOKEN_COUNTING_ADDRESS"
-	tokenCountingDefaultAddress   = "token-counting:50051"
 	tokenCountingServiceName      = "token-counting"
 	tokenCountingServicePort      = 50051
 )
@@ -35,7 +34,7 @@ func writeAgnConfig(llmBaseURL, apiKey, model, systemPrompt string, summarizatio
 	}
 	tokenCountingAddress, err := resolveTokenCountingAddress()
 	if err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf("resolve token counting address: %w", err)
 	}
 	agnDir := filepath.Join(home, ".agyn", "agn")
 	if err := os.MkdirAll(agnDir, 0o700); err != nil {
@@ -110,7 +109,7 @@ func resolveTokenCountingAddress() (string, error) {
 	}
 	apiAddress := strings.TrimSpace(os.Getenv(agynAPIAddressEnvVar))
 	if apiAddress == "" {
-		return tokenCountingDefaultAddress, nil
+		return fmt.Sprintf("%s:%d", tokenCountingServiceName, tokenCountingServicePort), nil
 	}
 	host, err := apiHost(apiAddress)
 	if err != nil {

--- a/internal/daemon/agnconfig.go
+++ b/internal/daemon/agnconfig.go
@@ -2,6 +2,8 @@ package daemon
 
 import (
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,11 +11,21 @@ import (
 	"github.com/agynio/agynd-cli/internal/config"
 )
 
+const (
+	agynAPIAddressEnvVar          = "AGYN_API_ADDRESS"
+	agnTokenCountingAddressEnvVar = "AGN_TOKEN_COUNTING_ADDRESS"
+	tokenCountingDefaultAddress   = "token-counting:50051"
+	tokenCountingServiceName      = "token-counting"
+	tokenCountingServicePort      = 50051
+)
+
 const agnConfigTemplate = `llm:
   endpoint: %s
   auth:
     api_key: %s
   model: %s
+token_counting:
+  address: %s
 `
 
 func writeAgnConfig(llmBaseURL, apiKey, model, systemPrompt string, summarization *summarizationConfig, mcpServers []config.MCPServer) (string, string, error) {
@@ -21,20 +33,24 @@ func writeAgnConfig(llmBaseURL, apiKey, model, systemPrompt string, summarizatio
 	if err != nil {
 		return "", "", fmt.Errorf("resolve home directory: %w", err)
 	}
+	tokenCountingAddress, err := resolveTokenCountingAddress()
+	if err != nil {
+		return "", "", err
+	}
 	agnDir := filepath.Join(home, ".agyn", "agn")
 	if err := os.MkdirAll(agnDir, 0o700); err != nil {
 		return "", "", fmt.Errorf("create agn config dir: %w", err)
 	}
 	configPath := filepath.Join(agnDir, "config.yaml")
-	payload := agnConfig(llmBaseURL, apiKey, model, systemPrompt, summarization, mcpServers)
+	payload := agnConfig(llmBaseURL, apiKey, model, tokenCountingAddress, systemPrompt, summarization, mcpServers)
 	if err := os.WriteFile(configPath, []byte(payload), 0o600); err != nil {
 		return "", "", fmt.Errorf("write agn config: %w", err)
 	}
 	return agnDir, configPath, nil
 }
 
-func agnConfig(llmBaseURL, apiKey, model, systemPrompt string, summarization *summarizationConfig, mcpServers []config.MCPServer) string {
-	payload := fmt.Sprintf(agnConfigTemplate, llmBaseURL, apiKey, model)
+func agnConfig(llmBaseURL, apiKey, model, tokenCountingAddress, systemPrompt string, summarization *summarizationConfig, mcpServers []config.MCPServer) string {
+	payload := fmt.Sprintf(agnConfigTemplate, llmBaseURL, apiKey, model, tokenCountingAddress)
 	cleanPrompt := strings.TrimSpace(systemPrompt)
 	if summarization == nil && len(mcpServers) == 0 && cleanPrompt == "" {
 		return payload
@@ -85,4 +101,65 @@ func appendSystemPrompt(builder *strings.Builder, prompt string) {
 	for _, line := range strings.Split(prompt, "\n") {
 		fmt.Fprintf(builder, "  %s\n", line)
 	}
+}
+
+func resolveTokenCountingAddress() (string, error) {
+	override := strings.TrimSpace(os.Getenv(agnTokenCountingAddressEnvVar))
+	if override != "" {
+		return override, nil
+	}
+	apiAddress := strings.TrimSpace(os.Getenv(agynAPIAddressEnvVar))
+	if apiAddress == "" {
+		return tokenCountingDefaultAddress, nil
+	}
+	host, err := apiHost(apiAddress)
+	if err != nil {
+		return "", err
+	}
+	suffix, err := serviceSuffix(host)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s.%s:%d", tokenCountingServiceName, suffix, tokenCountingServicePort), nil
+}
+
+func apiHost(address string) (string, error) {
+	if strings.Contains(address, "://") {
+		parsed, err := url.Parse(address)
+		if err != nil {
+			return "", fmt.Errorf("parse %s %q: %w", agynAPIAddressEnvVar, address, err)
+		}
+		address = parsed.Host
+	}
+	address = strings.TrimSpace(address)
+	if address == "" {
+		return "", fmt.Errorf("%s is empty", agynAPIAddressEnvVar)
+	}
+	if strings.Contains(address, "/") {
+		address = strings.Split(address, "/")[0]
+	}
+	if strings.Contains(address, ":") {
+		host, _, err := net.SplitHostPort(address)
+		if err != nil {
+			return "", fmt.Errorf("%s %q must be host:port", agynAPIAddressEnvVar, address)
+		}
+		address = host
+	}
+	address = strings.TrimSpace(address)
+	if address == "" {
+		return "", fmt.Errorf("%s is empty", agynAPIAddressEnvVar)
+	}
+	return address, nil
+}
+
+func serviceSuffix(host string) (string, error) {
+	parts := strings.Split(host, ".")
+	if len(parts) < 2 {
+		return "", fmt.Errorf("%s %q missing namespace", agynAPIAddressEnvVar, host)
+	}
+	suffix := strings.Join(parts[1:], ".")
+	if strings.TrimSpace(suffix) == "" {
+		return "", fmt.Errorf("%s %q missing namespace", agynAPIAddressEnvVar, host)
+	}
+	return suffix, nil
 }

--- a/internal/daemon/agnconfig_test.go
+++ b/internal/daemon/agnconfig_test.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	testAgnAPIAddress         = "api.platform.svc.cluster.local:443"
+	testAgnAPIAddressURL      = "https://api.platform.svc.cluster.local:443/v1"
 	testTokenCountingAddress  = "token-counting.platform.svc.cluster.local:50051"
 	testTokenCountingOverride = "token-counting.custom.svc.cluster.local:50052"
 )
@@ -286,6 +287,32 @@ func TestResolveTokenCountingAddressFromAPIAddress(t *testing.T) {
 	}
 	if address != testTokenCountingAddress {
 		t.Fatalf("expected address %q, got %q", testTokenCountingAddress, address)
+	}
+}
+
+func TestResolveTokenCountingAddressFromAPIAddressURL(t *testing.T) {
+	t.Setenv(agynAPIAddressEnvVar, testAgnAPIAddressURL)
+
+	address, err := resolveTokenCountingAddress()
+	if err != nil {
+		t.Fatalf("expected address, got %v", err)
+	}
+	if address != testTokenCountingAddress {
+		t.Fatalf("expected address %q, got %q", testTokenCountingAddress, address)
+	}
+}
+
+func TestResolveTokenCountingAddressDefault(t *testing.T) {
+	t.Setenv(agynAPIAddressEnvVar, "")
+	t.Setenv(agnTokenCountingAddressEnvVar, "")
+
+	address, err := resolveTokenCountingAddress()
+	if err != nil {
+		t.Fatalf("expected address, got %v", err)
+	}
+	expected := fmt.Sprintf("%s:%d", tokenCountingServiceName, tokenCountingServicePort)
+	if address != expected {
+		t.Fatalf("expected address %q, got %q", expected, address)
 	}
 }
 

--- a/internal/daemon/agnconfig_test.go
+++ b/internal/daemon/agnconfig_test.go
@@ -9,9 +9,21 @@ import (
 	"github.com/agynio/agynd-cli/internal/config"
 )
 
+const (
+	testAgnAPIAddress         = "api.platform.svc.cluster.local:443"
+	testTokenCountingAddress  = "token-counting.platform.svc.cluster.local:50051"
+	testTokenCountingOverride = "token-counting.custom.svc.cluster.local:50052"
+)
+
+func setAgnAPIAddress(t *testing.T) {
+	t.Helper()
+	t.Setenv(agynAPIAddressEnvVar, testAgnAPIAddress)
+}
+
 func TestWriteAgnConfig(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
+	setAgnAPIAddress(t)
 
 	baseURL := "https://example.com"
 	apiKey := "test-api-key"
@@ -36,7 +48,7 @@ func TestWriteAgnConfig(t *testing.T) {
 		t.Fatalf("expected config to be readable, got %v", err)
 	}
 
-	expected := fmt.Sprintf(agnConfigTemplate, baseURL, apiKey, model)
+	expected := fmt.Sprintf(agnConfigTemplate, baseURL, apiKey, model, testTokenCountingAddress)
 	if string(content) != expected {
 		t.Fatalf("expected config %q, got %q", expected, string(content))
 	}
@@ -56,8 +68,8 @@ func TestAgnConfigNoSummarizationInJSON(t *testing.T) {
 		t.Fatalf("expected nil summarization, got %#v", summarization)
 	}
 
-	content := agnConfig(baseURL, apiKey, model, "", summarization, nil)
-	expected := fmt.Sprintf(agnConfigTemplate, baseURL, apiKey, model)
+	content := agnConfig(baseURL, apiKey, model, testTokenCountingAddress, "", summarization, nil)
+	expected := fmt.Sprintf(agnConfigTemplate, baseURL, apiKey, model, testTokenCountingAddress)
 	if content != expected {
 		t.Fatalf("expected config %q, got %q", expected, content)
 	}
@@ -66,6 +78,7 @@ func TestAgnConfigNoSummarizationInJSON(t *testing.T) {
 func TestWriteAgnConfigWithMCPServers(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
+	setAgnAPIAddress(t)
 
 	baseURL := "https://example.com"
 	apiKey := "test-api-key"
@@ -94,7 +107,7 @@ func TestWriteAgnConfigWithMCPServers(t *testing.T) {
 		t.Fatalf("expected config to be readable, got %v", err)
 	}
 
-	expected := fmt.Sprintf(agnConfigTemplate, baseURL, apiKey, model) +
+	expected := fmt.Sprintf(agnConfigTemplate, baseURL, apiKey, model, testTokenCountingAddress) +
 		"mcp:\n  servers:\n" +
 		"    memory:\n      url: http://localhost:8100/mcp\n" +
 		"    filesystem:\n      url: http://localhost:8200/mcp\n"
@@ -106,6 +119,7 @@ func TestWriteAgnConfigWithMCPServers(t *testing.T) {
 func TestWriteAgnConfigWithSummarizationThresholds(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
+	setAgnAPIAddress(t)
 
 	baseURL := "https://example.com"
 	apiKey := "test-api-key"
@@ -126,7 +140,7 @@ func TestWriteAgnConfigWithSummarizationThresholds(t *testing.T) {
 		t.Fatalf("expected config to be readable, got %v", err)
 	}
 
-	expected := fmt.Sprintf(agnConfigTemplate, baseURL, apiKey, model) +
+	expected := fmt.Sprintf(agnConfigTemplate, baseURL, apiKey, model, testTokenCountingAddress) +
 		"summarization:\n" +
 		"  keep_tokens: 10\n" +
 		"  max_tokens: 200\n"
@@ -138,6 +152,7 @@ func TestWriteAgnConfigWithSummarizationThresholds(t *testing.T) {
 func TestWriteAgnConfigWithSummarizationLLMAPIKey(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
+	setAgnAPIAddress(t)
 
 	baseURL := "https://example.com"
 	apiKey := "test-api-key"
@@ -175,7 +190,7 @@ func TestWriteAgnConfigWithSummarizationLLMAPIKey(t *testing.T) {
 		t.Fatalf("expected config to be readable, got %v", err)
 	}
 
-	expected := fmt.Sprintf(agnConfigTemplate, baseURL, apiKey, model) +
+	expected := fmt.Sprintf(agnConfigTemplate, baseURL, apiKey, model, testTokenCountingAddress) +
 		"summarization:\n" +
 		"  keep_tokens: 10\n" +
 		"  max_tokens: 200\n" +
@@ -192,6 +207,7 @@ func TestWriteAgnConfigWithSummarizationLLMAPIKey(t *testing.T) {
 func TestWriteAgnConfigWithSummarizationLLMAPIKeyEnv(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
+	setAgnAPIAddress(t)
 
 	baseURL := "https://example.com"
 	apiKey := "test-api-key"
@@ -219,7 +235,7 @@ func TestWriteAgnConfigWithSummarizationLLMAPIKeyEnv(t *testing.T) {
 		t.Fatalf("expected config to be readable, got %v", err)
 	}
 
-	expected := fmt.Sprintf(agnConfigTemplate, baseURL, apiKey, model) +
+	expected := fmt.Sprintf(agnConfigTemplate, baseURL, apiKey, model, testTokenCountingAddress) +
 		"summarization:\n" +
 		"  keep_tokens: 10\n" +
 		"  max_tokens: 200\n" +
@@ -236,6 +252,7 @@ func TestWriteAgnConfigWithSummarizationLLMAPIKeyEnv(t *testing.T) {
 func TestWriteAgnConfigWithSystemPrompt(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
+	setAgnAPIAddress(t)
 
 	baseURL := "https://example.com"
 	apiKey := "test-api-key"
@@ -251,11 +268,36 @@ func TestWriteAgnConfigWithSystemPrompt(t *testing.T) {
 		t.Fatalf("expected config to be readable, got %v", err)
 	}
 
-	expected := fmt.Sprintf(agnConfigTemplate, baseURL, apiKey, model) +
+	expected := fmt.Sprintf(agnConfigTemplate, baseURL, apiKey, model, testTokenCountingAddress) +
 		"system_prompt: |\n" +
 		"  You are a helpful agent.\n" +
 		"  Follow the guidelines.\n"
 	if string(content) != expected {
 		t.Fatalf("expected config %q, got %q", expected, string(content))
+	}
+}
+
+func TestResolveTokenCountingAddressFromAPIAddress(t *testing.T) {
+	setAgnAPIAddress(t)
+
+	address, err := resolveTokenCountingAddress()
+	if err != nil {
+		t.Fatalf("expected address, got %v", err)
+	}
+	if address != testTokenCountingAddress {
+		t.Fatalf("expected address %q, got %q", testTokenCountingAddress, address)
+	}
+}
+
+func TestResolveTokenCountingAddressOverride(t *testing.T) {
+	setAgnAPIAddress(t)
+	t.Setenv(agnTokenCountingAddressEnvVar, testTokenCountingOverride)
+
+	address, err := resolveTokenCountingAddress()
+	if err != nil {
+		t.Fatalf("expected address, got %v", err)
+	}
+	if address != testTokenCountingOverride {
+		t.Fatalf("expected address %q, got %q", testTokenCountingOverride, address)
 	}
 }


### PR DESCRIPTION
## Summary
- derive token_counting.address from AGYN_API_ADDRESS or override
- include token_counting in generated AGN config
- add unit coverage for token counting address resolution

## Testing
- go vet ./...
- go test ./...

Refs #100