### PR TITLE
fix(daemon): enable codex otel config

### DIFF
--- a/internal/daemon/claude_test.go
+++ b/internal/daemon/claude_test.go
@@ -91,6 +91,10 @@ func (f *fakeClaudeThreadsClient) GetUnackedMessages(ctx context.Context, in *th
 	return nil, fmt.Errorf("GetUnackedMessages not implemented")
 }
 
+func (f *fakeClaudeThreadsClient) GetUnackedMessageCounts(ctx context.Context, in *threadsv1.GetUnackedMessageCountsRequest, opts ...grpc.CallOption) (*threadsv1.GetUnackedMessageCountsResponse, error) {
+	return nil, fmt.Errorf("GetUnackedMessageCounts not implemented")
+}
+
 func (f *fakeClaudeThreadsClient) AckMessages(ctx context.Context, in *threadsv1.AckMessagesRequest, opts ...grpc.CallOption) (*threadsv1.AckMessagesResponse, error) {
 	f.ackRequests = append(f.ackRequests, in)
 	return &threadsv1.AckMessagesResponse{}, nil

--- a/internal/daemon/codexconfig.go
+++ b/internal/daemon/codexconfig.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/agynio/agynd-cli/internal/config"
+	"github.com/agynio/agynd-cli/internal/tracingproxy"
 )
 
 const codexConfigTemplate = `model_provider = "platform"
@@ -14,7 +15,7 @@ approval_policy = "never"
 sandbox_mode = "danger-full-access"
 
 [otel]
-trace_exporter = { otlp-grpc = { endpoint = "http://localhost:4317" } }
+trace_exporter = { otlp-grpc = { endpoint = %q } }
 metrics_exporter = "none"
 exporter = "none"
 
@@ -39,7 +40,8 @@ func writeCodexConfig(llmBaseURL string, mcpServers []config.MCPServer) (string,
 }
 
 func codexConfig(llmBaseURL string, mcpServers []config.MCPServer) string {
-	payload := fmt.Sprintf(codexConfigTemplate, llmBaseURL)
+	otlpEndpoint := "http://" + tracingproxy.ListenAddress
+	payload := fmt.Sprintf(codexConfigTemplate, otlpEndpoint, llmBaseURL)
 	if len(mcpServers) == 0 {
 		return payload
 	}

--- a/internal/daemon/codexconfig.go
+++ b/internal/daemon/codexconfig.go
@@ -13,6 +13,11 @@ const codexConfigTemplate = `model_provider = "platform"
 approval_policy = "never"
 sandbox_mode = "danger-full-access"
 
+[otel]
+trace_exporter = { otlp-grpc = { endpoint = "http://localhost:4317" } }
+metrics_exporter = "none"
+exporter = "none"
+
 [model_providers.platform]
 name = "Agyn LLM"
 base_url = %q

--- a/internal/daemon/codexconfig_test.go
+++ b/internal/daemon/codexconfig_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/agynio/agynd-cli/internal/config"
+	"github.com/agynio/agynd-cli/internal/tracingproxy"
 )
 
 func TestWriteCodexConfig(t *testing.T) {
@@ -14,6 +15,7 @@ func TestWriteCodexConfig(t *testing.T) {
 	t.Setenv("HOME", tmpHome)
 
 	baseURL := "https://example.com"
+	otlpEndpoint := "http://" + tracingproxy.ListenAddress
 	codexHome, err := writeCodexConfig(baseURL, nil)
 	if err != nil {
 		t.Fatalf("expected config to be written, got %v", err)
@@ -35,7 +37,7 @@ approval_policy = "never"
 sandbox_mode = "danger-full-access"
 
 [otel]
-trace_exporter = { otlp-grpc = { endpoint = "http://localhost:4317" } }
+trace_exporter = { otlp-grpc = { endpoint = %q } }
 metrics_exporter = "none"
 exporter = "none"
 
@@ -44,7 +46,7 @@ name = "Agyn LLM"
 base_url = %q
 env_key = "OPENAI_API_KEY"
 wire_api = "responses"
-`, baseURL)
+`, otlpEndpoint, baseURL)
 	if string(content) != expected {
 		t.Fatalf("expected config %q, got %q", expected, string(content))
 	}
@@ -54,6 +56,7 @@ func TestWriteCodexConfigHomeFallback(t *testing.T) {
 	t.Setenv("HOME", "")
 
 	baseURL := "https://example.com"
+	otlpEndpoint := "http://" + tracingproxy.ListenAddress
 	codexHome, err := writeCodexConfig(baseURL, nil)
 	if err != nil {
 		t.Fatalf("expected config to be written, got %v", err)
@@ -75,7 +78,7 @@ approval_policy = "never"
 sandbox_mode = "danger-full-access"
 
 [otel]
-trace_exporter = { otlp-grpc = { endpoint = "http://localhost:4317" } }
+trace_exporter = { otlp-grpc = { endpoint = %q } }
 metrics_exporter = "none"
 exporter = "none"
 
@@ -84,7 +87,7 @@ name = "Agyn LLM"
 base_url = %q
 env_key = "OPENAI_API_KEY"
 wire_api = "responses"
-`, baseURL)
+`, otlpEndpoint, baseURL)
 	if string(content) != expected {
 		t.Fatalf("expected config %q, got %q", expected, string(content))
 	}
@@ -95,6 +98,7 @@ func TestWriteCodexConfigWithMCPServers(t *testing.T) {
 	t.Setenv("HOME", tmpHome)
 
 	baseURL := "https://example.com"
+	otlpEndpoint := "http://" + tracingproxy.ListenAddress
 	mcpServers := []config.MCPServer{
 		{Name: "memory", Port: 8100},
 		{Name: "cache", Port: 8200},
@@ -120,7 +124,7 @@ approval_policy = "never"
 sandbox_mode = "danger-full-access"
 
 [otel]
-trace_exporter = { otlp-grpc = { endpoint = "http://localhost:4317" } }
+trace_exporter = { otlp-grpc = { endpoint = %q } }
 metrics_exporter = "none"
 exporter = "none"
 
@@ -129,7 +133,7 @@ name = "Agyn LLM"
 base_url = %q
 env_key = "OPENAI_API_KEY"
 wire_api = "responses"
-`, baseURL) +
+`, otlpEndpoint, baseURL) +
 		"\n[mcp_servers.memory]\n" +
 		"url = \"http://localhost:8100/mcp\"\n" +
 		"required = true\n" +

--- a/internal/daemon/codexconfig_test.go
+++ b/internal/daemon/codexconfig_test.go
@@ -34,6 +34,11 @@ func TestWriteCodexConfig(t *testing.T) {
 approval_policy = "never"
 sandbox_mode = "danger-full-access"
 
+[otel]
+trace_exporter = { otlp-grpc = { endpoint = "http://localhost:4317" } }
+metrics_exporter = "none"
+exporter = "none"
+
 [model_providers.platform]
 name = "Agyn LLM"
 base_url = %q
@@ -68,6 +73,11 @@ func TestWriteCodexConfigHomeFallback(t *testing.T) {
 	expected := fmt.Sprintf(`model_provider = "platform"
 approval_policy = "never"
 sandbox_mode = "danger-full-access"
+
+[otel]
+trace_exporter = { otlp-grpc = { endpoint = "http://localhost:4317" } }
+metrics_exporter = "none"
+exporter = "none"
 
 [model_providers.platform]
 name = "Agyn LLM"
@@ -108,6 +118,11 @@ func TestWriteCodexConfigWithMCPServers(t *testing.T) {
 	expected := fmt.Sprintf(`model_provider = "platform"
 approval_policy = "never"
 sandbox_mode = "danger-full-access"
+
+[otel]
+trace_exporter = { otlp-grpc = { endpoint = "http://localhost:4317" } }
+metrics_exporter = "none"
+exporter = "none"
 
 [model_providers.platform]
 name = "Agyn LLM"

--- a/internal/platform/consumer_test.go
+++ b/internal/platform/consumer_test.go
@@ -66,6 +66,10 @@ func (f *fakeThreadsClient) GetUnackedMessages(ctx context.Context, in *threadsv
 	return resp, nil
 }
 
+func (f *fakeThreadsClient) GetUnackedMessageCounts(ctx context.Context, in *threadsv1.GetUnackedMessageCountsRequest, opts ...grpc.CallOption) (*threadsv1.GetUnackedMessageCountsResponse, error) {
+	return nil, fmt.Errorf("GetUnackedMessageCounts not implemented")
+}
+
 func (f *fakeThreadsClient) AckMessages(ctx context.Context, in *threadsv1.AckMessagesRequest, opts ...grpc.CallOption) (*threadsv1.AckMessagesResponse, error) {
 	return nil, fmt.Errorf("AckMessages not implemented")
 }


### PR DESCRIPTION
## Summary
- add Codex OTEL config with OTLP gRPC endpoint and disable metrics export
- update codex config tests for the new otel section
- extend ThreadsGatewayClient fakes to match interface changes

## Testing
- buf generate buf.build/agynio/api --path agynio/api/gateway/v1 --include-imports
- go test ./...
- go vet ./...

Refs #111