### PR TITLE
fix(tracing): retain turn message id

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,9 +26,6 @@ jobs:
       - name: Setup DevSpace
         uses: agynio/e2e/.github/actions/setup-devspace@main
 
-      - name: Deploy agynd-cli from source
-        run: devspace dev
-
       - name: Run E2E tests
         uses: agynio/e2e/.github/actions/run-tests@main
         with:

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -507,7 +507,6 @@ func (d *Daemon) syncMessages(ctx context.Context) error {
 	if err := d.consumer.Sync(ctx, d.cfg.AgentID.String(), d.cfg.ThreadID, func(message platform.Message) error {
 		if d.tracingProxy != nil {
 			d.tracingProxy.SetMessageID(message.ID)
-			defer d.tracingProxy.ClearMessageID()
 		}
 		return d.handleMessage(ctx, message)
 	}); err != nil {

--- a/internal/tracingproxy/proxy_test.go
+++ b/internal/tracingproxy/proxy_test.go
@@ -213,7 +213,7 @@ func TestProxyForwardsToUpstream(t *testing.T) {
 	}
 }
 
-func TestProxyClearsMessageID(t *testing.T) {
+func TestProxyKeepsMessageIDForDelayedExports(t *testing.T) {
 	server, listener, requests := startCaptureServer(t)
 	defer server.Stop()
 
@@ -245,7 +245,7 @@ func TestProxyClearsMessageID(t *testing.T) {
 		t.Fatalf("expected forwarded request to include message id, got %v", value)
 	}
 
-	proxy.ClearMessageID()
+	time.Sleep(25 * time.Millisecond)
 	_, err = client.Export(ctx, &collectortracev1.ExportTraceServiceRequest{
 		ResourceSpans: []*tracev1.ResourceSpans{{Resource: &resourcev1.Resource{}}},
 	})
@@ -253,8 +253,53 @@ func TestProxyClearsMessageID(t *testing.T) {
 		t.Fatalf("export via proxy: %v", err)
 	}
 	forwarded = awaitRequest(t, requests)
-	if _, ok := findAttribute(forwarded.ResourceSpans[0].Resource, messageIDAttributeKey); ok {
-		t.Fatal("expected message id to be cleared")
+	if value, ok := findAttribute(forwarded.ResourceSpans[0].Resource, messageIDAttributeKey); !ok || value.GetStringValue() != "message-5" {
+		t.Fatalf("expected delayed export to include message id, got %v", value)
+	}
+}
+
+func TestProxyNextMessageOverwritesMessageID(t *testing.T) {
+	server, listener, requests := startCaptureServer(t)
+	defer server.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	proxy, err := Start(ctx, Config{TracingAddress: listener.Addr().String(), ListenAddress: "127.0.0.1:0", ThreadID: "thread-6"})
+	if err != nil {
+		t.Fatalf("start proxy: %v", err)
+	}
+	defer proxy.Close()
+
+	conn, err := grpc.NewClient(proxy.Address(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer conn.Close()
+
+	client := collectortracev1.NewTraceServiceClient(conn)
+	proxy.SetMessageID("message-6a")
+	_, err = client.Export(ctx, &collectortracev1.ExportTraceServiceRequest{
+		ResourceSpans: []*tracev1.ResourceSpans{{Resource: &resourcev1.Resource{}}},
+	})
+	if err != nil {
+		t.Fatalf("export via proxy: %v", err)
+	}
+	forwarded := awaitRequest(t, requests)
+	if value, ok := findAttribute(forwarded.ResourceSpans[0].Resource, messageIDAttributeKey); !ok || value.GetStringValue() != "message-6a" {
+		t.Fatalf("expected forwarded request to include first message id, got %v", value)
+	}
+
+	proxy.SetMessageID("message-6b")
+	_, err = client.Export(ctx, &collectortracev1.ExportTraceServiceRequest{
+		ResourceSpans: []*tracev1.ResourceSpans{{Resource: &resourcev1.Resource{}}},
+	})
+	if err != nil {
+		t.Fatalf("export via proxy: %v", err)
+	}
+	forwarded = awaitRequest(t, requests)
+	if value, ok := findAttribute(forwarded.ResourceSpans[0].Resource, messageIDAttributeKey); !ok || value.GetStringValue() != "message-6b" {
+		t.Fatalf("expected forwarded request to include updated message id, got %v", value)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Keep the active Threads message UUID set on the tracing proxy after message handling returns.
- Let the next message overwrite `agyn.thread.message.id`, so delayed async OTLP exports for the current turn remain correlated.
- Add tracing proxy regression coverage for delayed exports and next-message overwrite behavior.
- Remove the PR E2E `devspace dev` deployment patch step because the provisioned stack does not include an `agynd` ArgoCD app or `agynd-agynd` deployment.

Closes #128
Closes #130

## Test & Lint Summary
- `go test ./...` — 193 passed, 0 failed, 0 skipped.
- `go vet ./...` — passed with no errors.
- `go build ./...` — passed.

## CI Note
- Pushed updates to PR branch `noa/issue-128`.
- GitHub Actions did not create new check runs for the latest branch SHA after the push; workflows in this repo do not expose `workflow_dispatch`, so a manual dispatch rerun is unavailable from the CLI.