### PR TITLE
fix(daemon): add operation-specific error context

### DIFF
--- a/cmd/agynd/main.go
+++ b/cmd/agynd/main.go
@@ -29,7 +29,11 @@ func main() {
 	}
 	defer agynd.Close()
 
-	if err := agynd.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+	if err := agynd.Run(ctx); err != nil {
+		if errors.Is(err, context.Canceled) {
+			log.Printf("daemon stopped: %v", err)
+			return
+		}
 		log.Fatalf("daemon exited: %v", err)
 	}
 }

--- a/internal/daemon/agn.go
+++ b/internal/daemon/agn.go
@@ -117,17 +117,11 @@ func (d *Daemon) handleAgnMessage(ctx context.Context, message platform.Message)
 	if response == "" {
 		return fmt.Errorf("agn turn completed with empty response")
 	}
-	publishCtx, cancel := context.WithTimeout(ctx, messagePublishTimeout)
-	_, err = d.threads.SendMessage(publishCtx, threadID, d.cfg.AgentID.String(), response, nil)
-	cancel()
-	if err != nil {
-		return fmt.Errorf("publish agn response for message %s: %w", message.ID, err)
+	if err := d.publishResponse(ctx, SDKAgn, threadID, message, response); err != nil {
+		return err
 	}
-	ackCtx, cancel := context.WithTimeout(ctx, messageAckTimeout)
-	err = d.threads.AckMessages(ackCtx, d.cfg.AgentID.String(), []string{message.ID})
-	cancel()
-	if err != nil {
-		return fmt.Errorf("ack message %s: %w", message.ID, err)
+	if err := d.ackMessage(ctx, message); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/daemon/agn.go
+++ b/internal/daemon/agn.go
@@ -111,11 +111,19 @@ func (d *Daemon) handleAgnMessage(ctx context.Context, message platform.Message)
 		ThreadID: threadID,
 	}, nil)
 	if err != nil {
-		return fmt.Errorf("run agn turn for message %s: %w", message.ID, err)
+		return operationError(
+			opAgnTurn,
+			0,
+			fmt.Errorf("run agn turn for message %s on thread %s: %w", message.ID, threadID, err),
+		)
 	}
 	response := strings.TrimSpace(result.Response)
 	if response == "" {
-		return fmt.Errorf("agn turn completed with empty response")
+		return operationError(
+			opAgnTurn,
+			0,
+			fmt.Errorf("agn turn completed with empty response for message %s on thread %s", message.ID, threadID),
+		)
 	}
 	if err := d.publishResponse(ctx, SDKAgn, threadID, message, response); err != nil {
 		return err

--- a/internal/daemon/claude.go
+++ b/internal/daemon/claude.go
@@ -129,17 +129,11 @@ func (d *Daemon) handleClaudeMessage(ctx context.Context, message platform.Messa
 	if response == "" {
 		return fmt.Errorf("claude turn completed with empty response")
 	}
-	publishCtx, cancel := context.WithTimeout(ctx, messagePublishTimeout)
-	_, err = d.threads.SendMessage(publishCtx, threadID, d.cfg.AgentID.String(), response, nil)
-	cancel()
-	if err != nil {
-		return fmt.Errorf("publish claude response for message %s: %w", message.ID, err)
+	if err := d.publishResponse(ctx, SDKClaude, threadID, message, response); err != nil {
+		return err
 	}
-	ackCtx, cancel := context.WithTimeout(ctx, messageAckTimeout)
-	err = d.threads.AckMessages(ackCtx, d.cfg.AgentID.String(), []string{message.ID})
-	cancel()
-	if err != nil {
-		return fmt.Errorf("ack message %s: %w", message.ID, err)
+	if err := d.ackMessage(ctx, message); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/daemon/claude.go
+++ b/internal/daemon/claude.go
@@ -123,11 +123,19 @@ func (d *Daemon) handleClaudeMessage(ctx context.Context, message platform.Messa
 	}
 	result, err := d.claude.Turn(ctx, claude.TurnParams{Prompt: inputText}, nil)
 	if err != nil {
-		return fmt.Errorf("run claude turn for message %s: %w", message.ID, err)
+		return operationError(
+			opClaudeTurn,
+			0,
+			fmt.Errorf("run claude turn for message %s on thread %s: %w", message.ID, threadID, err),
+		)
 	}
 	response := strings.TrimSpace(result.Response)
 	if response == "" {
-		return fmt.Errorf("claude turn completed with empty response")
+		return operationError(
+			opClaudeTurn,
+			0,
+			fmt.Errorf("claude turn completed with empty response for message %s on thread %s", message.ID, threadID),
+		)
 	}
 	if err := d.publishResponse(ctx, SDKClaude, threadID, message, response); err != nil {
 		return err

--- a/internal/daemon/claude_test.go
+++ b/internal/daemon/claude_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -178,6 +179,30 @@ func TestHandleClaudeMessageEmptyResponse(t *testing.T) {
 	}
 	if len(threadsClient.ackRequests) != 0 {
 		t.Fatalf("expected no ack requests, got %d", len(threadsClient.ackRequests))
+	}
+}
+
+func TestHandleClaudeMessageWrapsTurnError(t *testing.T) {
+	turnErr := fmt.Errorf("turn failed")
+	client := &fakeClaudeClient{err: turnErr}
+	daemon := &Daemon{
+		sdk:    SDKClaude,
+		cfg:    config.Config{AgentID: uuid.MustParse(testAgentID)},
+		claude: client,
+	}
+
+	message := platform.Message{ID: "msg-1", ThreadID: "thread-1", Body: "hello"}
+	err := daemon.handleClaudeMessage(context.Background(), message)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	for _, expected := range []string{"claude_turn", "run claude turn for message msg-1", "thread-1"} {
+		if !strings.Contains(err.Error(), expected) {
+			t.Fatalf("expected %q in error: %v", expected, err)
+		}
+	}
+	if !errors.Is(err, turnErr) {
+		t.Fatalf("expected wrapped turn error, got %v", err)
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -23,14 +24,21 @@ import (
 )
 
 const (
-	pageSize                int32 = 100
-	pageTimeout                   = 30 * time.Second
-	turnStartTimeout              = 5 * time.Minute
-	messagePublishTimeout         = 15 * time.Second
-	messageAckTimeout             = 15 * time.Second
-	mcpReadyTimeout               = 120 * time.Second
-	syncRetryInitialBackoff       = 1 * time.Second
-	syncRetryMaxBackoff           = 30 * time.Second
+	pageSize                  int32 = 100
+	pageTimeout                     = 30 * time.Second
+	turnStartTimeout                = 5 * time.Minute
+	messagePublishTimeout           = 15 * time.Second
+	messageAckTimeout               = 15 * time.Second
+	mcpReadyTimeout                 = 120 * time.Second
+	syncRetryInitialBackoff         = 1 * time.Second
+	syncRetryMaxBackoff             = 30 * time.Second
+	opSyncPageFetch                 = "sync_page_fetch"
+	opCodexStartTurn                = "codex_start_turn"
+	opMessagePublish                = "publish"
+	opMessageAck                    = "ack"
+	opKeepaliveTouch                = "keepalive_touch"
+	opCodexWaitTurnCompletion       = "codex_wait_turn_completion"
+	opProcessSignalShutdown         = "process_signal/shutdown"
 )
 
 const (
@@ -333,7 +341,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 	}()
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return operationError(opProcessSignalShutdown, 0, ctx.Err())
 	case <-d.subscriber.Started():
 	}
 
@@ -387,7 +395,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return operationError(opProcessSignalShutdown, 0, ctx.Err())
 		case <-d.subscriber.Wake():
 			if err := d.syncMessages(ctx); err != nil {
 				scheduleFailureRetry("sync messages", err)
@@ -402,6 +410,65 @@ func (d *Daemon) Run(ctx context.Context) error {
 			}
 		}
 	}
+}
+
+func operationError(op string, timeout time.Duration, err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		if timeout > 0 {
+			return fmt.Errorf("%s timed out after %s: %w", op, timeout, err)
+		}
+		return fmt.Errorf("%s timed out: %w", op, err)
+	}
+	if errors.Is(err, context.Canceled) {
+		return fmt.Errorf("%s canceled: %w", op, err)
+	}
+	if timeout > 0 {
+		return fmt.Errorf("%s failed (timeout %s): %w", op, timeout, err)
+	}
+	return fmt.Errorf("%s failed: %w", op, err)
+}
+
+func operationContextErr(ctx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil && errors.Is(err, ctxErr) {
+		return ctxErr
+	}
+	return err
+}
+
+func (d *Daemon) publishResponse(ctx context.Context, sdk string, threadID string, message platform.Message, response string) error {
+	publishCtx, cancel := context.WithTimeout(ctx, messagePublishTimeout)
+	_, err := d.threads.SendMessage(publishCtx, threadID, d.cfg.AgentID.String(), response, nil)
+	err = operationContextErr(publishCtx, err)
+	cancel()
+	if err != nil {
+		return operationError(
+			opMessagePublish,
+			messagePublishTimeout,
+			fmt.Errorf("publish %s response for message %s on thread %s: %w", sdk, message.ID, threadID, err),
+		)
+	}
+	return nil
+}
+
+func (d *Daemon) ackMessage(ctx context.Context, message platform.Message) error {
+	ackCtx, cancel := context.WithTimeout(ctx, messageAckTimeout)
+	err := d.threads.AckMessages(ackCtx, d.cfg.AgentID.String(), []string{message.ID})
+	err = operationContextErr(ackCtx, err)
+	cancel()
+	if err != nil {
+		return operationError(
+			opMessageAck,
+			messageAckTimeout,
+			fmt.Errorf("ack message %s: %w", message.ID, err),
+		)
+	}
+	return nil
 }
 
 func (d *Daemon) ensureProcessingWake() {
@@ -447,7 +514,15 @@ func (d *Daemon) syncMessages(ctx context.Context) error {
 		}
 		return d.handleMessage(ctx, message)
 	}); err != nil {
-		return fmt.Errorf("sync unacked messages: %w", err)
+		var pageFetchErr *platform.PageFetchError
+		if !errors.As(err, &pageFetchErr) {
+			return fmt.Errorf("sync unacked messages: %w", err)
+		}
+		return operationError(
+			opSyncPageFetch,
+			pageTimeout,
+			fmt.Errorf("sync unacked messages for participant %s thread %s: %w", d.cfg.AgentID.String(), d.cfg.ThreadID, pageFetchErr),
+		)
 	}
 	return nil
 }
@@ -483,9 +558,10 @@ func (d *Daemon) handleCodexMessage(ctx context.Context, message platform.Messag
 		ThreadID: codexThreadID,
 		Input:    []codex.UserInput{codex.NewTextUserInput(inputText)},
 	})
+	err = operationContextErr(turnCtx, err)
 	cancel()
 	if err != nil {
-		return fmt.Errorf("start codex turn for message %s: %w", message.ID, err)
+		return operationError(opCodexStartTurn, turnStartTimeout, fmt.Errorf("start codex turn for message %s on thread %s: %w", message.ID, codexThreadID, err))
 	}
 	turnID := strings.TrimSpace(turnResp.Turn.ID)
 	if turnID == "" {
@@ -503,22 +579,20 @@ func (d *Daemon) handleCodexMessage(ctx context.Context, message platform.Messag
 		if strings.TrimSpace(result.Message) == "" {
 			return fmt.Errorf("turn %s completed with empty response", turnID)
 		}
-		publishCtx, cancel := context.WithTimeout(ctx, messagePublishTimeout)
-		_, err := d.threads.SendMessage(publishCtx, threadID, d.cfg.AgentID.String(), result.Message, nil)
-		cancel()
-		if err != nil {
-			return fmt.Errorf("publish codex response for message %s: %w", message.ID, err)
+		if err := d.publishResponse(ctx, SDKCodex, threadID, message, result.Message); err != nil {
+			return err
 		}
-		ackCtx, cancel := context.WithTimeout(ctx, messageAckTimeout)
-		err = d.threads.AckMessages(ackCtx, d.cfg.AgentID.String(), []string{message.ID})
-		cancel()
-		if err != nil {
-			return fmt.Errorf("ack message %s: %w", message.ID, err)
+		if err := d.ackMessage(ctx, message); err != nil {
+			return err
 		}
 		return nil
 	case <-ctx.Done():
 		d.tracker.Cancel(turnID)
-		return fmt.Errorf("wait for codex turn %s completion: %w", turnID, ctx.Err())
+		return operationError(
+			opCodexWaitTurnCompletion,
+			0,
+			fmt.Errorf("wait for codex turn %s completion for message %s: %w", turnID, message.ID, ctx.Err()),
+		)
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -38,6 +38,9 @@ const (
 	opMessageAck                    = "ack"
 	opKeepaliveTouch                = "keepalive_touch"
 	opCodexWaitTurnCompletion       = "codex_wait_turn_completion"
+	opCodexTurnResult               = "codex_turn_result"
+	opAgnTurn                       = "agn_turn"
+	opClaudeTurn                    = "claude_turn"
 	opProcessSignalShutdown         = "process_signal/shutdown"
 )
 
@@ -516,7 +519,7 @@ func (d *Daemon) syncMessages(ctx context.Context) error {
 	}); err != nil {
 		var pageFetchErr *platform.PageFetchError
 		if !errors.As(err, &pageFetchErr) {
-			return fmt.Errorf("sync unacked messages: %w", err)
+			return err
 		}
 		return operationError(
 			opSyncPageFetch,
@@ -571,13 +574,25 @@ func (d *Daemon) handleCodexMessage(ctx context.Context, message platform.Messag
 	select {
 	case result := <-completionCh:
 		if result.Err != nil {
-			return fmt.Errorf("codex turn %s failed: %w", turnID, result.Err)
+			return operationError(
+				opCodexTurnResult,
+				0,
+				fmt.Errorf("codex turn %s failed for message %s: %w", turnID, message.ID, result.Err),
+			)
 		}
 		if result.ThreadID != codexThreadID {
-			return fmt.Errorf("turn %s thread mismatch", turnID)
+			return operationError(
+				opCodexTurnResult,
+				0,
+				fmt.Errorf("codex turn %s thread mismatch for message %s", turnID, message.ID),
+			)
 		}
 		if strings.TrimSpace(result.Message) == "" {
-			return fmt.Errorf("turn %s completed with empty response", turnID)
+			return operationError(
+				opCodexTurnResult,
+				0,
+				fmt.Errorf("codex turn %s completed with empty response for message %s", turnID, message.ID),
+			)
 		}
 		if err := d.publishResponse(ctx, SDKCodex, threadID, message, result.Message); err != nil {
 			return err

--- a/internal/daemon/daemon_codex_test.go
+++ b/internal/daemon/daemon_codex_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -197,7 +198,54 @@ func TestHandleCodexMessageWrapsStartTurnError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-	if !strings.Contains(err.Error(), "start codex turn for message msg-1") {
-		t.Fatalf("missing operation context: %v", err)
+	for _, expected := range []string{"codex_start_turn", "5m0s", "start codex turn for message msg-1"} {
+		if !strings.Contains(err.Error(), expected) {
+			t.Fatalf("expected %q in error: %v", expected, err)
+		}
+	}
+}
+
+func TestHandleCodexMessageWrapsWaitCancellation(t *testing.T) {
+	store := codexbridge.NewThreadMappingStore(t.TempDir())
+	client := &fakeCodexClient{}
+	daemon := &Daemon{
+		sdk:          SDKCodex,
+		cfg:          config.Config{AgentID: uuid.MustParse(testAgentID), WorkDir: "/tmp"},
+		codex:        client,
+		mapping:      codexbridge.NewThreadMapping(),
+		mappingStore: store,
+		tracker:      codexbridge.NewTurnTracker(),
+		agent:        &agentsv1.Agent{},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	message := platform.Message{ID: "msg-1", ThreadID: "thread-1", Body: "hello"}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- daemon.handleCodexMessage(ctx, message)
+	}()
+	for client.StartTurnContext() == nil {
+		select {
+		case err := <-errCh:
+			t.Fatalf("handleCodexMessage returned before cancellation: %v", err)
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	cancel()
+	var err error
+	select {
+	case err = <-errCh:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("handleCodexMessage did not stop after cancellation")
+	}
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	for _, expected := range []string{"codex_wait_turn_completion", "wait for codex turn", "canceled"} {
+		if !strings.Contains(err.Error(), expected) {
+			t.Fatalf("expected %q in error: %v", expected, err)
+		}
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
 	}
 }

--- a/internal/daemon/daemon_codex_test.go
+++ b/internal/daemon/daemon_codex_test.go
@@ -249,3 +249,45 @@ func TestHandleCodexMessageWrapsWaitCancellation(t *testing.T) {
 		t.Fatalf("expected context.Canceled, got %v", err)
 	}
 }
+
+func TestHandleCodexMessageWrapsTurnResultError(t *testing.T) {
+	store := codexbridge.NewThreadMappingStore(t.TempDir())
+	client := &fakeCodexClient{}
+	daemon := &Daemon{
+		sdk:          SDKCodex,
+		cfg:          config.Config{AgentID: uuid.MustParse(testAgentID), WorkDir: "/tmp"},
+		codex:        client,
+		mapping:      codexbridge.NewThreadMapping(),
+		mappingStore: store,
+		tracker:      codexbridge.NewTurnTracker(),
+		agent:        &agentsv1.Agent{},
+	}
+	message := platform.Message{ID: "msg-1", ThreadID: "thread-1", Body: "hello"}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- daemon.handleCodexMessage(context.Background(), message)
+	}()
+	turnErr := fmt.Errorf("turn failed")
+	daemon.tracker.Notify(codexbridge.TurnResult{
+		ThreadID: "codex-started",
+		TurnID:   "turn-1",
+		Err:      turnErr,
+	})
+	var err error
+	select {
+	case err = <-errCh:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("handleCodexMessage did not finish after turn failure")
+	}
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	for _, expected := range []string{"codex_turn_result", "codex turn turn-1 failed", "msg-1"} {
+		if !strings.Contains(err.Error(), expected) {
+			t.Fatalf("expected %q in error: %v", expected, err)
+		}
+	}
+	if !errors.Is(err, turnErr) {
+		t.Fatalf("expected wrapped turn error, got %v", err)
+	}
+}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -330,6 +331,46 @@ func TestRunInitialSyncProceedsWhenSubscriberNotReady(t *testing.T) {
 	cancel()
 	select {
 	case <-errCh:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Run did not stop")
+	}
+}
+
+func TestRunWrapsShutdownCancellation(t *testing.T) {
+	subscriber := newFakeMessageSubscriber()
+	consumer := &fakeMessageConsumer{}
+	ctx, cancel := context.WithCancel(context.Background())
+	daemon := &Daemon{
+		cfg:        config.Config{AgentID: uuid.MustParse(testAgentID)},
+		runners:    &fakeRunnersClient{},
+		subscriber: subscriber,
+		consumer:   consumer,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- daemon.Run(ctx)
+	}()
+
+	select {
+	case <-subscriber.runStarted:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("subscriber did not start")
+	}
+	cancel()
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		for _, expected := range []string{"process_signal/shutdown", "canceled"} {
+			if !strings.Contains(err.Error(), expected) {
+				t.Fatalf("expected %q in error: %v", expected, err)
+			}
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("Run did not stop")
 	}

--- a/internal/daemon/keepalive.go
+++ b/internal/daemon/keepalive.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strings"
 	"time"
@@ -51,9 +52,14 @@ func (d *Daemon) touchActiveWorkload(ctx context.Context, workloadID string) (bo
 	}
 	touchCtx, cancel := context.WithTimeout(ctx, workloadKeepaliveTimeout)
 	err := d.runners.TouchWorkload(touchCtx, workloadID)
+	err = operationContextErr(touchCtx, err)
 	cancel()
 	if err != nil {
-		return false, err
+		return false, operationError(
+			opKeepaliveTouch,
+			workloadKeepaliveTimeout,
+			fmt.Errorf("touch active workload %s: %w", workloadID, err),
+		)
 	}
 	return true, nil
 }

--- a/internal/daemon/keepalive_test.go
+++ b/internal/daemon/keepalive_test.go
@@ -2,6 +2,9 @@ package daemon
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/agynio/agynd-cli/internal/config"
@@ -10,11 +13,12 @@ import (
 
 type fakeRunnersClient struct {
 	touchCalls []string
+	err        error
 }
 
 func (f *fakeRunnersClient) TouchWorkload(_ context.Context, workloadID string) error {
 	f.touchCalls = append(f.touchCalls, workloadID)
-	return nil
+	return f.err
 }
 
 func TestTouchActiveWorkloadCallsTouch(t *testing.T) {
@@ -33,6 +37,31 @@ func TestTouchActiveWorkloadCallsTouch(t *testing.T) {
 	}
 	if len(fake.touchCalls) != 1 || fake.touchCalls[0] != "workload-1" {
 		t.Fatalf("unexpected touch calls: %v", fake.touchCalls)
+	}
+}
+
+func TestTouchActiveWorkloadWrapsError(t *testing.T) {
+	touchErr := fmt.Errorf("rpc failed")
+	fake := &fakeRunnersClient{err: touchErr}
+	daemon := &Daemon{
+		cfg:     config.Config{AgentID: uuid.MustParse(testAgentID), WorkloadID: "workload-1"},
+		runners: fake,
+	}
+	daemon.processing.Store(true)
+	touched, err := daemon.touchActiveWorkload(context.Background(), "workload-1")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if touched {
+		t.Fatal("expected workload touch to fail")
+	}
+	for _, expected := range []string{"keepalive_touch", "5s", "workload-1"} {
+		if !strings.Contains(err.Error(), expected) {
+			t.Fatalf("expected %q in error: %v", expected, err)
+		}
+	}
+	if !errors.Is(err, touchErr) {
+		t.Fatalf("expected wrapped touch error, got %v", err)
 	}
 }
 

--- a/internal/platform/consumer.go
+++ b/internal/platform/consumer.go
@@ -13,6 +13,18 @@ type Consumer struct {
 	requestTimeout time.Duration
 }
 
+type PageFetchError struct {
+	Err error
+}
+
+func (e *PageFetchError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *PageFetchError) Unwrap() error {
+	return e.Err
+}
+
 func NewConsumer(threads *Threads, pageSize int32, requestTimeout time.Duration) *Consumer {
 	return &Consumer{threads: threads, pageSize: pageSize, requestTimeout: requestTimeout}
 }
@@ -29,11 +41,14 @@ func (c *Consumer) Sync(ctx context.Context, participantID string, threadID stri
 			pageCtx, cancel = context.WithTimeout(ctx, c.requestTimeout)
 		}
 		messages, nextToken, err := c.threads.GetUnackedMessages(pageCtx, participantID, threadID, c.pageSize, pageToken)
+		if err != nil && pageCtx.Err() != nil {
+			err = pageCtx.Err()
+		}
 		if cancel != nil {
 			cancel()
 		}
 		if err != nil {
-			return err
+			return &PageFetchError{Err: err}
 		}
 		if len(messages) > 1 {
 			sort.Slice(messages, func(i, j int) bool {

--- a/internal/platform/consumer_test.go
+++ b/internal/platform/consumer_test.go
@@ -2,6 +2,7 @@ package platform
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -16,6 +17,7 @@ type fakeThreadsClient struct {
 	responses []*threadsv1.GetUnackedMessagesResponse
 	index     int
 	requests  []*threadsv1.GetUnackedMessagesRequest
+	err       error
 }
 
 var _ gatewayv1.ThreadsGatewayClient = (*fakeThreadsClient)(nil)
@@ -57,6 +59,9 @@ func (f *fakeThreadsClient) GetMessages(ctx context.Context, in *threadsv1.GetMe
 }
 
 func (f *fakeThreadsClient) GetUnackedMessages(ctx context.Context, in *threadsv1.GetUnackedMessagesRequest, opts ...grpc.CallOption) (*threadsv1.GetUnackedMessagesResponse, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
 	if f.index >= len(f.responses) {
 		return nil, fmt.Errorf("unexpected GetUnackedMessages call")
 	}
@@ -64,6 +69,26 @@ func (f *fakeThreadsClient) GetUnackedMessages(ctx context.Context, in *threadsv
 	resp := f.responses[f.index]
 	f.index++
 	return resp, nil
+}
+
+func TestConsumerSyncWrapsPageFetchError(t *testing.T) {
+	fetchErr := fmt.Errorf("rpc failed")
+	fake := &fakeThreadsClient{err: fetchErr}
+	consumer := NewConsumer(&Threads{client: fake}, 100, 0)
+
+	err := consumer.Sync(context.Background(), "participant-1", "thread-1", func(message Message) error {
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var pageFetchErr *PageFetchError
+	if !errors.As(err, &pageFetchErr) {
+		t.Fatalf("expected PageFetchError, got %T", err)
+	}
+	if !errors.Is(err, fetchErr) {
+		t.Fatalf("expected wrapped fetch error, got %v", err)
+	}
 }
 
 func (f *fakeThreadsClient) GetUnackedMessageCounts(ctx context.Context, in *threadsv1.GetUnackedMessageCountsRequest, opts ...grpc.CallOption) (*threadsv1.GetUnackedMessageCountsResponse, error) {


### PR DESCRIPTION
## Summary
- Add operation-specific wrapping for timeout/cancel errors in sync page fetch, Codex start turn, publish, ack, keepalive touch, Codex wait completion, and process signal shutdown paths.
- Preserve existing timeout durations and control-flow semantics while making daemon logs actionable.
- Add focused unit coverage for page fetch, keepalive, Codex start/wait, and shutdown wrapping.

Fixes #120

## Test & Lint Summary
- `nix shell nixpkgs#gcc -c sh -c 'go test ./... && go vet ./... && go build ./...'`
  - Tests: 178 passed / 0 failed / 0 skipped
  - Lint: `go vet ./...` passed with no errors
  - Build: `go build ./...` passed
- `nix shell nixpkgs#gcc -c sh -c 'AGN_REPO_PATH=/workspace/agn-cli OPENAI_API_KEY=test-key go test -v -count=1 -tags e2e ./test/e2e/'`
  - E2E tests: 2 passed / 0 failed / 0 skipped