### PR TITLE
Add room-scoped notifications subscribe

### DIFF
--- a/internal/platform/notifications.go
+++ b/internal/platform/notifications.go
@@ -24,7 +24,8 @@ func (n *Notifications) Subscribe(ctx context.Context, agentID string) (Subscrib
 	if agentID == "" {
 		return nil, fmt.Errorf("agent id is required")
 	}
-	// NOTE: SubscribeRequest currently has no rooms field; server-side filtering
-	// must ensure the agent only receives thread_participant:{agentID} events.
-	return n.client.Subscribe(ctx, &notificationsv1.SubscribeRequest{})
+	request := &notificationsv1.SubscribeRequest{
+		Rooms: []string{fmt.Sprintf("thread_participant:%s", agentID)},
+	}
+	return n.client.Subscribe(ctx, request)
 }


### PR DESCRIPTION
## Summary
- send room-scoped Subscribe requests for notifications using the agent identity

## Room list derivation
Rooms are derived from the agent id as `thread_participant:{agentID}`.

## Testing
- go test ./...

Refs https://github.com/agynio/architecture/issues/142 (#142)