### PR TITLE
fix(daemon): avoid bearer auth for ziti llm

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.1
 require (
 	github.com/agynio/agn-sdk-go v0.1.0
 	github.com/agynio/claude-sdk-go v0.2.1
-	github.com/agynio/codex-sdk-go v0.1.0
+	github.com/agynio/codex-sdk-go v0.1.1-0.20260324143246-85080838f61f
 	github.com/google/uuid v1.6.0
 	go.opentelemetry.io/proto/otlp v1.10.0
 	google.golang.org/grpc v1.79.2

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/agynio/claude-sdk-go v0.2.1 h1:08VKWyXiN1Td5fqVRLThr/9EQHpsmP6j58MlAH
 github.com/agynio/claude-sdk-go v0.2.1/go.mod h1:RdzMhfP4XpToQkzE7WecDXHINq+B7e/ggU4pWKGdoks=
 github.com/agynio/codex-sdk-go v0.1.0 h1:EqsijEpD9/KnkoipdOf0n8cq2oC//4q2LY3edOVhicE=
 github.com/agynio/codex-sdk-go v0.1.0/go.mod h1:YhNX7IO1zVMcfpFINRD1reQFWTQzCZXQT1aCghtKNok=
+github.com/agynio/codex-sdk-go v0.1.1-0.20260324143246-85080838f61f h1:F7xvZs7UQERckptH6O/BYyb0m2TqhdsZG/bbO4xDEIY=
+github.com/agynio/codex-sdk-go v0.1.1-0.20260324143246-85080838f61f/go.mod h1:YhNX7IO1zVMcfpFINRD1reQFWTQzCZXQT1aCghtKNok=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/internal/daemon/codexconfig.go
+++ b/internal/daemon/codexconfig.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,9 +23,21 @@ exporter = "none"
 [model_providers.platform]
 name = "Agyn LLM"
 base_url = %q
-env_key = "OPENAI_API_KEY"
-wire_api = "responses"
+%swire_api = "responses"
 `
+
+const codexAPIKeyEnv = `env_key = "OPENAI_API_KEY"
+`
+
+const zitiHostnameSuffix = ".ziti"
+
+const (
+	codexEnvPath                     = "PATH"
+	codexEnvHome                     = "HOME"
+	codexEnvCodexHome                = "CODEX_HOME"
+	codexEnvOpenAIAPIKey             = "OPENAI_API_KEY"
+	codexEnvOTELExporterOTLPEndpoint = "OTEL_EXPORTER_OTLP_ENDPOINT"
+)
 
 func writeCodexConfig(llmBaseURL string, mcpServers []config.MCPServer) (string, error) {
 	codexHome := filepath.Join(codexHomeEnv(), ".codex")
@@ -41,7 +54,11 @@ func writeCodexConfig(llmBaseURL string, mcpServers []config.MCPServer) (string,
 
 func codexConfig(llmBaseURL string, mcpServers []config.MCPServer) string {
 	otlpEndpoint := "http://" + tracingproxy.ListenAddress
-	payload := fmt.Sprintf(codexConfigTemplate, otlpEndpoint, llmBaseURL)
+	apiKeyEnv := codexAPIKeyEnv
+	if isZitiLLMBaseURL(llmBaseURL) {
+		apiKeyEnv = ""
+	}
+	payload := fmt.Sprintf(codexConfigTemplate, otlpEndpoint, llmBaseURL, apiKeyEnv)
 	if len(mcpServers) == 0 {
 		return payload
 	}
@@ -52,4 +69,26 @@ func codexConfig(llmBaseURL string, mcpServers []config.MCPServer) string {
 		fmt.Fprintf(&builder, "\n[mcp_servers.%s]\nurl = %q\nrequired = true\nstartup_timeout_sec = 120\n", server.Name, url)
 	}
 	return builder.String()
+}
+
+func codexEnv(cfg config.Config, codexHome, codexHomeValue, otlpEndpoint string) map[string]string {
+	env := map[string]string{
+		codexEnvPath:                     agentPathValue(),
+		codexEnvCodexHome:                codexHome,
+		codexEnvHome:                     codexHomeValue,
+		codexEnvOTELExporterOTLPEndpoint: otlpEndpoint,
+	}
+	if !isZitiLLMBaseURL(cfg.LLMBaseURL) {
+		env[codexEnvOpenAIAPIKey] = cfg.LLMAPIToken
+	}
+	return env
+}
+
+func isZitiLLMBaseURL(llmBaseURL string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(llmBaseURL))
+	if err != nil {
+		return false
+	}
+	hostname := strings.ToLower(parsed.Hostname())
+	return strings.HasSuffix(hostname, zitiHostnameSuffix)
 }

--- a/internal/daemon/codexconfig.go
+++ b/internal/daemon/codexconfig.go
@@ -1,14 +1,17 @@
 package daemon
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/agynio/agynd-cli/internal/config"
 	"github.com/agynio/agynd-cli/internal/tracingproxy"
+	codex "github.com/agynio/codex-sdk-go"
 )
 
 const codexConfigTemplate = `model_provider = "platform"
@@ -36,8 +39,18 @@ const (
 	codexEnvHome                     = "HOME"
 	codexEnvCodexHome                = "CODEX_HOME"
 	codexEnvOpenAIAPIKey             = "OPENAI_API_KEY"
+	codexEnvCodexAPIKey              = "CODEX_API_KEY"
+	codexEnvCodexAccessToken         = "CODEX_ACCESS_TOKEN"
 	codexEnvOTELExporterOTLPEndpoint = "OTEL_EXPORTER_OTLP_ENDPOINT"
 )
+
+var codexAuthEnvMu sync.Mutex
+
+var codexAuthEnvVars = []string{
+	codexEnvOpenAIAPIKey,
+	codexEnvCodexAPIKey,
+	codexEnvCodexAccessToken,
+}
 
 func writeCodexConfig(llmBaseURL string, mcpServers []config.MCPServer) (string, error) {
 	codexHome := filepath.Join(codexHomeEnv(), ".codex")
@@ -82,6 +95,56 @@ func codexEnv(cfg config.Config, codexHome, codexHomeValue, otlpEndpoint string)
 		env[codexEnvOpenAIAPIKey] = cfg.LLMAPIToken
 	}
 	return env
+}
+
+func newCodexClient(ctx context.Context, cfg config.Config, options ...codex.Option) (codexClient, error) {
+	if !isZitiLLMBaseURL(cfg.LLMBaseURL) {
+		return codex.NewClient(ctx, options...)
+	}
+	return withoutCodexAuthEnv(func() (codexClient, error) {
+		return codex.NewClient(ctx, options...)
+	})
+}
+
+func withoutCodexAuthEnv(start func() (codexClient, error)) (codexClient, error) {
+	codexAuthEnvMu.Lock()
+	defer codexAuthEnvMu.Unlock()
+
+	originalEnv := captureEnv(codexAuthEnvVars)
+	for _, key := range codexAuthEnvVars {
+		if err := os.Unsetenv(key); err != nil {
+			restoreEnv(originalEnv)
+			return nil, fmt.Errorf("unset %s: %w", key, err)
+		}
+	}
+
+	client, err := start()
+	restoreEnv(originalEnv)
+	return client, err
+}
+
+type envValue struct {
+	value string
+	set   bool
+}
+
+func captureEnv(keys []string) map[string]envValue {
+	values := make(map[string]envValue, len(keys))
+	for _, key := range keys {
+		value, ok := os.LookupEnv(key)
+		values[key] = envValue{value: value, set: ok}
+	}
+	return values
+}
+
+func restoreEnv(values map[string]envValue) {
+	for key, value := range values {
+		if value.set {
+			_ = os.Setenv(key, value.value)
+			continue
+		}
+		_ = os.Unsetenv(key)
+	}
 }
 
 func isZitiLLMBaseURL(llmBaseURL string) bool {

--- a/internal/daemon/codexconfig_test.go
+++ b/internal/daemon/codexconfig_test.go
@@ -1,14 +1,35 @@
 package daemon
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/agynio/agynd-cli/internal/config"
 	"github.com/agynio/agynd-cli/internal/tracingproxy"
+	codex "github.com/agynio/codex-sdk-go"
 )
+
+type noopCodexClient struct{}
+
+func (noopCodexClient) StartThread(context.Context, *codex.ThreadStartParams) (*codex.ThreadStartResponse, error) {
+	return nil, nil
+}
+
+func (noopCodexClient) ResumeThread(context.Context, *codex.ThreadResumeParams) (*codex.ThreadResumeResponse, error) {
+	return nil, nil
+}
+
+func (noopCodexClient) StartTurn(context.Context, *codex.TurnStartParams) (*codex.TurnStartResponse, error) {
+	return nil, nil
+}
+
+func (noopCodexClient) Close() error {
+	return nil
+}
 
 func TestWriteCodexConfig(t *testing.T) {
 	tmpHome := t.TempDir()
@@ -152,6 +173,74 @@ func TestCodexEnvOmitsAPIKeyForZitiLLM(t *testing.T) {
 		t.Fatalf("expected ziti codex env to omit %s", codexEnvOpenAIAPIKey)
 	}
 	assertCodexBaseEnv(t, env)
+}
+
+func TestWithoutCodexAuthEnvRemovesParentAuthVarsDuringStart(t *testing.T) {
+	t.Setenv(codexEnvOpenAIAPIKey, "parent-openai-token")
+	t.Setenv(codexEnvCodexAPIKey, "parent-codex-token")
+	t.Setenv(codexEnvCodexAccessToken, "parent-access-token")
+
+	seenEnv := map[string]bool{}
+	_, err := withoutCodexAuthEnv(func() (codexClient, error) {
+		for _, key := range codexAuthEnvVars {
+			_, seenEnv[key] = os.LookupEnv(key)
+		}
+		return noopCodexClient{}, nil
+	})
+	if err != nil {
+		t.Fatalf("expected auth env scrub to succeed, got %v", err)
+	}
+
+	for _, key := range codexAuthEnvVars {
+		if seenEnv[key] {
+			t.Fatalf("expected %s to be unset while starting ziti Codex", key)
+		}
+	}
+	if got := os.Getenv(codexEnvOpenAIAPIKey); got != "parent-openai-token" {
+		t.Fatalf("expected OPENAI_API_KEY restore, got %q", got)
+	}
+	if got := os.Getenv(codexEnvCodexAPIKey); got != "parent-codex-token" {
+		t.Fatalf("expected CODEX_API_KEY restore, got %q", got)
+	}
+	if got := os.Getenv(codexEnvCodexAccessToken); got != "parent-access-token" {
+		t.Fatalf("expected CODEX_ACCESS_TOKEN restore, got %q", got)
+	}
+}
+
+func TestZitiCodexProcessReceivesNoAuthEnvConfig(t *testing.T) {
+	t.Setenv(codexEnvOpenAIAPIKey, "parent-openai-token")
+	t.Setenv(codexEnvCodexAPIKey, "parent-codex-token")
+	t.Setenv(codexEnvCodexAccessToken, "parent-access-token")
+	t.Setenv("PATH", "/usr/bin")
+	cfg := config.Config{
+		LLMBaseURL:  "http://llm-proxy.ziti:443/v1",
+		LLMAPIToken: "agent-env-token",
+	}
+
+	env := codexEnv(cfg, "/tmp/.codex", "/tmp", "http://127.0.0.1:4317")
+	configPayload := codexConfig(cfg.LLMBaseURL, nil)
+	seenEnv := map[string]bool{}
+	_, err := withoutCodexAuthEnv(func() (codexClient, error) {
+		for _, key := range codexAuthEnvVars {
+			_, seenEnv[key] = os.LookupEnv(key)
+			if _, ok := env[key]; ok {
+				t.Fatalf("expected ziti codex env overrides to omit %s", key)
+			}
+		}
+		return noopCodexClient{}, nil
+	})
+	if err != nil {
+		t.Fatalf("expected auth env scrub to succeed, got %v", err)
+	}
+
+	for _, key := range codexAuthEnvVars {
+		if seenEnv[key] {
+			t.Fatalf("expected parent %s to be absent during ziti Codex start", key)
+		}
+	}
+	if strings.Contains(configPayload, "env_key") {
+		t.Fatalf("expected ziti codex config to omit env_key, got %q", configPayload)
+	}
 }
 
 func TestIsZitiLLMBaseURL(t *testing.T) {

--- a/internal/daemon/codexconfig_test.go
+++ b/internal/daemon/codexconfig_test.go
@@ -15,7 +15,6 @@ func TestWriteCodexConfig(t *testing.T) {
 	t.Setenv("HOME", tmpHome)
 
 	baseURL := "https://example.com"
-	otlpEndpoint := "http://" + tracingproxy.ListenAddress
 	codexHome, err := writeCodexConfig(baseURL, nil)
 	if err != nil {
 		t.Fatalf("expected config to be written, got %v", err)
@@ -32,21 +31,7 @@ func TestWriteCodexConfig(t *testing.T) {
 		t.Fatalf("expected config to be readable, got %v", err)
 	}
 
-	expected := fmt.Sprintf(`model_provider = "platform"
-approval_policy = "never"
-sandbox_mode = "danger-full-access"
-
-[otel]
-trace_exporter = { otlp-grpc = { endpoint = %q } }
-metrics_exporter = "none"
-exporter = "none"
-
-[model_providers.platform]
-name = "Agyn LLM"
-base_url = %q
-env_key = "OPENAI_API_KEY"
-wire_api = "responses"
-`, otlpEndpoint, baseURL)
+	expected := codexConfigWithAPIKey(baseURL)
 	if string(content) != expected {
 		t.Fatalf("expected config %q, got %q", expected, string(content))
 	}
@@ -56,7 +41,6 @@ func TestWriteCodexConfigHomeFallback(t *testing.T) {
 	t.Setenv("HOME", "")
 
 	baseURL := "https://example.com"
-	otlpEndpoint := "http://" + tracingproxy.ListenAddress
 	codexHome, err := writeCodexConfig(baseURL, nil)
 	if err != nil {
 		t.Fatalf("expected config to be written, got %v", err)
@@ -73,21 +57,29 @@ func TestWriteCodexConfigHomeFallback(t *testing.T) {
 		t.Fatalf("expected config to be readable, got %v", err)
 	}
 
-	expected := fmt.Sprintf(`model_provider = "platform"
-approval_policy = "never"
-sandbox_mode = "danger-full-access"
+	expected := codexConfigWithAPIKey(baseURL)
+	if string(content) != expected {
+		t.Fatalf("expected config %q, got %q", expected, string(content))
+	}
+}
 
-[otel]
-trace_exporter = { otlp-grpc = { endpoint = %q } }
-metrics_exporter = "none"
-exporter = "none"
+func TestWriteCodexConfigForZitiOmitsAPIKeyEnv(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
 
-[model_providers.platform]
-name = "Agyn LLM"
-base_url = %q
-env_key = "OPENAI_API_KEY"
-wire_api = "responses"
-`, otlpEndpoint, baseURL)
+	baseURL := "http://llm-proxy.ziti:443/v1"
+	codexHome, err := writeCodexConfig(baseURL, nil)
+	if err != nil {
+		t.Fatalf("expected config to be written, got %v", err)
+	}
+
+	configPath := filepath.Join(codexHome, "config.toml")
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("expected config to be readable, got %v", err)
+	}
+
+	expected := codexConfigWithoutAPIKey(baseURL)
 	if string(content) != expected {
 		t.Fatalf("expected config %q, got %q", expected, string(content))
 	}
@@ -98,7 +90,6 @@ func TestWriteCodexConfigWithMCPServers(t *testing.T) {
 	t.Setenv("HOME", tmpHome)
 
 	baseURL := "https://example.com"
-	otlpEndpoint := "http://" + tracingproxy.ListenAddress
 	mcpServers := []config.MCPServer{
 		{Name: "memory", Port: 8100},
 		{Name: "cache", Port: 8200},
@@ -119,21 +110,7 @@ func TestWriteCodexConfigWithMCPServers(t *testing.T) {
 		t.Fatalf("expected config to be readable, got %v", err)
 	}
 
-	expected := fmt.Sprintf(`model_provider = "platform"
-approval_policy = "never"
-sandbox_mode = "danger-full-access"
-
-[otel]
-trace_exporter = { otlp-grpc = { endpoint = %q } }
-metrics_exporter = "none"
-exporter = "none"
-
-[model_providers.platform]
-name = "Agyn LLM"
-base_url = %q
-env_key = "OPENAI_API_KEY"
-wire_api = "responses"
-`, otlpEndpoint, baseURL) +
+	expected := codexConfigWithAPIKey(baseURL) +
 		"\n[mcp_servers.memory]\n" +
 		"url = \"http://localhost:8100/mcp\"\n" +
 		"required = true\n" +
@@ -145,4 +122,100 @@ wire_api = "responses"
 	if string(content) != expected {
 		t.Fatalf("expected config %q, got %q", expected, string(content))
 	}
+}
+
+func TestCodexEnvIncludesAPIKeyForPublicLLM(t *testing.T) {
+	t.Setenv("PATH", "/usr/bin")
+	cfg := config.Config{
+		LLMBaseURL:  "https://llm.example/v1",
+		LLMAPIToken: "token-123",
+	}
+
+	env := codexEnv(cfg, "/tmp/.codex", "/tmp", "http://127.0.0.1:4317")
+
+	if env[codexEnvOpenAIAPIKey] != "token-123" {
+		t.Fatalf("expected API key in codex env, got %q", env[codexEnvOpenAIAPIKey])
+	}
+	assertCodexBaseEnv(t, env)
+}
+
+func TestCodexEnvOmitsAPIKeyForZitiLLM(t *testing.T) {
+	t.Setenv("PATH", "/usr/bin")
+	cfg := config.Config{
+		LLMBaseURL:  "http://llm-proxy.ziti:443/v1",
+		LLMAPIToken: "user-token",
+	}
+
+	env := codexEnv(cfg, "/tmp/.codex", "/tmp", "http://127.0.0.1:4317")
+
+	if _, ok := env[codexEnvOpenAIAPIKey]; ok {
+		t.Fatalf("expected ziti codex env to omit %s", codexEnvOpenAIAPIKey)
+	}
+	assertCodexBaseEnv(t, env)
+}
+
+func TestIsZitiLLMBaseURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{name: "platform proxy", url: "http://llm-proxy.ziti:443/v1", want: true},
+		{name: "nested ziti host", url: "https://models.mesh.ziti/v1", want: true},
+		{name: "uppercase host", url: " HTTP://LLM-PROXY.ZITI:443/v1 ", want: true},
+		{name: "public endpoint", url: "https://llm.example/v1", want: false},
+		{name: "ziti as registrable suffix", url: "https://exampleziti/v1", want: false},
+		{name: "invalid url", url: "://bad", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isZitiLLMBaseURL(tt.url); got != tt.want {
+				t.Fatalf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+func assertCodexBaseEnv(t *testing.T, env map[string]string) {
+	t.Helper()
+	if env[codexEnvPath] != agentPathValue() {
+		t.Fatalf("expected PATH %q, got %q", agentPathValue(), env[codexEnvPath])
+	}
+	if env[codexEnvCodexHome] != "/tmp/.codex" {
+		t.Fatalf("expected CODEX_HOME, got %q", env[codexEnvCodexHome])
+	}
+	if env[codexEnvHome] != "/tmp" {
+		t.Fatalf("expected HOME, got %q", env[codexEnvHome])
+	}
+	if env[codexEnvOTELExporterOTLPEndpoint] != "http://127.0.0.1:4317" {
+		t.Fatalf("expected OTLP endpoint, got %q", env[codexEnvOTELExporterOTLPEndpoint])
+	}
+}
+
+func codexConfigWithAPIKey(baseURL string) string {
+	return codexConfigPayload(baseURL, `env_key = "OPENAI_API_KEY"
+`)
+}
+
+func codexConfigWithoutAPIKey(baseURL string) string {
+	return codexConfigPayload(baseURL, "")
+}
+
+func codexConfigPayload(baseURL, apiKeyEnv string) string {
+	otlpEndpoint := "http://" + tracingproxy.ListenAddress
+	return fmt.Sprintf(`model_provider = "platform"
+approval_policy = "never"
+sandbox_mode = "danger-full-access"
+
+[otel]
+trace_exporter = { otlp-grpc = { endpoint = %q } }
+metrics_exporter = "none"
+exporter = "none"
+
+[model_providers.platform]
+name = "Agyn LLM"
+base_url = %q
+%swire_api = "responses"
+`, otlpEndpoint, baseURL, apiKeyEnv)
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -284,7 +284,7 @@ func newCodexDaemon(ctx context.Context, cfg config.Config, version string) (*Da
 		codex.WithApprovalHandler(codex.AutoApprovalHandler{}),
 		codex.WithClientInfo("agynd", version),
 	}
-	codexClient, err := codex.NewClient(ctx, options...)
+	codexClient, err := newCodexClient(ctx, cfg, options...)
 	if err != nil {
 		tracingProxy.Close()
 		_ = setup.gatewayConn.Close()

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -279,13 +279,7 @@ func newCodexDaemon(ctx context.Context, cfg config.Config, version string) (*Da
 	options := []codex.Option{
 		codex.WithBinary(cfg.AgentBinary),
 		codex.WithWorkDir(cfg.WorkDir),
-		codex.WithEnv(map[string]string{
-			"PATH":                        agentPathValue(),
-			"CODEX_HOME":                  codexHome,
-			"HOME":                        codexHomeValue,
-			"OPENAI_API_KEY":              cfg.LLMAPIToken,
-			"OTEL_EXPORTER_OTLP_ENDPOINT": otlpEndpoint,
-		}),
+		codex.WithEnv(codexEnv(cfg, codexHome, codexHomeValue, otlpEndpoint)),
 		codex.WithNotificationHandler(bridge),
 		codex.WithApprovalHandler(codex.AutoApprovalHandler{}),
 		codex.WithClientInfo("agynd", version),


### PR DESCRIPTION
## Summary
- Fixes agynio/chat-app#96.
- Stops Codex agent turns from attaching a human `OPENAI_API_KEY` bearer token when the configured LLM endpoint is an OpenZiti host (`*.ziti`).
- Omits Codex provider `env_key` for Ziti LLM endpoints so llm-proxy authenticates via workload/Ziti identity instead of resolving the human user token first.
- Keeps the existing API-key behavior for non-Ziti/public LLM endpoints.
- Updates `github.com/agynio/codex-sdk-go` from `@main` so Codex can launch without `OPENAI_API_KEY` in the Ziti path.

## Evidence
Run `26183071285` logged `principal_identity_type=user` and `tuple_user=identity:<human-user-id>` for `llm-proxy.ziti` requests. Tracing found agynd was exporting the e2e human API token as `OPENAI_API_KEY`, and Codex provider config used `env_key = "OPENAI_API_KEY"`, causing the bearer token to override Ziti identity resolution.

## Tests
- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `git diff --check`