### PR TITLE
fix(codex): bypass proxies for Ziti services

### DIFF
--- a/internal/daemon/codexconfig.go
+++ b/internal/daemon/codexconfig.go
@@ -41,7 +41,16 @@ const (
 	codexEnvCodexAPIKey              = "CODEX_API_KEY"
 	codexEnvCodexAccessToken         = "CODEX_ACCESS_TOKEN"
 	codexEnvOTELExporterOTLPEndpoint = "OTEL_EXPORTER_OTLP_ENDPOINT"
+	codexEnvNoProxy                  = "NO_PROXY"
+	codexEnvNoProxyLower             = "no_proxy"
 )
+
+var codexZitiNoProxyHosts = []string{
+	".ziti",
+	"llm-proxy.ziti",
+	"gateway.ziti",
+	"tracing.ziti",
+}
 
 var codexAuthEnvMu sync.Mutex
 
@@ -89,10 +98,49 @@ func codexEnv(cfg config.Config, codexHome, codexHomeValue, otlpEndpoint string)
 		codexEnvHome:                     codexHomeValue,
 		codexEnvOTELExporterOTLPEndpoint: otlpEndpoint,
 	}
-	if !isZitiLLMBaseURL(cfg.LLMBaseURL) {
+	if isZitiLLMBaseURL(cfg.LLMBaseURL) {
+		noProxyValue := zitiNoProxyValue(os.Getenv(codexEnvNoProxy))
+		env[codexEnvNoProxy] = noProxyValue
+		env[codexEnvNoProxyLower] = zitiNoProxyValue(os.Getenv(codexEnvNoProxyLower))
+	} else {
 		env[codexEnvOpenAIAPIKey] = cfg.LLMAPIToken
 	}
 	return env
+}
+
+func zitiNoProxyValue(current string) string {
+	entries := splitNoProxy(current)
+	seen := make(map[string]struct{}, len(entries)+len(codexZitiNoProxyHosts))
+	merged := make([]string, 0, len(entries)+len(codexZitiNoProxyHosts))
+	for _, entry := range entries {
+		key := strings.ToLower(entry)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		merged = append(merged, entry)
+	}
+	for _, host := range codexZitiNoProxyHosts {
+		key := strings.ToLower(host)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		merged = append(merged, host)
+	}
+	return strings.Join(merged, ",")
+}
+
+func splitNoProxy(value string) []string {
+	parts := strings.Split(value, ",")
+	entries := make([]string, 0, len(parts))
+	for _, part := range parts {
+		entry := strings.TrimSpace(part)
+		if entry != "" {
+			entries = append(entries, entry)
+		}
+	}
+	return entries
 }
 
 func newCodexClient(ctx context.Context, cfg config.Config, options ...codex.Option) (codexClient, error) {

--- a/internal/daemon/codexconfig.go
+++ b/internal/daemon/codexconfig.go
@@ -99,26 +99,30 @@ func codexEnv(cfg config.Config, codexHome, codexHomeValue, otlpEndpoint string)
 		codexEnvOTELExporterOTLPEndpoint: otlpEndpoint,
 	}
 	if isZitiLLMBaseURL(cfg.LLMBaseURL) {
-		noProxyValue := zitiNoProxyValue(os.Getenv(codexEnvNoProxy))
+		noProxyValue := zitiNoProxyValue(
+			os.Getenv(codexEnvNoProxy),
+			os.Getenv(codexEnvNoProxyLower),
+		)
 		env[codexEnvNoProxy] = noProxyValue
-		env[codexEnvNoProxyLower] = zitiNoProxyValue(os.Getenv(codexEnvNoProxyLower))
+		env[codexEnvNoProxyLower] = noProxyValue
 	} else {
 		env[codexEnvOpenAIAPIKey] = cfg.LLMAPIToken
 	}
 	return env
 }
 
-func zitiNoProxyValue(current string) string {
-	entries := splitNoProxy(current)
-	seen := make(map[string]struct{}, len(entries)+len(codexZitiNoProxyHosts))
-	merged := make([]string, 0, len(entries)+len(codexZitiNoProxyHosts))
-	for _, entry := range entries {
-		key := strings.ToLower(entry)
-		if _, ok := seen[key]; ok {
-			continue
+func zitiNoProxyValue(values ...string) string {
+	seen := make(map[string]struct{}, len(codexZitiNoProxyHosts))
+	merged := make([]string, 0, len(codexZitiNoProxyHosts))
+	for _, value := range values {
+		for _, entry := range splitNoProxy(value) {
+			key := strings.ToLower(entry)
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			merged = append(merged, entry)
 		}
-		seen[key] = struct{}{}
-		merged = append(merged, entry)
 	}
 	for _, host := range codexZitiNoProxyHosts {
 		key := strings.ToLower(host)

--- a/internal/daemon/codexconfig_test.go
+++ b/internal/daemon/codexconfig_test.go
@@ -193,6 +193,9 @@ func TestCodexEnvMergesNoProxySpellingsForZitiLLM(t *testing.T) {
 	env := codexEnv(cfg, "/tmp/.codex", "/tmp", testCodexOTLPEndpoint)
 
 	want := "localhost,.ZITI,127.0.0.1,gateway.ziti,llm-proxy.ziti,tracing.ziti"
+	if env[codexEnvNoProxyLower] != env[codexEnvNoProxy] {
+		t.Fatalf("expected proxy bypass env spellings to match: %s=%q %s=%q", codexEnvNoProxy, env[codexEnvNoProxy], codexEnvNoProxyLower, env[codexEnvNoProxyLower])
+	}
 	if env[codexEnvNoProxy] != want {
 		t.Fatalf("expected %s %q, got %q", codexEnvNoProxy, want, env[codexEnvNoProxy])
 	}

--- a/internal/daemon/codexconfig_test.go
+++ b/internal/daemon/codexconfig_test.go
@@ -175,13 +175,30 @@ func TestCodexEnvOmitsAPIKeyForZitiLLM(t *testing.T) {
 	if _, ok := env[codexEnvOpenAIAPIKey]; ok {
 		t.Fatalf("expected ziti codex env to omit %s", codexEnvOpenAIAPIKey)
 	}
-	if env[codexEnvNoProxy] != "localhost,llm-proxy.ziti,.ziti,gateway.ziti,tracing.ziti" {
+	if env[codexEnvNoProxy] != "localhost,llm-proxy.ziti,127.0.0.1,.ziti,gateway.ziti,tracing.ziti" {
 		t.Fatalf("unexpected %s: %q", codexEnvNoProxy, env[codexEnvNoProxy])
 	}
-	if env[codexEnvNoProxyLower] != "127.0.0.1,.ziti,llm-proxy.ziti,gateway.ziti,tracing.ziti" {
+	if env[codexEnvNoProxyLower] != env[codexEnvNoProxy] {
 		t.Fatalf("unexpected %s: %q", codexEnvNoProxyLower, env[codexEnvNoProxyLower])
 	}
 	assertCodexBaseEnv(t, env)
+}
+
+func TestCodexEnvMergesNoProxySpellingsForZitiLLM(t *testing.T) {
+	t.Setenv("PATH", "/usr/bin")
+	t.Setenv(codexEnvNoProxy, "localhost, .ZITI")
+	t.Setenv(codexEnvNoProxyLower, "127.0.0.1, localhost, gateway.ziti")
+	cfg := config.Config{LLMBaseURL: "http://llm-proxy.ziti:443/v1"}
+
+	env := codexEnv(cfg, "/tmp/.codex", "/tmp", testCodexOTLPEndpoint)
+
+	want := "localhost,.ZITI,127.0.0.1,gateway.ziti,llm-proxy.ziti,tracing.ziti"
+	if env[codexEnvNoProxy] != want {
+		t.Fatalf("expected %s %q, got %q", codexEnvNoProxy, want, env[codexEnvNoProxy])
+	}
+	if env[codexEnvNoProxyLower] != want {
+		t.Fatalf("expected %s %q, got %q", codexEnvNoProxyLower, want, env[codexEnvNoProxyLower])
+	}
 }
 
 func TestCodexEnvDoesNotSetNoProxyForPublicLLM(t *testing.T) {
@@ -202,8 +219,8 @@ func TestCodexEnvDoesNotSetNoProxyForPublicLLM(t *testing.T) {
 }
 
 func TestZitiNoProxyValue(t *testing.T) {
-	got := zitiNoProxyValue(" localhost, .ZITI,,gateway.ziti ")
-	want := "localhost,.ZITI,gateway.ziti,llm-proxy.ziti,tracing.ziti"
+	got := zitiNoProxyValue(" localhost, .ZITI,,gateway.ziti ", "127.0.0.1,localhost")
+	want := "localhost,.ZITI,gateway.ziti,127.0.0.1,llm-proxy.ziti,tracing.ziti"
 	if got != want {
 		t.Fatalf("expected %q, got %q", want, got)
 	}

--- a/internal/daemon/codexconfig_test.go
+++ b/internal/daemon/codexconfig_test.go
@@ -163,6 +163,8 @@ func TestCodexEnvIncludesAPIKeyForPublicLLM(t *testing.T) {
 
 func TestCodexEnvOmitsAPIKeyForZitiLLM(t *testing.T) {
 	t.Setenv("PATH", "/usr/bin")
+	t.Setenv(codexEnvNoProxy, "localhost, llm-proxy.ziti")
+	t.Setenv(codexEnvNoProxyLower, "127.0.0.1")
 	cfg := config.Config{
 		LLMBaseURL:  "http://llm-proxy.ziti:443/v1",
 		LLMAPIToken: "user-token",
@@ -173,7 +175,38 @@ func TestCodexEnvOmitsAPIKeyForZitiLLM(t *testing.T) {
 	if _, ok := env[codexEnvOpenAIAPIKey]; ok {
 		t.Fatalf("expected ziti codex env to omit %s", codexEnvOpenAIAPIKey)
 	}
+	if env[codexEnvNoProxy] != "localhost,llm-proxy.ziti,.ziti,gateway.ziti,tracing.ziti" {
+		t.Fatalf("unexpected %s: %q", codexEnvNoProxy, env[codexEnvNoProxy])
+	}
+	if env[codexEnvNoProxyLower] != "127.0.0.1,.ziti,llm-proxy.ziti,gateway.ziti,tracing.ziti" {
+		t.Fatalf("unexpected %s: %q", codexEnvNoProxyLower, env[codexEnvNoProxyLower])
+	}
 	assertCodexBaseEnv(t, env)
+}
+
+func TestCodexEnvDoesNotSetNoProxyForPublicLLM(t *testing.T) {
+	t.Setenv("PATH", "/usr/bin")
+	cfg := config.Config{
+		LLMBaseURL:  "https://llm.example/v1",
+		LLMAPIToken: "token-123",
+	}
+
+	env := codexEnv(cfg, "/tmp/.codex", "/tmp", testCodexOTLPEndpoint)
+
+	if _, ok := env[codexEnvNoProxy]; ok {
+		t.Fatalf("expected public LLM env to omit %s", codexEnvNoProxy)
+	}
+	if _, ok := env[codexEnvNoProxyLower]; ok {
+		t.Fatalf("expected public LLM env to omit %s", codexEnvNoProxyLower)
+	}
+}
+
+func TestZitiNoProxyValue(t *testing.T) {
+	got := zitiNoProxyValue(" localhost, .ZITI,,gateway.ziti ")
+	want := "localhost,.ZITI,gateway.ziti,llm-proxy.ziti,tracing.ziti"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
 }
 
 func TestWithoutCodexAuthEnvRemovesParentAuthVarsDuringStart(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fixes #137.
- Adds Ziti service hosts to `NO_PROXY`/`no_proxy` for Codex subprocesses when the LLM base URL targets `.ziti`.
- Preserves existing proxy behavior for public LLM providers.

## Investigation
AO E2E run `28735435589` showed Codex repeatedly emitted `Reconnecting...` and then `stream disconnected before completion: error sending request for url (http://llm-proxy.ziti/v1/responses)`, while `llm-proxy` logs had no matching `/v1/responses` traffic during the failure window. The AO-rendered Ziti intercept for `llm-proxy.ziti` is HTTP on port 80, and Codex's HTTP client respects proxy environment variables unless `NO_PROXY` excludes the origin. Keeping `.ziti`/platform Ziti hosts out of outbound proxies lets the sidecar intercept `http://llm-proxy.ziti/v1/responses` directly.

## Validation
- `go install github.com/bufbuild/buf/cmd/buf@v1.66.0`
- `buf generate buf.build/agynio/api --path agynio/api/gateway/v1 --include-imports`
- `go vet ./...`
- `go test -v ./...`
- Test stats: 195 passed, 0 failed, 0 skipped.
- Lint status: `go vet ./...` passed with no errors.