### PR TITLE
fix(daemon): remove turn completion timeout

### DIFF
--- a/internal/daemon/agn.go
+++ b/internal/daemon/agn.go
@@ -111,7 +111,7 @@ func (d *Daemon) handleAgnMessage(ctx context.Context, message platform.Message)
 		ThreadID: threadID,
 	}, nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("run agn turn for message %s: %w", message.ID, err)
 	}
 	response := strings.TrimSpace(result.Response)
 	if response == "" {
@@ -121,7 +121,7 @@ func (d *Daemon) handleAgnMessage(ctx context.Context, message platform.Message)
 	_, err = d.threads.SendMessage(publishCtx, threadID, d.cfg.AgentID.String(), response, nil)
 	cancel()
 	if err != nil {
-		return err
+		return fmt.Errorf("publish agn response for message %s: %w", message.ID, err)
 	}
 	ackCtx, cancel := context.WithTimeout(ctx, messageAckTimeout)
 	err = d.threads.AckMessages(ackCtx, d.cfg.AgentID.String(), []string{message.ID})

--- a/internal/daemon/claude.go
+++ b/internal/daemon/claude.go
@@ -119,13 +119,11 @@ func (d *Daemon) handleClaudeMessage(ctx context.Context, message platform.Messa
 		return err
 	}
 	if err := d.ensureClaudeReady(ctx); err != nil {
-		return err
+		return fmt.Errorf("prepare claude MCP servers: %w", err)
 	}
-	turnCtx, cancel := context.WithTimeout(ctx, turnCompletionTimeout)
-	defer cancel()
-	result, err := d.claude.Turn(turnCtx, claude.TurnParams{Prompt: inputText}, nil)
+	result, err := d.claude.Turn(ctx, claude.TurnParams{Prompt: inputText}, nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("run claude turn for message %s: %w", message.ID, err)
 	}
 	response := strings.TrimSpace(result.Response)
 	if response == "" {
@@ -135,7 +133,7 @@ func (d *Daemon) handleClaudeMessage(ctx context.Context, message platform.Messa
 	_, err = d.threads.SendMessage(publishCtx, threadID, d.cfg.AgentID.String(), response, nil)
 	cancel()
 	if err != nil {
-		return err
+		return fmt.Errorf("publish claude response for message %s: %w", message.ID, err)
 	}
 	ackCtx, cancel := context.WithTimeout(ctx, messageAckTimeout)
 	err = d.threads.AckMessages(ackCtx, d.cfg.AgentID.String(), []string{message.ID})

--- a/internal/daemon/claude_test.go
+++ b/internal/daemon/claude_test.go
@@ -20,13 +20,15 @@ import (
 type fakeClaudeClient struct {
 	turnCalls int
 	params    claude.TurnParams
+	ctx       context.Context
 	result    *claude.TurnResult
 	err       error
 }
 
-func (f *fakeClaudeClient) Turn(_ context.Context, params claude.TurnParams, _ claude.EventHandler) (*claude.TurnResult, error) {
+func (f *fakeClaudeClient) Turn(ctx context.Context, params claude.TurnParams, _ claude.EventHandler) (*claude.TurnResult, error) {
 	f.turnCalls++
 	f.params = params
+	f.ctx = ctx
 	return f.result, f.err
 }
 
@@ -126,6 +128,9 @@ func TestHandleClaudeMessageSuccess(t *testing.T) {
 	}
 	if client.params.Prompt != "hello" {
 		t.Fatalf("expected prompt %q, got %q", "hello", client.params.Prompt)
+	}
+	if _, ok := client.ctx.Deadline(); ok {
+		t.Fatal("expected claude turn context without completion deadline")
 	}
 	if len(threadsClient.sendRequests) != 1 {
 		t.Fatalf("expected SendMessage to be called once, got %d", len(threadsClient.sendRequests))

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -86,7 +86,7 @@ type runnersClient interface {
 
 type messageSubscriber interface {
 	Run(ctx context.Context) error
-	Ready() <-chan struct{}
+	Started() <-chan struct{}
 	Wake() <-chan struct{}
 }
 
@@ -334,7 +334,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case <-d.subscriber.Ready():
+	case <-d.subscriber.Started():
 	}
 
 	backoff := syncRetryInitialBackoff

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -59,8 +59,9 @@ type Daemon struct {
 	claudeReadyMu sync.Mutex
 	claudeReady   bool
 
-	processing atomic.Bool
-	syncMu     sync.Mutex
+	processing     atomic.Bool
+	processingWake chan struct{}
+	syncMu         sync.Mutex
 }
 
 type platformConn interface {
@@ -85,6 +86,7 @@ type runnersClient interface {
 
 type messageSubscriber interface {
 	Run(ctx context.Context) error
+	Ready() <-chan struct{}
 	Wake() <-chan struct{}
 }
 
@@ -321,6 +323,7 @@ func (d *Daemon) Close() {
 }
 
 func (d *Daemon) Run(ctx context.Context) error {
+	d.ensureProcessingWake()
 	go d.runKeepalive(ctx)
 
 	go func() {
@@ -328,6 +331,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 			log.Printf("subscriber stopped: %v", err)
 		}
 	}()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-d.subscriber.Ready():
+	}
 
 	backoff := syncRetryInitialBackoff
 	var retryTimer *time.Timer
@@ -396,6 +404,22 @@ func (d *Daemon) Run(ctx context.Context) error {
 	}
 }
 
+func (d *Daemon) ensureProcessingWake() {
+	if d.processingWake == nil {
+		d.processingWake = make(chan struct{}, 1)
+	}
+}
+
+func (d *Daemon) signalProcessingStarted() {
+	if d.processingWake == nil {
+		return
+	}
+	select {
+	case d.processingWake <- struct{}{}:
+	default:
+	}
+}
+
 func nextSyncRetryBackoff(current time.Duration) time.Duration {
 	if current <= 0 {
 		return syncRetryInitialBackoff
@@ -410,6 +434,7 @@ func nextSyncRetryBackoff(current time.Duration) time.Duration {
 func (d *Daemon) syncMessages(ctx context.Context) error {
 	d.syncMu.Lock()
 	d.processing.Store(true)
+	d.signalProcessingStarted()
 	defer func() {
 		d.processing.Store(false)
 		d.syncMu.Unlock()

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -23,13 +23,14 @@ import (
 )
 
 const (
-	pageSize              int32 = 100
-	pageTimeout                 = 30 * time.Second
-	turnStartTimeout            = 5 * time.Minute
-	turnCompletionTimeout       = 5 * time.Minute
-	messagePublishTimeout       = 15 * time.Second
-	messageAckTimeout           = 15 * time.Second
-	mcpReadyTimeout             = 120 * time.Second
+	pageSize                int32 = 100
+	pageTimeout                   = 30 * time.Second
+	turnStartTimeout              = 5 * time.Minute
+	messagePublishTimeout         = 15 * time.Second
+	messageAckTimeout             = 15 * time.Second
+	mcpReadyTimeout               = 120 * time.Second
+	syncRetryInitialBackoff       = 1 * time.Second
+	syncRetryMaxBackoff           = 30 * time.Second
 )
 
 const (
@@ -45,8 +46,8 @@ type Daemon struct {
 	threads       *platform.Threads
 	agents        gatewayv1.AgentsGatewayClient
 	runners       runnersClient
-	subscriber    *subscriber.Subscriber
-	consumer      *platform.Consumer
+	subscriber    messageSubscriber
+	consumer      messageConsumer
 	codex         codexClient
 	mapping       *codexbridge.ThreadMapping
 	mappingStore  *codexbridge.ThreadMappingStore
@@ -80,6 +81,15 @@ type claudeClient interface {
 
 type runnersClient interface {
 	TouchWorkload(ctx context.Context, workloadID string) error
+}
+
+type messageSubscriber interface {
+	Run(ctx context.Context) error
+	Wake() <-chan struct{}
+}
+
+type messageConsumer interface {
+	Sync(ctx context.Context, participantID string, threadID string, handle func(platform.Message) error) error
 }
 
 type platformSetup struct {
@@ -311,9 +321,7 @@ func (d *Daemon) Close() {
 }
 
 func (d *Daemon) Run(ctx context.Context) error {
-	if err := d.syncMessages(ctx); err != nil {
-		return err
-	}
+	go d.runKeepalive(ctx)
 
 	go func() {
 		if err := d.subscriber.Run(ctx); err != nil && ctx.Err() == nil {
@@ -321,7 +329,52 @@ func (d *Daemon) Run(ctx context.Context) error {
 		}
 	}()
 
-	go d.runKeepalive(ctx)
+	backoff := syncRetryInitialBackoff
+	var retryTimer *time.Timer
+	var retry <-chan time.Time
+	defer func() {
+		if retryTimer != nil {
+			retryTimer.Stop()
+		}
+	}()
+	scheduleRetry := func(delay time.Duration) {
+		if retryTimer == nil {
+			retryTimer = time.NewTimer(delay)
+		} else {
+			if !retryTimer.Stop() {
+				select {
+				case <-retryTimer.C:
+				default:
+				}
+			}
+			retryTimer.Reset(delay)
+		}
+		retry = retryTimer.C
+	}
+	clearRetry := func() {
+		if retryTimer != nil {
+			if !retryTimer.Stop() {
+				select {
+				case <-retryTimer.C:
+				default:
+				}
+			}
+		}
+		retry = nil
+		backoff = syncRetryInitialBackoff
+	}
+	scheduleFailureRetry := func(operation string, err error) {
+		delay := backoff
+		log.Printf("%s failed: %v; retrying in %s", operation, err, delay)
+		backoff = nextSyncRetryBackoff(backoff)
+		scheduleRetry(delay)
+	}
+
+	if err := d.syncMessages(ctx); err != nil {
+		scheduleFailureRetry("initial sync messages", err)
+	} else {
+		clearRetry()
+	}
 
 	for {
 		select {
@@ -329,10 +382,29 @@ func (d *Daemon) Run(ctx context.Context) error {
 			return ctx.Err()
 		case <-d.subscriber.Wake():
 			if err := d.syncMessages(ctx); err != nil {
-				log.Printf("sync messages failed: %v", err)
+				scheduleFailureRetry("sync messages", err)
+			} else {
+				clearRetry()
+			}
+		case <-retry:
+			if err := d.syncMessages(ctx); err != nil {
+				scheduleFailureRetry("sync messages retry", err)
+			} else {
+				clearRetry()
 			}
 		}
 	}
+}
+
+func nextSyncRetryBackoff(current time.Duration) time.Duration {
+	if current <= 0 {
+		return syncRetryInitialBackoff
+	}
+	next := current * 2
+	if next > syncRetryMaxBackoff {
+		return syncRetryMaxBackoff
+	}
+	return next
 }
 
 func (d *Daemon) syncMessages(ctx context.Context) error {
@@ -343,13 +415,16 @@ func (d *Daemon) syncMessages(ctx context.Context) error {
 		d.syncMu.Unlock()
 	}()
 
-	return d.consumer.Sync(ctx, d.cfg.AgentID.String(), d.cfg.ThreadID, func(message platform.Message) error {
+	if err := d.consumer.Sync(ctx, d.cfg.AgentID.String(), d.cfg.ThreadID, func(message platform.Message) error {
 		if d.tracingProxy != nil {
 			d.tracingProxy.SetMessageID(message.ID)
 			defer d.tracingProxy.ClearMessageID()
 		}
 		return d.handleMessage(ctx, message)
-	})
+	}); err != nil {
+		return fmt.Errorf("sync unacked messages: %w", err)
+	}
+	return nil
 }
 
 func (d *Daemon) handleMessage(ctx context.Context, message platform.Message) error {
@@ -385,19 +460,17 @@ func (d *Daemon) handleCodexMessage(ctx context.Context, message platform.Messag
 	})
 	cancel()
 	if err != nil {
-		return err
+		return fmt.Errorf("start codex turn for message %s: %w", message.ID, err)
 	}
 	turnID := strings.TrimSpace(turnResp.Turn.ID)
 	if turnID == "" {
 		return fmt.Errorf("codex turn id missing")
 	}
 	completionCh := d.tracker.Register(turnID)
-	completionCtx, cancel := context.WithTimeout(ctx, turnCompletionTimeout)
-	defer cancel()
 	select {
 	case result := <-completionCh:
 		if result.Err != nil {
-			return result.Err
+			return fmt.Errorf("codex turn %s failed: %w", turnID, result.Err)
 		}
 		if result.ThreadID != codexThreadID {
 			return fmt.Errorf("turn %s thread mismatch", turnID)
@@ -409,7 +482,7 @@ func (d *Daemon) handleCodexMessage(ctx context.Context, message platform.Messag
 		_, err := d.threads.SendMessage(publishCtx, threadID, d.cfg.AgentID.String(), result.Message, nil)
 		cancel()
 		if err != nil {
-			return err
+			return fmt.Errorf("publish codex response for message %s: %w", message.ID, err)
 		}
 		ackCtx, cancel := context.WithTimeout(ctx, messageAckTimeout)
 		err = d.threads.AckMessages(ackCtx, d.cfg.AgentID.String(), []string{message.ID})
@@ -418,9 +491,9 @@ func (d *Daemon) handleCodexMessage(ctx context.Context, message platform.Messag
 			return fmt.Errorf("ack message %s: %w", message.ID, err)
 		}
 		return nil
-	case <-completionCtx.Done():
+	case <-ctx.Done():
 		d.tracker.Cancel(turnID)
-		return completionCtx.Err()
+		return fmt.Errorf("wait for codex turn %s completion: %w", turnID, ctx.Err())
 	}
 }
 
@@ -433,16 +506,16 @@ func (d *Daemon) ensureCodexThread(ctx context.Context, platformThreadID string)
 		updated.LastUsedAtUnixMs = time.Now().UnixMilli()
 		d.mapping.SetRecord(updated)
 		if err := d.mappingStore.Save(updated); err != nil {
-			return "", err
+			return "", fmt.Errorf("save codex thread mapping for platform thread %s: %w", platformThreadID, err)
 		}
 		return record.CodexThreadID, nil
 	}
 	if err := waitForMCPServers(ctx, d.cfg.MCPServers, mcpReadyTimeout); err != nil {
-		return "", err
+		return "", fmt.Errorf("wait for MCP servers before codex thread: %w", err)
 	}
 	record, ok, err := d.mappingStore.Load(platformThreadID)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("load codex thread mapping for platform thread %s: %w", platformThreadID, err)
 	}
 	if ok {
 		if err := d.resumeCodexThread(ctx, record.CodexThreadID); err != nil {
@@ -451,7 +524,7 @@ func (d *Daemon) ensureCodexThread(ctx context.Context, platformThreadID string)
 		record.LastUsedAtUnixMs = time.Now().UnixMilli()
 		d.mapping.SetRecord(record)
 		if err := d.mappingStore.Save(record); err != nil {
-			return "", err
+			return "", fmt.Errorf("save codex thread mapping for platform thread %s: %w", platformThreadID, err)
 		}
 		return record.CodexThreadID, nil
 	}
@@ -468,7 +541,7 @@ func (d *Daemon) ensureCodexThread(ctx context.Context, platformThreadID string)
 	}
 	d.mapping.SetRecord(newRecord)
 	if err := d.mappingStore.Save(newRecord); err != nil {
-		return "", err
+		return "", fmt.Errorf("save codex thread mapping for platform thread %s: %w", platformThreadID, err)
 	}
 	return codexThreadID, nil
 }

--- a/internal/daemon/daemon_codex_test.go
+++ b/internal/daemon/daemon_codex_test.go
@@ -2,19 +2,28 @@ package daemon
 
 import (
 	"context"
+	"fmt"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	agentsv1 "github.com/agynio/agynd-cli/.gen/go/agynio/api/agents/v1"
 	"github.com/agynio/agynd-cli/internal/codexbridge"
 	"github.com/agynio/agynd-cli/internal/config"
+	"github.com/agynio/agynd-cli/internal/platform"
 	codex "github.com/agynio/codex-sdk-go"
+	"github.com/google/uuid"
 )
 
 type fakeCodexClient struct {
+	mu                sync.Mutex
 	startThreadCalls  int
 	resumeThreadCalls int
 	startParams       *codex.ThreadStartParams
 	resumeParams      *codex.ThreadResumeParams
+	startTurnCtx      context.Context
+	startTurnErr      error
 }
 
 func (f *fakeCodexClient) StartThread(_ context.Context, params *codex.ThreadStartParams) (*codex.ThreadStartResponse, error) {
@@ -29,8 +38,20 @@ func (f *fakeCodexClient) ResumeThread(_ context.Context, params *codex.ThreadRe
 	return &codex.ThreadResumeResponse{Thread: codex.Thread{ID: params.ThreadID}}, nil
 }
 
-func (f *fakeCodexClient) StartTurn(_ context.Context, _ *codex.TurnStartParams) (*codex.TurnStartResponse, error) {
+func (f *fakeCodexClient) StartTurn(ctx context.Context, _ *codex.TurnStartParams) (*codex.TurnStartResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.startTurnCtx = ctx
+	if f.startTurnErr != nil {
+		return nil, f.startTurnErr
+	}
 	return &codex.TurnStartResponse{Turn: codex.Turn{ID: "turn-1"}}, nil
+}
+
+func (f *fakeCodexClient) StartTurnContext() context.Context {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.startTurnCtx
 }
 
 func (f *fakeCodexClient) Close() error {
@@ -114,5 +135,69 @@ func TestEnsureCodexThreadStartsNonEphemeral(t *testing.T) {
 	}
 	if stored.CodexThreadID != "codex-started" {
 		t.Fatalf("expected stored codex id %q, got %q", "codex-started", stored.CodexThreadID)
+	}
+}
+
+func TestHandleCodexMessageWaitsWithoutCompletionTimeout(t *testing.T) {
+	store := codexbridge.NewThreadMappingStore(t.TempDir())
+	client := &fakeCodexClient{}
+	daemon := &Daemon{
+		sdk:          SDKCodex,
+		cfg:          config.Config{AgentID: uuid.MustParse(testAgentID), WorkDir: "/tmp"},
+		codex:        client,
+		mapping:      codexbridge.NewThreadMapping(),
+		mappingStore: store,
+		tracker:      codexbridge.NewTurnTracker(),
+		agent:        &agentsv1.Agent{},
+		threads:      platform.NewThreads(&fakeClaudeThreadsClient{}),
+	}
+	message := platform.Message{ID: "msg-1", ThreadID: "thread-1", Body: "hello"}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- daemon.handleCodexMessage(context.Background(), message)
+	}()
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("handleCodexMessage returned before turn completion: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	daemon.tracker.Notify(codexbridge.TurnResult{
+		ThreadID: "codex-started",
+		TurnID:   "turn-1",
+		Message:  "done",
+	})
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("handleCodexMessage did not finish after turn completion")
+	}
+	if client.StartTurnContext() == nil {
+		t.Fatal("expected StartTurn to be called")
+	}
+}
+
+func TestHandleCodexMessageWrapsStartTurnError(t *testing.T) {
+	store := codexbridge.NewThreadMappingStore(t.TempDir())
+	client := &fakeCodexClient{startTurnErr: fmt.Errorf("rpc unavailable")}
+	daemon := &Daemon{
+		sdk:          SDKCodex,
+		cfg:          config.Config{AgentID: uuid.MustParse(testAgentID), WorkDir: "/tmp"},
+		codex:        client,
+		mapping:      codexbridge.NewThreadMapping(),
+		mappingStore: store,
+		tracker:      codexbridge.NewTurnTracker(),
+		agent:        &agentsv1.Agent{},
+	}
+	message := platform.Message{ID: "msg-1", ThreadID: "thread-1", Body: "hello"}
+	err := daemon.handleCodexMessage(context.Background(), message)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "start codex turn for message msg-1") {
+		t.Fatalf("missing operation context: %v", err)
 	}
 }

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2,7 +2,9 @@ package daemon
 
 import (
 	"context"
+	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -28,6 +30,81 @@ func testConfig(sdk string) config.Config {
 		SDK:            sdk,
 		AgentBinary:    binary,
 		WorkDir:        "/tmp",
+	}
+}
+
+type fakeMessageSubscriber struct {
+	runStarted chan struct{}
+	wake       chan struct{}
+	runOnce    sync.Once
+}
+
+func newFakeMessageSubscriber() *fakeMessageSubscriber {
+	return &fakeMessageSubscriber{
+		runStarted: make(chan struct{}),
+		wake:       make(chan struct{}, 1),
+	}
+}
+
+func (f *fakeMessageSubscriber) Run(ctx context.Context) error {
+	f.runOnce.Do(func() { close(f.runStarted) })
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (f *fakeMessageSubscriber) Wake() <-chan struct{} {
+	return f.wake
+}
+
+type fakeMessageConsumer struct {
+	mu     sync.Mutex
+	errors []error
+	calls  int
+}
+
+func (f *fakeMessageConsumer) Sync(_ context.Context, _ string, _ string, _ func(platform.Message) error) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	if len(f.errors) == 0 {
+		return nil
+	}
+	err := f.errors[0]
+	f.errors = f.errors[1:]
+	return err
+}
+
+func (f *fakeMessageConsumer) Calls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+type recordingRunnersClient struct {
+	touched chan struct{}
+}
+
+func (r *recordingRunnersClient) TouchWorkload(_ context.Context, _ string) error {
+	select {
+	case r.touched <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+type blockingMessageConsumer struct {
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (b *blockingMessageConsumer) Sync(ctx context.Context, _ string, _ string, _ func(platform.Message) error) error {
+	b.once.Do(func() { close(b.started) })
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-b.release:
+		return fmt.Errorf("sync released")
 	}
 }
 
@@ -131,5 +208,98 @@ func TestNewClaudeDispatch(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "not yet supported") || strings.Contains(err.Error(), "unknown sdk") {
 		t.Fatalf("unexpected dispatch error: %v", err)
+	}
+}
+
+func TestRunStartsKeepaliveAndSubscriberBeforeInitialSync(t *testing.T) {
+	subscriber := newFakeMessageSubscriber()
+	consumer := &blockingMessageConsumer{started: make(chan struct{}), release: make(chan struct{})}
+	runners := &recordingRunnersClient{touched: make(chan struct{}, 1)}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	daemon := &Daemon{
+		cfg: config.Config{
+			AgentID:    uuid.MustParse(testAgentID),
+			WorkloadID: "workload-1",
+		},
+		runners:    runners,
+		subscriber: subscriber,
+		consumer:   consumer,
+	}
+	daemon.processing.Store(true)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- daemon.Run(ctx)
+	}()
+
+	select {
+	case <-subscriber.runStarted:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("subscriber did not start")
+	}
+	select {
+	case <-runners.touched:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("keepalive did not touch active workload")
+	}
+	select {
+	case <-consumer.started:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("initial sync did not run")
+	}
+	cancel()
+	select {
+	case err := <-errCh:
+		if err == nil || !strings.Contains(err.Error(), "context canceled") {
+			t.Fatalf("unexpected run error: %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Run did not stop")
+	}
+}
+
+func TestRunRetriesSyncAfterFailure(t *testing.T) {
+	subscriber := newFakeMessageSubscriber()
+	consumer := &fakeMessageConsumer{errors: []error{fmt.Errorf("transient")}}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	daemon := &Daemon{
+		cfg:        config.Config{AgentID: uuid.MustParse(testAgentID)},
+		runners:    &fakeRunnersClient{},
+		subscriber: subscriber,
+		consumer:   consumer,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- daemon.Run(ctx)
+	}()
+
+	deadline := time.After(1500 * time.Millisecond)
+	for consumer.Calls() < 2 {
+		select {
+		case <-deadline:
+			t.Fatalf("expected sync retry, got %d calls", consumer.Calls())
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	cancel()
+	select {
+	case <-errCh:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Run did not stop")
+	}
+}
+
+func TestNextSyncRetryBackoffCapsAtMaximum(t *testing.T) {
+	if got := nextSyncRetryBackoff(0); got != syncRetryInitialBackoff {
+		t.Fatalf("expected initial backoff, got %s", got)
+	}
+	if got := nextSyncRetryBackoff(10 * time.Second); got != 20*time.Second {
+		t.Fatalf("expected doubled backoff, got %s", got)
+	}
+	if got := nextSyncRetryBackoff(20 * time.Second); got != syncRetryMaxBackoff {
+		t.Fatalf("expected max backoff, got %s", got)
 	}
 }

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -52,6 +52,10 @@ func (f *fakeMessageSubscriber) Run(ctx context.Context) error {
 	return ctx.Err()
 }
 
+func (f *fakeMessageSubscriber) Ready() <-chan struct{} {
+	return f.runStarted
+}
+
 func (f *fakeMessageSubscriber) Wake() <-chan struct{} {
 	return f.wake
 }
@@ -93,12 +97,22 @@ func (r *recordingRunnersClient) TouchWorkload(_ context.Context, _ string) erro
 }
 
 type blockingMessageConsumer struct {
-	started chan struct{}
-	release chan struct{}
-	once    sync.Once
+	started         chan struct{}
+	release         chan struct{}
+	subscriberReady <-chan struct{}
+	readyBeforeSync bool
+	mu              sync.Mutex
+	once            sync.Once
 }
 
 func (b *blockingMessageConsumer) Sync(ctx context.Context, _ string, _ string, _ func(platform.Message) error) error {
+	select {
+	case <-b.subscriberReady:
+		b.mu.Lock()
+		b.readyBeforeSync = true
+		b.mu.Unlock()
+	default:
+	}
 	b.once.Do(func() { close(b.started) })
 	select {
 	case <-ctx.Done():
@@ -106,6 +120,12 @@ func (b *blockingMessageConsumer) Sync(ctx context.Context, _ string, _ string, 
 	case <-b.release:
 		return fmt.Errorf("sync released")
 	}
+}
+
+func (b *blockingMessageConsumer) ReadyBeforeSync() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.readyBeforeSync
 }
 
 func TestBuildInputText(t *testing.T) {
@@ -213,7 +233,11 @@ func TestNewClaudeDispatch(t *testing.T) {
 
 func TestRunStartsKeepaliveAndSubscriberBeforeInitialSync(t *testing.T) {
 	subscriber := newFakeMessageSubscriber()
-	consumer := &blockingMessageConsumer{started: make(chan struct{}), release: make(chan struct{})}
+	consumer := &blockingMessageConsumer{
+		started:         make(chan struct{}),
+		release:         make(chan struct{}),
+		subscriberReady: subscriber.runStarted,
+	}
 	runners := &recordingRunnersClient{touched: make(chan struct{}, 1)}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -226,7 +250,6 @@ func TestRunStartsKeepaliveAndSubscriberBeforeInitialSync(t *testing.T) {
 		subscriber: subscriber,
 		consumer:   consumer,
 	}
-	daemon.processing.Store(true)
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -239,14 +262,17 @@ func TestRunStartsKeepaliveAndSubscriberBeforeInitialSync(t *testing.T) {
 		t.Fatal("subscriber did not start")
 	}
 	select {
-	case <-runners.touched:
-	case <-time.After(500 * time.Millisecond):
-		t.Fatal("keepalive did not touch active workload")
-	}
-	select {
 	case <-consumer.started:
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("initial sync did not run")
+	}
+	if !consumer.ReadyBeforeSync() {
+		t.Fatal("initial sync started before subscriber")
+	}
+	select {
+	case <-runners.touched:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("keepalive did not touch active workload during initial sync")
 	}
 	cancel()
 	select {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -35,6 +35,7 @@ func testConfig(sdk string) config.Config {
 
 type fakeMessageSubscriber struct {
 	runStarted chan struct{}
+	releaseRun chan struct{}
 	wake       chan struct{}
 	runOnce    sync.Once
 }
@@ -42,18 +43,27 @@ type fakeMessageSubscriber struct {
 func newFakeMessageSubscriber() *fakeMessageSubscriber {
 	return &fakeMessageSubscriber{
 		runStarted: make(chan struct{}),
+		releaseRun: make(chan struct{}),
 		wake:       make(chan struct{}, 1),
 	}
 }
 
 func (f *fakeMessageSubscriber) Run(ctx context.Context) error {
 	f.runOnce.Do(func() { close(f.runStarted) })
-	<-ctx.Done()
-	return ctx.Err()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-f.releaseRun:
+		return fmt.Errorf("subscriber released")
+	}
+}
+
+func (f *fakeMessageSubscriber) Started() <-chan struct{} {
+	return f.runStarted
 }
 
 func (f *fakeMessageSubscriber) Ready() <-chan struct{} {
-	return f.runStarted
+	return make(chan struct{})
 }
 
 func (f *fakeMessageSubscriber) Wake() <-chan struct{} {
@@ -97,19 +107,19 @@ func (r *recordingRunnersClient) TouchWorkload(_ context.Context, _ string) erro
 }
 
 type blockingMessageConsumer struct {
-	started         chan struct{}
-	release         chan struct{}
-	subscriberReady <-chan struct{}
-	readyBeforeSync bool
-	mu              sync.Mutex
-	once            sync.Once
+	started           chan struct{}
+	release           chan struct{}
+	subscriberStarted <-chan struct{}
+	startedBeforeSync bool
+	mu                sync.Mutex
+	once              sync.Once
 }
 
 func (b *blockingMessageConsumer) Sync(ctx context.Context, _ string, _ string, _ func(platform.Message) error) error {
 	select {
-	case <-b.subscriberReady:
+	case <-b.subscriberStarted:
 		b.mu.Lock()
-		b.readyBeforeSync = true
+		b.startedBeforeSync = true
 		b.mu.Unlock()
 	default:
 	}
@@ -122,10 +132,10 @@ func (b *blockingMessageConsumer) Sync(ctx context.Context, _ string, _ string, 
 	}
 }
 
-func (b *blockingMessageConsumer) ReadyBeforeSync() bool {
+func (b *blockingMessageConsumer) StartedBeforeSync() bool {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	return b.readyBeforeSync
+	return b.startedBeforeSync
 }
 
 func TestBuildInputText(t *testing.T) {
@@ -234,9 +244,9 @@ func TestNewClaudeDispatch(t *testing.T) {
 func TestRunStartsKeepaliveAndSubscriberBeforeInitialSync(t *testing.T) {
 	subscriber := newFakeMessageSubscriber()
 	consumer := &blockingMessageConsumer{
-		started:         make(chan struct{}),
-		release:         make(chan struct{}),
-		subscriberReady: subscriber.runStarted,
+		started:           make(chan struct{}),
+		release:           make(chan struct{}),
+		subscriberStarted: subscriber.runStarted,
 	}
 	runners := &recordingRunnersClient{touched: make(chan struct{}, 1)}
 	ctx, cancel := context.WithCancel(context.Background())
@@ -266,7 +276,7 @@ func TestRunStartsKeepaliveAndSubscriberBeforeInitialSync(t *testing.T) {
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("initial sync did not run")
 	}
-	if !consumer.ReadyBeforeSync() {
+	if !consumer.StartedBeforeSync() {
 		t.Fatal("initial sync started before subscriber")
 	}
 	select {
@@ -280,6 +290,46 @@ func TestRunStartsKeepaliveAndSubscriberBeforeInitialSync(t *testing.T) {
 		if err == nil || !strings.Contains(err.Error(), "context canceled") {
 			t.Fatalf("unexpected run error: %v", err)
 		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Run did not stop")
+	}
+}
+
+func TestRunInitialSyncProceedsWhenSubscriberNotReady(t *testing.T) {
+	subscriber := newFakeMessageSubscriber()
+	consumer := &fakeMessageConsumer{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	daemon := &Daemon{
+		cfg:        config.Config{AgentID: uuid.MustParse(testAgentID)},
+		runners:    &fakeRunnersClient{},
+		subscriber: subscriber,
+		consumer:   consumer,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- daemon.Run(ctx)
+	}()
+
+	select {
+	case <-subscriber.runStarted:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("subscriber did not start")
+	}
+	deadline := time.After(500 * time.Millisecond)
+	for consumer.Calls() == 0 {
+		select {
+		case err := <-errCh:
+			t.Fatalf("Run returned before sync: %v", err)
+		case <-deadline:
+			t.Fatal("initial sync did not run while subscriber was not ready")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	cancel()
+	select {
+	case <-errCh:
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("Run did not stop")
 	}

--- a/internal/daemon/keepalive.go
+++ b/internal/daemon/keepalive.go
@@ -29,6 +29,10 @@ func (d *Daemon) runKeepalive(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
+		case <-d.processingWake:
+			if _, err := d.touchActiveWorkload(ctx, workloadID); err != nil && ctx.Err() == nil {
+				log.Printf("workload keepalive failed: %v", err)
+			}
 		case <-ticker.C:
 			if _, err := d.touchActiveWorkload(ctx, workloadID); err != nil && ctx.Err() == nil {
 				log.Printf("workload keepalive failed: %v", err)

--- a/internal/platform/notifications.go
+++ b/internal/platform/notifications.go
@@ -2,6 +2,7 @@ package platform
 
 import (
 	"context"
+	"fmt"
 
 	gatewayv1 "github.com/agynio/agynd-cli/.gen/go/agynio/api/gateway/v1"
 	notificationsv1 "github.com/agynio/agynd-cli/.gen/go/agynio/api/notifications/v1"
@@ -25,5 +26,9 @@ func (n *Notifications) Subscribe(ctx context.Context) (SubscribeStream, error) 
 	request := &notificationsv1.SubscribeRequest{
 		Rooms: []string{threadParticipantSelfRoom},
 	}
-	return n.client.Subscribe(ctx, request)
+	stream, err := n.client.Subscribe(ctx, request)
+	if err != nil {
+		return nil, fmt.Errorf("subscribe notifications: %w", err)
+	}
+	return stream, nil
 }

--- a/internal/platform/notifications_test.go
+++ b/internal/platform/notifications_test.go
@@ -1,0 +1,62 @@
+package platform
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	gatewayv1 "github.com/agynio/agynd-cli/.gen/go/agynio/api/gateway/v1"
+	notificationsv1 "github.com/agynio/agynd-cli/.gen/go/agynio/api/notifications/v1"
+	"google.golang.org/grpc"
+)
+
+type fakeNotificationsGatewayClient struct {
+	request *notificationsv1.SubscribeRequest
+	err     error
+}
+
+var _ gatewayv1.NotificationsGatewayClient = (*fakeNotificationsGatewayClient)(nil)
+
+func (f *fakeNotificationsGatewayClient) Subscribe(ctx context.Context, in *notificationsv1.SubscribeRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[notificationsv1.SubscribeResponse], error) {
+	f.request = in
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &fakeSubscribeStream{}, nil
+}
+
+type fakeSubscribeStream struct {
+	grpc.ClientStream
+}
+
+func (f *fakeSubscribeStream) Recv() (*notificationsv1.SubscribeResponse, error) {
+	return nil, fmt.Errorf("Recv not implemented")
+}
+
+func TestNotificationsSubscribe(t *testing.T) {
+	fake := &fakeNotificationsGatewayClient{}
+	client := NewNotifications(fake)
+	stream, err := client.Subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if stream == nil {
+		t.Fatal("expected stream")
+	}
+	if fake.request == nil || len(fake.request.GetRooms()) != 1 || fake.request.GetRooms()[0] != threadParticipantSelfRoom {
+		t.Fatalf("unexpected subscribe request: %+v", fake.request)
+	}
+}
+
+func TestNotificationsSubscribeWrapsError(t *testing.T) {
+	fake := &fakeNotificationsGatewayClient{err: fmt.Errorf("rpc failed")}
+	client := NewNotifications(fake)
+	_, err := client.Subscribe(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "subscribe notifications") {
+		t.Fatalf("missing operation context: %v", err)
+	}
+}

--- a/internal/platform/runners.go
+++ b/internal/platform/runners.go
@@ -37,7 +37,7 @@ func (r *Runners) ListWorkloadsByThread(ctx context.Context, threadID string, pa
 		PageToken: pageToken,
 	})
 	if err != nil {
-		return nil, "", err
+		return nil, "", fmt.Errorf("list workloads by thread: %w", err)
 	}
 	workloads := make([]Workload, 0, len(resp.GetWorkloads()))
 	for _, workload := range resp.GetWorkloads() {
@@ -56,7 +56,10 @@ func (r *Runners) TouchWorkload(ctx context.Context, workloadID string) error {
 		return fmt.Errorf("workload id is required")
 	}
 	_, err := r.client.TouchWorkload(ctx, &runnersv1.TouchWorkloadRequest{Id: workloadID})
-	return err
+	if err != nil {
+		return fmt.Errorf("touch workload: %w", err)
+	}
+	return nil
 }
 
 func workloadFromProto(workload *runnersv1.Workload) (Workload, error) {

--- a/internal/platform/runners_test.go
+++ b/internal/platform/runners_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -194,6 +195,18 @@ func TestRunnersListWorkloadsByThreadValidation(t *testing.T) {
 	}
 }
 
+func TestRunnersListWorkloadsByThreadWrapsError(t *testing.T) {
+	fake := &fakeRunnersGatewayClient{listErr: fmt.Errorf("rpc failed")}
+	client := NewRunners(fake)
+	_, _, err := client.ListWorkloadsByThread(context.Background(), "thread-1", 10, "")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "list workloads by thread") {
+		t.Fatalf("missing operation context: %v", err)
+	}
+}
+
 func TestRunnersTouchWorkload(t *testing.T) {
 	fake := &fakeRunnersGatewayClient{}
 	client := NewRunners(fake)
@@ -209,6 +222,18 @@ func TestRunnersTouchWorkloadValidation(t *testing.T) {
 	client := NewRunners(&fakeRunnersGatewayClient{})
 	if err := client.TouchWorkload(context.Background(), " "); err == nil {
 		t.Fatal("expected error for missing workload id")
+	}
+}
+
+func TestRunnersTouchWorkloadWrapsError(t *testing.T) {
+	fake := &fakeRunnersGatewayClient{touchErr: fmt.Errorf("rpc failed")}
+	client := NewRunners(fake)
+	err := client.TouchWorkload(context.Background(), "workload-1")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "touch workload") {
+		t.Fatalf("missing operation context: %v", err)
 	}
 }
 

--- a/internal/subscriber/subscriber.go
+++ b/internal/subscriber/subscriber.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/agynio/agynd-cli/internal/platform"
@@ -16,9 +17,11 @@ import (
 const messageCreatedEvent = "message.created"
 
 type Subscriber struct {
-	client   notificationsClient
-	threadID string
-	wake     chan struct{}
+	client    notificationsClient
+	threadID  string
+	ready     chan struct{}
+	readyOnce sync.Once
+	wake      chan struct{}
 }
 
 type notificationsClient interface {
@@ -26,7 +29,7 @@ type notificationsClient interface {
 }
 
 func New(client notificationsClient, threadID string) *Subscriber {
-	return &Subscriber{client: client, threadID: threadID, wake: make(chan struct{}, 1)}
+	return &Subscriber{client: client, threadID: threadID, ready: make(chan struct{}), wake: make(chan struct{}, 1)}
 }
 
 func (s *Subscriber) Run(ctx context.Context) error {
@@ -44,6 +47,7 @@ func (s *Subscriber) Run(ctx context.Context) error {
 			backoff = nextBackoff(backoff)
 			continue
 		}
+		s.readyOnce.Do(func() { close(s.ready) })
 		backoff = time.Second
 
 		for {
@@ -80,6 +84,10 @@ func (s *Subscriber) Run(ctx context.Context) error {
 			}
 		}
 	}
+}
+
+func (s *Subscriber) Ready() <-chan struct{} {
+	return s.ready
 }
 
 func (s *Subscriber) Wake() <-chan struct{} {

--- a/internal/subscriber/subscriber.go
+++ b/internal/subscriber/subscriber.go
@@ -19,6 +19,8 @@ const messageCreatedEvent = "message.created"
 type Subscriber struct {
 	client    notificationsClient
 	threadID  string
+	started   chan struct{}
+	startOnce sync.Once
 	ready     chan struct{}
 	readyOnce sync.Once
 	wake      chan struct{}
@@ -29,10 +31,11 @@ type notificationsClient interface {
 }
 
 func New(client notificationsClient, threadID string) *Subscriber {
-	return &Subscriber{client: client, threadID: threadID, ready: make(chan struct{}), wake: make(chan struct{}, 1)}
+	return &Subscriber{client: client, threadID: threadID, started: make(chan struct{}), ready: make(chan struct{}), wake: make(chan struct{}, 1)}
 }
 
 func (s *Subscriber) Run(ctx context.Context) error {
+	s.startOnce.Do(func() { close(s.started) })
 	backoff := time.Second
 	for {
 		if ctx.Err() != nil {
@@ -84,6 +87,10 @@ func (s *Subscriber) Run(ctx context.Context) error {
 			}
 		}
 	}
+}
+
+func (s *Subscriber) Started() <-chan struct{} {
+	return s.started
 }
 
 func (s *Subscriber) Ready() <-chan struct{} {

--- a/internal/tracingproxy/proxy.go
+++ b/internal/tracingproxy/proxy.go
@@ -19,7 +19,8 @@ import (
 )
 
 const (
-	ListenAddress          = "127.0.0.1:4317"
+	DefaultListenAddress   = "127.0.0.1:4317"
+	ListenAddress          = DefaultListenAddress
 	threadIDAttributeKey   = "agyn.thread.id"
 	messageIDAttributeKey  = "agyn.thread.message.id"
 	workloadIDAttributeKey = "agyn.workload.id"
@@ -27,6 +28,7 @@ const (
 
 type Config struct {
 	TracingAddress string
+	ListenAddress  string
 	ThreadID       string
 	WorkloadID     string
 }
@@ -37,6 +39,7 @@ type Proxy struct {
 	server     *grpc.Server
 	upstream   collectortracev1.TraceServiceClient
 	conn       *grpc.ClientConn
+	address    string
 	threadID   string
 	workloadID string
 	messageMu  sync.RWMutex
@@ -61,11 +64,16 @@ func Start(ctx context.Context, cfg Config) (*Proxy, error) {
 	}
 	collectortracev1.RegisterTraceServiceServer(server, proxy)
 
-	listener, err := net.Listen("tcp", ListenAddress)
+	listenAddress := cfg.ListenAddress
+	if listenAddress == "" {
+		listenAddress = DefaultListenAddress
+	}
+	listener, err := net.Listen("tcp", listenAddress)
 	if err != nil {
 		_ = conn.Close()
-		return nil, fmt.Errorf("listen on %s: %w", ListenAddress, err)
+		return nil, fmt.Errorf("listen on %s: %w", listenAddress, err)
 	}
+	proxy.address = listener.Addr().String()
 
 	go func() {
 		if err := server.Serve(listener); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
@@ -74,6 +82,10 @@ func Start(ctx context.Context, cfg Config) (*Proxy, error) {
 	}()
 
 	return proxy, nil
+}
+
+func (p *Proxy) Address() string {
+	return p.address
 }
 
 func (p *Proxy) Export(ctx context.Context, req *collectortracev1.ExportTraceServiceRequest) (*collectortracev1.ExportTraceServiceResponse, error) {

--- a/internal/tracingproxy/proxy_test.go
+++ b/internal/tracingproxy/proxy_test.go
@@ -172,14 +172,14 @@ func TestProxyForwardsToUpstream(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	proxy, err := Start(ctx, Config{TracingAddress: listener.Addr().String(), ThreadID: "thread-4", WorkloadID: "workload-4"})
+	proxy, err := Start(ctx, Config{TracingAddress: listener.Addr().String(), ListenAddress: "127.0.0.1:0", ThreadID: "thread-4", WorkloadID: "workload-4"})
 	if err != nil {
 		t.Fatalf("start proxy: %v", err)
 	}
 	defer proxy.Close()
 	proxy.SetMessageID("message-4")
 
-	conn, err := grpc.NewClient(ListenAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(proxy.Address(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("dial proxy: %v", err)
 	}
@@ -220,13 +220,13 @@ func TestProxyClearsMessageID(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	proxy, err := Start(ctx, Config{TracingAddress: listener.Addr().String(), ThreadID: "thread-5"})
+	proxy, err := Start(ctx, Config{TracingAddress: listener.Addr().String(), ListenAddress: "127.0.0.1:0", ThreadID: "thread-5"})
 	if err != nil {
 		t.Fatalf("start proxy: %v", err)
 	}
 	defer proxy.Close()
 
-	conn, err := grpc.NewClient(ListenAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(proxy.Address(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("dial proxy: %v", err)
 	}
@@ -265,13 +265,13 @@ func TestProxyNoThreadIDPassthrough(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	proxy, err := Start(ctx, Config{TracingAddress: listener.Addr().String(), ThreadID: ""})
+	proxy, err := Start(ctx, Config{TracingAddress: listener.Addr().String(), ListenAddress: "127.0.0.1:0", ThreadID: ""})
 	if err != nil {
 		t.Fatalf("start proxy: %v", err)
 	}
 	defer proxy.Close()
 
-	conn, err := grpc.NewClient(ListenAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(proxy.Address(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("dial proxy: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Remove active per-turn completion timeout from Codex and Claude execution paths while keeping bounded RPC/start/publish/ack/MCP timeouts.
- Start keepalive and notification subscriber before initial sync, and retry failed syncs with 1s exponential backoff capped at 30s.
- Add operation context to daemon/platform RPC errors and expand tests for startup ordering, sync retry, timeout removal, and error wrapping.
- Allow tracing proxy tests to use an ephemeral listen address so local tests pass when the default OTLP port is occupied.

Closes #120

## Test & Lint Summary
- `CGO_ENABLED=0 go test -count=1 ./...`
  - Passed: 7 packages
  - Failed: 0
  - Skipped: 0
- `go vet ./...`
  - Linting passed with no errors.