### PR TITLE
fix: include agent binaries on subprocess PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- daemon: include `/agyn-bin` in agent subprocess `PATH` so the injected agent CLI binary is discoverable by name.
+
 ## v0.14.9
 - tracing: inject agyn.thread.message.id for message-id correlation.
 

--- a/internal/daemon/env.go
+++ b/internal/daemon/env.go
@@ -6,15 +6,21 @@ import (
 )
 
 const (
-	cliPathPrefix     = "/agyn-bin/cli"
-	codexDefaultHome  = "/tmp"
+	cliPathPrefix    = "/agyn-bin/cli"
+	agentBinPath     = "/agyn-bin"
+	codexDefaultHome = "/tmp"
 )
 
+func agentPathPrefix() string {
+	return cliPathPrefix + string(os.PathListSeparator) + agentBinPath
+}
+
 func prependCLIPath(pathValue string) string {
+	prefix := agentPathPrefix()
 	if pathValue == "" {
-		return cliPathPrefix
+		return prefix
 	}
-	return cliPathPrefix + string(os.PathListSeparator) + pathValue
+	return prefix + string(os.PathListSeparator) + pathValue
 }
 
 func agentPathValue() string {

--- a/internal/daemon/env_test.go
+++ b/internal/daemon/env_test.go
@@ -7,14 +7,15 @@ import (
 
 func TestPrependCLIPathEmpty(t *testing.T) {
 	got := prependCLIPath("")
-	if got != cliPathPrefix {
-		t.Fatalf("expected %q, got %q", cliPathPrefix, got)
+	expected := agentPathPrefix()
+	if got != expected {
+		t.Fatalf("expected %q, got %q", expected, got)
 	}
 }
 
 func TestPrependCLIPathExisting(t *testing.T) {
 	basePath := "/usr/local/bin"
-	expected := cliPathPrefix + string(os.PathListSeparator) + basePath
+	expected := agentPathPrefix() + string(os.PathListSeparator) + basePath
 	got := prependCLIPath(basePath)
 	if got != expected {
 		t.Fatalf("expected %q, got %q", expected, got)


### PR DESCRIPTION
Prepends /agyn-bin in addition to /agyn-bin/cli when spawning agent subprocesses. This keeps agyn available from /agyn-bin/cli and makes injected agent binaries (claude/codex/agn) available by name from /agyn-bin.\n\nValidation:\n- buf generate buf.build/agynio/api --path agynio/api/gateway/v1 --include-imports\n- go test ./internal/daemon ./internal/config ./internal/codexbridge ./internal/uuidutil