### PR TITLE
fix: bind OTLP proxy to 127.0.0.1

### DIFF
--- a/internal/tracingproxy/proxy.go
+++ b/internal/tracingproxy/proxy.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	ListenAddress          = "localhost:4317"
+	ListenAddress          = "127.0.0.1:4317"
 	threadIDAttributeKey   = "agyn.thread.id"
 	messageIDAttributeKey  = "agyn.thread.message.id"
 	workloadIDAttributeKey = "agyn.workload.id"


### PR DESCRIPTION
## Summary
- bind tracing proxy to 127.0.0.1 to avoid localhost ambiguity
- use updated local OTLP endpoint for generated configs and env vars

## Testing
- buf generate buf.build/agynio/api --path agynio/api/gateway/v1 --include-imports
- go test ./...
- go vet ./...

Closes #115