### PR TITLE
fix(e2e): skip missing agynd workload patch

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -3,31 +3,40 @@ version: v2beta1
 vars:
   AGYND_NAMESPACE: platform
   DEV_IMAGE: ghcr.io/agynio/devcontainer-go:1
+  AGYND_ARGOCD_APP: agynd
+  AGYND_DEPLOYMENT: agynd-agynd
 
 functions:
   disable_argocd_sync: |-
-    if kubectl get application agynd -n argocd >/dev/null 2>&1; then
-      echo "Disabling ArgoCD auto-sync for agynd..."
-      kubectl patch application agynd -n argocd \
+    if kubectl get application ${AGYND_ARGOCD_APP} -n argocd >/dev/null 2>&1; then
+      echo "Disabling ArgoCD auto-sync for ${AGYND_ARGOCD_APP}..."
+      kubectl patch application ${AGYND_ARGOCD_APP} -n argocd \
         --type merge \
         -p '{"spec":{"syncPolicy":{"automated":null}}}'
       echo "ArgoCD auto-sync disabled."
     else
-      echo "WARNING: ArgoCD Application 'agynd' not found in argocd namespace."
+      echo "ArgoCD Application '${AGYND_ARGOCD_APP}' not found; using baseline stack."
     fi
   restore_argocd_sync: &restore_argocd_sync |-
-    if kubectl get application agynd -n argocd >/dev/null 2>&1; then
-      echo "Re-enabling ArgoCD auto-sync for agynd..."
-      kubectl patch application agynd -n argocd \
+    if kubectl get application ${AGYND_ARGOCD_APP} -n argocd >/dev/null 2>&1; then
+      echo "Re-enabling ArgoCD auto-sync for ${AGYND_ARGOCD_APP}..."
+      kubectl patch application ${AGYND_ARGOCD_APP} -n argocd \
         --type merge \
         -p '{"spec":{"syncPolicy":{"automated":{"prune":true,"selfHeal":true}}}}'
       echo "ArgoCD auto-sync restored."
     else
-      echo "WARNING: ArgoCD Application 'agynd' not found in argocd namespace."
+      echo "ArgoCD Application '${AGYND_ARGOCD_APP}' not found; no sync policy to restore."
     fi
+  agynd_deployment_exists: |-
+    kubectl get deployment ${AGYND_DEPLOYMENT} -n ${AGYND_NAMESPACE} >/dev/null 2>&1
   patch_deployment: |-
-    echo "Patching agynd deployment for DevSpace..."
-    kubectl patch deployment agynd-agynd -n ${AGYND_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
+    if ! agynd_deployment_exists; then
+      echo "Deployment '${AGYND_DEPLOYMENT}' not found in namespace '${AGYND_NAMESPACE}'; using baseline stack."
+      return 0
+    fi
+
+    echo "Patching ${AGYND_DEPLOYMENT} deployment for DevSpace..."
+    kubectl patch deployment ${AGYND_DEPLOYMENT} -n ${AGYND_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
     spec:
       template:
         spec:
@@ -88,7 +97,9 @@ pipelines:
     run: |-
       disable_argocd_sync
       patch_deployment
-      if [ "$(get_flag "watch")" == "true" ]; then
+      if ! agynd_deployment_exists; then
+        echo "No agynd deployment is provisioned; deploy step completed against baseline stack."
+      elif [ "$(get_flag "watch")" == "true" ]; then
         start_dev --disable-pod-replace agynd
       else
         start_dev --disable-pod-replace agynd


### PR DESCRIPTION
## Summary
- Confirmed bootstrap platform stack provisions ArgoCD apps such as `agents` and `agents-orchestrator`, but not an `agynd` ArgoCD app or `agynd-agynd` deployment.
- Updated `devspace.yaml` so deploy-from-source skips patching/start-dev when the agynd workload is absent and continues against the provisioned baseline stack.
- Kept the existing patch path intact for environments that do provide an agynd workload.

Fixes #126

## Test & Lint Summary
- `buf generate buf.build/agynio/api --path agynio/api/gateway/v1 --include-imports`: passed
- `go test ./...`: 7 passed / 0 failed / 0 skipped
- `AGN_REPO_PATH=/workspace/agn-cli go test -count=1 -tags e2e ./test/e2e`: 2 passed / 0 failed / 0 skipped
- `go vet ./...`: passed with no errors
- `go build ./...`: passed
- `helm dependency build charts/agynd && helm lint charts/agynd`: 1 chart passed / 0 failed / 0 skipped; lint passed with no errors
- `devspace print`: passed