### PR TITLE
fix(agn): use configuration system prompt

### DIFF
--- a/internal/daemon/agentconfig.go
+++ b/internal/daemon/agentconfig.go
@@ -24,6 +24,7 @@ type summarizationAuthConfig struct {
 }
 
 type agentConfigurationPayload struct {
+	SystemPrompt  *string               `json:"system_prompt"`
 	Summarization *summarizationPayload `json:"summarization"`
 }
 
@@ -45,17 +46,43 @@ type summarizationAuthPayload struct {
 }
 
 func parseAgentSummarization(raw string) (*summarizationConfig, error) {
+	cfg, err := parseAgentConfiguration(raw)
+	if err != nil {
+		return nil, err
+	}
+	return cfg.Summarization, nil
+}
+
+type agentConfiguration struct {
+	SystemPrompt  string
+	Summarization *summarizationConfig
+}
+
+func parseAgentConfiguration(raw string) (agentConfiguration, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
-		return nil, nil
+		return agentConfiguration{}, nil
 	}
 
 	var payload agentConfigurationPayload
 	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
-		return nil, fmt.Errorf("parse agent configuration: %w", err)
+		return agentConfiguration{}, fmt.Errorf("parse agent configuration: %w", err)
 	}
 
-	return normalizeSummarizationPayload(payload.Summarization)
+	summarization, err := normalizeSummarizationPayload(payload.Summarization)
+	if err != nil {
+		return agentConfiguration{}, err
+	}
+
+	systemPrompt := ""
+	if payload.SystemPrompt != nil {
+		systemPrompt = strings.TrimSpace(*payload.SystemPrompt)
+	}
+
+	return agentConfiguration{
+		SystemPrompt:  systemPrompt,
+		Summarization: summarization,
+	}, nil
 }
 
 func normalizeSummarizationPayload(payload *summarizationPayload) (*summarizationConfig, error) {

--- a/internal/daemon/agentconfig_test.go
+++ b/internal/daemon/agentconfig_test.go
@@ -71,6 +71,21 @@ func TestParseAgentSummarizationNoBlock(t *testing.T) {
 	}
 }
 
+func TestParseAgentConfigurationSystemPrompt(t *testing.T) {
+	payload := `{"system_prompt":"  hello there  "}`
+
+	cfg, err := parseAgentConfiguration(payload)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if cfg.SystemPrompt != "hello there" {
+		t.Fatalf("unexpected system prompt %q", cfg.SystemPrompt)
+	}
+	if cfg.Summarization != nil {
+		t.Fatalf("expected nil summarization, got %#v", cfg.Summarization)
+	}
+}
+
 func TestParseAgentSummarizationInvalidJSON(t *testing.T) {
 	_, err := parseAgentSummarization("{")
 	if err == nil {

--- a/internal/daemon/agn.go
+++ b/internal/daemon/agn.go
@@ -27,19 +27,19 @@ func newAgnDaemon(ctx context.Context, cfg config.Config, version string) (*Daem
 		return nil, err
 	}
 
-	summarization, err := parseAgentSummarization(setup.agent.GetConfiguration())
+	agentConfig, err := parseAgentConfiguration(setup.agent.GetConfiguration())
 	if err != nil {
 		_ = setup.gatewayConn.Close()
 		return nil, err
 	}
-	systemPrompt := buildSystemPrompt(setup.agent.GetRole(), setup.skills)
+	systemPrompt := buildSystemPrompt(agentConfig.SystemPrompt, setup.skills)
 
 	_, configPath, err := writeAgnConfig(
 		cfg.LLMBaseURL,
 		cfg.LLMAPIToken,
 		setup.agent.GetModel(),
 		systemPrompt,
-		summarization,
+		agentConfig.Summarization,
 		cfg.MCPServers,
 	)
 	if err != nil {

--- a/internal/daemon/agnconfig.go
+++ b/internal/daemon/agnconfig.go
@@ -96,7 +96,7 @@ func appendSummarizationConfig(builder *strings.Builder, summarization *summariz
 }
 
 func appendSystemPrompt(builder *strings.Builder, prompt string) {
-	builder.WriteString("system_prompt: |\n")
+	builder.WriteString("system_prompt: |-\n")
 	for _, line := range strings.Split(prompt, "\n") {
 		fmt.Fprintf(builder, "  %s\n", line)
 	}

--- a/internal/daemon/agnconfig_test.go
+++ b/internal/daemon/agnconfig_test.go
@@ -270,7 +270,7 @@ func TestWriteAgnConfigWithSystemPrompt(t *testing.T) {
 	}
 
 	expected := fmt.Sprintf(agnConfigTemplate, baseURL, apiKey, model, testTokenCountingAddress) +
-		"system_prompt: |\n" +
+		"system_prompt: |-\n" +
 		"  You are a helpful agent.\n" +
 		"  Follow the guidelines.\n"
 	if string(content) != expected {

--- a/internal/daemon/skills.go
+++ b/internal/daemon/skills.go
@@ -154,14 +154,14 @@ func validateSkillName(name string) error {
 	return nil
 }
 
-func buildSystemPrompt(role string, skills []skill) string {
-	role = strings.TrimSpace(role)
-	if role == "" && len(skills) == 0 {
+func buildSystemPrompt(systemPrompt string, skills []skill) string {
+	systemPrompt = strings.TrimSpace(systemPrompt)
+	if systemPrompt == "" && len(skills) == 0 {
 		return ""
 	}
 	parts := make([]string, 0, len(skills)+1)
-	if role != "" {
-		parts = append(parts, role)
+	if systemPrompt != "" {
+		parts = append(parts, systemPrompt)
 	}
 	for _, entry := range skills {
 		body := strings.TrimSpace(entry.Body)


### PR DESCRIPTION
## Summary
- parse system_prompt from agent configuration and build AGN system prompt from it plus skills (no role usage)
- emit system_prompt with YAML chomp indicator to avoid trailing newline
- add config parsing coverage for system_prompt

## Testing
- go test ./...
- go vet -p 1 ./...

Fixes #103