### PR TITLE
Align CI with centralized E2E workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,44 +5,31 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     runs-on: ubuntu-latest
     env:
       GOPRIVATE: github.com/agynio/*
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Configure Git for private modules
         run: git config --global url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
-      - uses: actions/checkout@v4
+      - name: Provision cluster
+        uses: agynio/bootstrap/.github/actions/provision@main
+
+      - name: Setup DevSpace
+        uses: agynio/e2e/.github/actions/setup-devspace@main
+
+      - name: Deploy agynd-cli from source
+        run: devspace dev
+
+      - name: Run E2E tests
+        uses: agynio/e2e/.github/actions/run-tests@main
         with:
-          repository: agynio/agn-cli
-          token: ${{ secrets.GITHUB_TOKEN }}
-          path: .agn-cli
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '1.26.x'
-
-      - name: Install buf
-        uses: bufbuild/buf-setup-action@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          version: 1.66.0
-
-      - name: Generate protobuf bindings
-        run: |
-          buf generate buf.build/agynio/api \
-            --path agynio/api/gateway/v1 \
-            --include-imports
-
-      - name: Install Codex CLI
-        run: npm install -g @openai/codex
-
-      - name: Run e2e tests
-        run: go test -v -count=1 -tags e2e ./test/e2e/
-        env:
-          OPENAI_API_KEY: test-key
-          AGN_REPO_PATH: ${{ github.workspace }}/.agn-cli
+          service: agynd_cli

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -52,8 +52,8 @@ functions:
                     sleep 1; elapsed=$((elapsed + 1))
                     [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
                   done
-                  buf generate https://github.com/agynio/api.git#commit=ec008b1e2dfacec3e4d85776729fe1c3d5f2c42d \
-                    --path proto/agynio/api/gateway/v1 \
+                  buf generate buf.build/agynio/api \
+                    --path agynio/api/gateway/v1 \
                     --include-imports
                   exec go run ./cmd/agynd
               volumeMounts:


### PR DESCRIPTION
## Summary
- Aligns E2E workflow with centralized architecture: provision via `agynio/bootstrap/.github/actions/provision@main`, deploy agynd-cli from source with `devspace dev`, then run `agynio/e2e/.github/actions/run-tests@main`.
- Removes repo-local E2E execution, Codex install, ad hoc agn-cli checkout, and local test env overrides from the PR workflow.
- Adds read-only workflow permissions to CI/E2E.
- Updates DevSpace source deploy to use the unpinned `buf.build/agynio/api` module instead of a pinned API commit.
- Verified PR workflows do not build or publish images/charts and do not override bootstrap cluster environment.

Closes #123

## Test & Lint Summary
- `actionlint .github/workflows/ci.yml .github/workflows/e2e.yml .github/workflows/release.yml` — passed with no errors.
- `yamllint -d '{extends: default, rules: {line-length: disable, document-start: disable, truthy: disable}}' .github/workflows/ci.yml .github/workflows/e2e.yml .github/workflows/release.yml devspace.yaml` — passed with no errors.
- `buf generate buf.build/agynio/api --path agynio/api/gateway/v1 --include-imports` — passed.
- `gofmt -w $(find cmd internal test -name '*.go' -print)` — passed with no changes.
- `go test ./...` — 7 packages passed, 0 failed, 0 skipped.
- `go build ./...` — passed.
- `devspace print --debug` — passed.