### PR TITLE
feat(tracingproxy): add message id attr

### DIFF
--- a/internal/daemon/claude_test.go
+++ b/internal/daemon/claude_test.go
@@ -75,6 +75,10 @@ func (f *fakeClaudeThreadsClient) GetOrganizationThreads(ctx context.Context, in
 	return nil, fmt.Errorf("GetOrganizationThreads not implemented")
 }
 
+func (f *fakeClaudeThreadsClient) ListOrganizationThreads(ctx context.Context, in *threadsv1.ListOrganizationThreadsRequest, opts ...grpc.CallOption) (*threadsv1.ListOrganizationThreadsResponse, error) {
+	return nil, fmt.Errorf("ListOrganizationThreads not implemented")
+}
+
 func (f *fakeClaudeThreadsClient) GetThread(ctx context.Context, in *threadsv1.GetThreadRequest, opts ...grpc.CallOption) (*threadsv1.GetThreadResponse, error) {
 	return nil, fmt.Errorf("GetThread not implemented")
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -344,6 +344,10 @@ func (d *Daemon) syncMessages(ctx context.Context) error {
 	}()
 
 	return d.consumer.Sync(ctx, d.cfg.AgentID.String(), d.cfg.ThreadID, func(message platform.Message) error {
+		if d.tracingProxy != nil {
+			d.tracingProxy.SetMessageID(message.ID)
+			defer d.tracingProxy.ClearMessageID()
+		}
 		return d.handleMessage(ctx, message)
 	})
 }

--- a/internal/platform/consumer_test.go
+++ b/internal/platform/consumer_test.go
@@ -44,6 +44,10 @@ func (f *fakeThreadsClient) GetOrganizationThreads(ctx context.Context, in *thre
 	return nil, fmt.Errorf("GetOrganizationThreads not implemented")
 }
 
+func (f *fakeThreadsClient) ListOrganizationThreads(ctx context.Context, in *threadsv1.ListOrganizationThreadsRequest, opts ...grpc.CallOption) (*threadsv1.ListOrganizationThreadsResponse, error) {
+	return nil, fmt.Errorf("ListOrganizationThreads not implemented")
+}
+
 func (f *fakeThreadsClient) GetThread(ctx context.Context, in *threadsv1.GetThreadRequest, opts ...grpc.CallOption) (*threadsv1.GetThreadResponse, error) {
 	return nil, fmt.Errorf("GetThread not implemented")
 }

--- a/internal/tracingproxy/proxy.go
+++ b/internal/tracingproxy/proxy.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"sync"
 	"time"
 
 	collectortracev1 "go.opentelemetry.io/proto/otlp/collector/trace/v1"
@@ -20,6 +21,7 @@ import (
 const (
 	ListenAddress          = "localhost:4317"
 	threadIDAttributeKey   = "agyn.thread.id"
+	messageIDAttributeKey  = "agyn.thread.message.id"
 	workloadIDAttributeKey = "agyn.workload.id"
 )
 
@@ -37,6 +39,8 @@ type Proxy struct {
 	conn       *grpc.ClientConn
 	threadID   string
 	workloadID string
+	messageMu  sync.RWMutex
+	messageID  string
 }
 
 func Start(ctx context.Context, cfg Config) (*Proxy, error) {
@@ -82,7 +86,28 @@ func (p *Proxy) Export(ctx context.Context, req *collectortracev1.ExportTraceSer
 	if p.workloadID != "" {
 		injectWorkloadID(req, p.workloadID)
 	}
+	if messageID := p.messageIDValue(); messageID != "" {
+		injectMessageID(req, messageID)
+	}
 	return p.upstream.Export(ctx, req)
+}
+
+func (p *Proxy) SetMessageID(messageID string) {
+	p.messageMu.Lock()
+	p.messageID = messageID
+	p.messageMu.Unlock()
+}
+
+func (p *Proxy) ClearMessageID() {
+	p.messageMu.Lock()
+	p.messageID = ""
+	p.messageMu.Unlock()
+}
+
+func (p *Proxy) messageIDValue() string {
+	p.messageMu.RLock()
+	defer p.messageMu.RUnlock()
+	return p.messageID
 }
 
 func (p *Proxy) Close() {
@@ -124,6 +149,20 @@ func injectWorkloadID(req *collectortracev1.ExportTraceServiceRequest, workloadI
 			spans.Resource = resource
 		}
 		upsertAttribute(resource, workloadIDAttributeKey, workloadID)
+	}
+}
+
+func injectMessageID(req *collectortracev1.ExportTraceServiceRequest, messageID string) {
+	for _, spans := range req.ResourceSpans {
+		if spans == nil {
+			continue
+		}
+		resource := spans.Resource
+		if resource == nil {
+			resource = &resourcev1.Resource{}
+			spans.Resource = resource
+		}
+		upsertAttribute(resource, messageIDAttributeKey, messageID)
 	}
 }
 

--- a/internal/tracingproxy/proxy_test.go
+++ b/internal/tracingproxy/proxy_test.go
@@ -78,6 +78,33 @@ func TestInjectWorkloadID(t *testing.T) {
 	}
 }
 
+func TestInjectMessageID(t *testing.T) {
+	req := &collectortracev1.ExportTraceServiceRequest{
+		ResourceSpans: []*tracev1.ResourceSpans{
+			{
+				Resource: &resourcev1.Resource{
+					Attributes: []*commonv1.KeyValue{
+						{Key: "existing", Value: stringValue("keep")},
+					},
+				},
+			},
+		},
+	}
+
+	injectMessageID(req, "message-1")
+
+	resource := req.ResourceSpans[0].Resource
+	if value, ok := findAttribute(resource, "existing"); !ok || value.GetStringValue() != "keep" {
+		t.Fatalf("expected existing attribute preserved, got %v", value)
+	}
+	if value, ok := findAttribute(resource, messageIDAttributeKey); !ok || value.GetStringValue() != "message-1" {
+		t.Fatalf("expected message id injected, got %v", value)
+	}
+	if len(resource.Attributes) != 2 {
+		t.Fatalf("expected 2 attributes, got %d", len(resource.Attributes))
+	}
+}
+
 func TestInjectThreadIDOverwritesExisting(t *testing.T) {
 	req := &collectortracev1.ExportTraceServiceRequest{
 		ResourceSpans: []*tracev1.ResourceSpans{
@@ -150,6 +177,7 @@ func TestProxyForwardsToUpstream(t *testing.T) {
 		t.Fatalf("start proxy: %v", err)
 	}
 	defer proxy.Close()
+	proxy.SetMessageID("message-4")
 
 	conn, err := grpc.NewClient(ListenAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
@@ -178,6 +206,55 @@ func TestProxyForwardsToUpstream(t *testing.T) {
 	value, ok = findAttribute(forwarded.ResourceSpans[0].Resource, workloadIDAttributeKey)
 	if !ok || value.GetStringValue() != "workload-4" {
 		t.Fatalf("expected forwarded request to include workload id, got %v", value)
+	}
+	value, ok = findAttribute(forwarded.ResourceSpans[0].Resource, messageIDAttributeKey)
+	if !ok || value.GetStringValue() != "message-4" {
+		t.Fatalf("expected forwarded request to include message id, got %v", value)
+	}
+}
+
+func TestProxyClearsMessageID(t *testing.T) {
+	server, listener, requests := startCaptureServer(t)
+	defer server.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	proxy, err := Start(ctx, Config{TracingAddress: listener.Addr().String(), ThreadID: "thread-5"})
+	if err != nil {
+		t.Fatalf("start proxy: %v", err)
+	}
+	defer proxy.Close()
+
+	conn, err := grpc.NewClient(ListenAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer conn.Close()
+
+	client := collectortracev1.NewTraceServiceClient(conn)
+	proxy.SetMessageID("message-5")
+	_, err = client.Export(ctx, &collectortracev1.ExportTraceServiceRequest{
+		ResourceSpans: []*tracev1.ResourceSpans{{Resource: &resourcev1.Resource{}}},
+	})
+	if err != nil {
+		t.Fatalf("export via proxy: %v", err)
+	}
+	forwarded := awaitRequest(t, requests)
+	if value, ok := findAttribute(forwarded.ResourceSpans[0].Resource, messageIDAttributeKey); !ok || value.GetStringValue() != "message-5" {
+		t.Fatalf("expected forwarded request to include message id, got %v", value)
+	}
+
+	proxy.ClearMessageID()
+	_, err = client.Export(ctx, &collectortracev1.ExportTraceServiceRequest{
+		ResourceSpans: []*tracev1.ResourceSpans{{Resource: &resourcev1.Resource{}}},
+	})
+	if err != nil {
+		t.Fatalf("export via proxy: %v", err)
+	}
+	forwarded = awaitRequest(t, requests)
+	if _, ok := findAttribute(forwarded.ResourceSpans[0].Resource, messageIDAttributeKey); ok {
+		t.Fatal("expected message id to be cleared")
 	}
 }
 


### PR DESCRIPTION
## Summary
- inject agyn.thread.message.id resource attribute in tracing proxy exports
- set message id per processed message in the daemon
- extend tracing proxy tests and threads gateway fakes

## Testing
- go test ./...
- go vet ./...