### PR TITLE
fix(subscriber): use self notification room

### DIFF
--- a/internal/daemon/agn.go
+++ b/internal/daemon/agn.go
@@ -89,7 +89,7 @@ func newAgnDaemon(ctx context.Context, cfg config.Config, version string) (*Daem
 		threads:      setup.threads,
 		agents:       setup.agents,
 		runners:      setup.runners,
-		subscriber:   subscriber.New(setup.notifications, cfg.AgentID.String(), cfg.ThreadID),
+		subscriber:   subscriber.New(setup.notifications, cfg.ThreadID),
 		consumer:     platform.NewConsumer(setup.threads, pageSize, pageTimeout),
 		agn:          agnClient,
 		agent:        setup.agent,

--- a/internal/daemon/claude.go
+++ b/internal/daemon/claude.go
@@ -88,7 +88,7 @@ func newClaudeDaemon(ctx context.Context, cfg config.Config, version string) (*D
 		threads:      setup.threads,
 		agents:       setup.agents,
 		runners:      setup.runners,
-		subscriber:   subscriber.New(setup.notifications, cfg.AgentID.String(), cfg.ThreadID),
+		subscriber:   subscriber.New(setup.notifications, cfg.ThreadID),
 		consumer:     platform.NewConsumer(setup.threads, pageSize, pageTimeout),
 		claude:       claudeClient,
 		agent:        setup.agent,

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -281,7 +281,7 @@ func newCodexDaemon(ctx context.Context, cfg config.Config, version string) (*Da
 		threads:      setup.threads,
 		agents:       setup.agents,
 		runners:      setup.runners,
-		subscriber:   subscriber.New(setup.notifications, cfg.AgentID.String(), cfg.ThreadID),
+		subscriber:   subscriber.New(setup.notifications, cfg.ThreadID),
 		consumer:     platform.NewConsumer(setup.threads, pageSize, pageTimeout),
 		codex:        codexClient,
 		mapping:      threadsMapping,

--- a/internal/platform/notifications.go
+++ b/internal/platform/notifications.go
@@ -2,11 +2,12 @@ package platform
 
 import (
 	"context"
-	"fmt"
 
 	gatewayv1 "github.com/agynio/agynd-cli/.gen/go/agynio/api/gateway/v1"
 	notificationsv1 "github.com/agynio/agynd-cli/.gen/go/agynio/api/notifications/v1"
 )
+
+const threadParticipantSelfRoom = "thread_participant:me"
 
 type SubscribeStream interface {
 	Recv() (*notificationsv1.SubscribeResponse, error)
@@ -20,12 +21,9 @@ func NewNotifications(client gatewayv1.NotificationsGatewayClient) *Notification
 	return &Notifications{client: client}
 }
 
-func (n *Notifications) Subscribe(ctx context.Context, agentID string) (SubscribeStream, error) {
-	if agentID == "" {
-		return nil, fmt.Errorf("agent id is required")
-	}
+func (n *Notifications) Subscribe(ctx context.Context) (SubscribeStream, error) {
 	request := &notificationsv1.SubscribeRequest{
-		Rooms: []string{fmt.Sprintf("thread_participant:%s", agentID)},
+		Rooms: []string{threadParticipantSelfRoom},
 	}
 	return n.client.Subscribe(ctx, request)
 }

--- a/internal/subscriber/subscriber.go
+++ b/internal/subscriber/subscriber.go
@@ -17,17 +17,16 @@ const messageCreatedEvent = "message.created"
 
 type Subscriber struct {
 	client   notificationsClient
-	agentID  string
 	threadID string
 	wake     chan struct{}
 }
 
 type notificationsClient interface {
-	Subscribe(ctx context.Context, agentID string) (platform.SubscribeStream, error)
+	Subscribe(ctx context.Context) (platform.SubscribeStream, error)
 }
 
-func New(client notificationsClient, agentID string, threadID string) *Subscriber {
-	return &Subscriber{client: client, agentID: agentID, threadID: threadID, wake: make(chan struct{}, 1)}
+func New(client notificationsClient, threadID string) *Subscriber {
+	return &Subscriber{client: client, threadID: threadID, wake: make(chan struct{}, 1)}
 }
 
 func (s *Subscriber) Run(ctx context.Context) error {
@@ -36,7 +35,7 @@ func (s *Subscriber) Run(ctx context.Context) error {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		stream, err := s.client.Subscribe(ctx, s.agentID)
+		stream, err := s.client.Subscribe(ctx)
 		if err != nil {
 			log.Printf("subscriber: subscribe failed: %v", err)
 			if err := waitWithBackoff(ctx, backoff); err != nil {

--- a/internal/subscriber/subscriber_test.go
+++ b/internal/subscriber/subscriber_test.go
@@ -18,9 +18,8 @@ type fakeNotifications struct {
 	called  int
 }
 
-func (f *fakeNotifications) Subscribe(_ context.Context, agentID string) (platform.SubscribeStream, error) {
+func (f *fakeNotifications) Subscribe(_ context.Context) (platform.SubscribeStream, error) {
 	f.called++
-	f.agentID = agentID
 	return f.stream, nil
 }
 
@@ -121,7 +120,7 @@ func TestSubscriberWakeOnMatchingThread(t *testing.T) {
 	responses := make(chan *notificationsv1.SubscribeResponse, 1)
 	stream := &fakeStream{responses: responses}
 	client := &fakeNotifications{stream: stream}
-	sub := New(client, "agent-1", threadID)
+	sub := New(client, threadID)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
@@ -148,7 +147,7 @@ func TestSubscriberIgnoreOtherThread(t *testing.T) {
 	responses := make(chan *notificationsv1.SubscribeResponse, 1)
 	stream := &fakeStream{responses: responses}
 	client := &fakeNotifications{stream: stream}
-	sub := New(client, "agent-1", threadID)
+	sub := New(client, threadID)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)


### PR DESCRIPTION
Updates agynd notification subscriber to use thread_participant:me and removes AGENT_ID from notification Subscribe room construction. AGENT_ID remains used for agent resource calls.\n\nTests: go test ./internal/subscriber