### PR TITLE
fix(tracing): mirror message id on spans

### DIFF
--- a/internal/tracingproxy/proxy.go
+++ b/internal/tracingproxy/proxy.go
@@ -12,6 +12,7 @@ import (
 	collectortracev1 "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
 	resourcev1 "go.opentelemetry.io/proto/otlp/resource/v1"
+	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
@@ -175,7 +176,31 @@ func injectMessageID(req *collectortracev1.ExportTraceServiceRequest, messageID 
 			spans.Resource = resource
 		}
 		upsertAttribute(resource, messageIDAttributeKey, messageID)
+		for _, scopeSpans := range spans.GetScopeSpans() {
+			for _, span := range scopeSpans.GetSpans() {
+				upsertSpanAttribute(span, messageIDAttributeKey, messageID)
+			}
+		}
 	}
+}
+
+func upsertSpanAttribute(span *tracev1.Span, key, value string) {
+	if span == nil {
+		return
+	}
+	attributeValue := &commonv1.AnyValue{
+		Value: &commonv1.AnyValue_StringValue{StringValue: value},
+	}
+	for _, attribute := range span.Attributes {
+		if attribute != nil && attribute.Key == key {
+			attribute.Value = attributeValue
+			return
+		}
+	}
+	span.Attributes = append(span.Attributes, &commonv1.KeyValue{
+		Key:   key,
+		Value: attributeValue,
+	})
 }
 
 func upsertAttribute(resource *resourcev1.Resource, key, value string) {

--- a/internal/tracingproxy/proxy_test.go
+++ b/internal/tracingproxy/proxy_test.go
@@ -87,6 +87,15 @@ func TestInjectMessageID(t *testing.T) {
 						{Key: "existing", Value: stringValue("keep")},
 					},
 				},
+				ScopeSpans: []*tracev1.ScopeSpans{
+					{
+						Spans: []*tracev1.Span{
+							{
+								Attributes: []*commonv1.KeyValue{{Key: "span.existing", Value: stringValue("keep")}},
+							},
+						},
+					},
+				},
 			},
 		},
 	}
@@ -100,8 +109,18 @@ func TestInjectMessageID(t *testing.T) {
 	if value, ok := findAttribute(resource, messageIDAttributeKey); !ok || value.GetStringValue() != "message-1" {
 		t.Fatalf("expected message id injected, got %v", value)
 	}
+	span := req.ResourceSpans[0].ScopeSpans[0].Spans[0]
+	if value, ok := findSpanAttribute(span, "span.existing"); !ok || value.GetStringValue() != "keep" {
+		t.Fatalf("expected existing span attribute preserved, got %v", value)
+	}
+	if value, ok := findSpanAttribute(span, messageIDAttributeKey); !ok || value.GetStringValue() != "message-1" {
+		t.Fatalf("expected span message id injected, got %v", value)
+	}
 	if len(resource.Attributes) != 2 {
 		t.Fatalf("expected 2 attributes, got %d", len(resource.Attributes))
+	}
+	if len(span.Attributes) != 2 {
+		t.Fatalf("expected 2 span attributes, got %d", len(span.Attributes))
 	}
 }
 
@@ -382,6 +401,18 @@ func findAttribute(resource *resourcev1.Resource, key string) (*commonv1.AnyValu
 		return nil, false
 	}
 	for _, attribute := range resource.Attributes {
+		if attribute != nil && attribute.Key == key {
+			return attribute.Value, true
+		}
+	}
+	return nil, false
+}
+
+func findSpanAttribute(span *tracev1.Span, key string) (*commonv1.AnyValue, bool) {
+	if span == nil {
+		return nil, false
+	}
+	for _, attribute := range span.Attributes {
 		if attribute != nil && attribute.Key == key {
 			return attribute.Value, true
 		}


### PR DESCRIPTION
## Summary

- Mirror `agyn.thread.message.id` onto each exported span attribute as well as the resource attribute.
- Keep the existing resource-level message-id injection unchanged for tracing store generated-column lookup.
- This gives tracing UI/query diagnostics an explicit per-span message-id attribute and keeps message correlation visible even when consumers inspect span attributes directly.

Refs #135
Tracks agynio/agents-orchestrator#207.

## Validation

- `git diff --check`
- `go test ./internal/tracingproxy ./internal/daemon`
- `go test ./...`
- `go vet ./...`

Latest agents-orchestrator E2E after init-image pins still fails only on claude/codex `ListSpans(filter: { messageId })` while go-core expose lifecycle passes; this PR is the next owning daemon-side fix.