### PR TITLE
fix(codex): wait for Ziti LLM endpoint

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -699,55 +699,52 @@ func zitiLLMServiceAddress(llmBaseURL string) (string, bool, error) {
 	return net.JoinHostPort(host, port), true, nil
 }
 
-func waitForTCPService(ctx context.Context, addr string, timeout time.Duration, label string) error {
-	deadline := time.NewTimer(timeout)
-	defer deadline.Stop()
-	attempt := 0
-	for {
-		attempt++
-		conn, err := net.DialTimeout("tcp", addr, 1*time.Second)
-		if err == nil {
-			_ = conn.Close()
-			return nil
-		}
-		log.Printf("waiting for %s at %s (attempt %d): %v", label, addr, attempt, err)
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-deadline.C:
-			return fmt.Errorf("%s at %s not ready after %s", label, addr, timeout)
-		case <-time.After(2 * time.Second):
-		}
-	}
+type tcpServiceTarget struct {
+	label string
+	addr  string
 }
 
-func waitForMCPServers(ctx context.Context, servers []config.MCPServer, timeout time.Duration) error {
-	if len(servers) == 0 {
+func waitForTCPService(ctx context.Context, addr string, timeout time.Duration, label string) error {
+	return waitForTCPServices(ctx, []tcpServiceTarget{{label: label, addr: addr}}, timeout)
+}
+
+func waitForTCPServices(ctx context.Context, targets []tcpServiceTarget, timeout time.Duration) error {
+	if len(targets) == 0 {
 		return nil
 	}
 	deadline := time.NewTimer(timeout)
 	defer deadline.Stop()
-	for _, server := range servers {
-		addr := fmt.Sprintf("localhost:%d", server.Port)
+	for _, target := range targets {
 		attempt := 0
 		for {
 			attempt++
-			conn, err := net.DialTimeout("tcp", addr, 1*time.Second)
+			conn, err := net.DialTimeout("tcp", target.addr, 1*time.Second)
 			if err == nil {
 				_ = conn.Close()
 				break
 			}
-			log.Printf("waiting for MCP server %s at %s (attempt %d): %v", server.Name, addr, attempt, err)
+			log.Printf("waiting for %s at %s (attempt %d): %v", target.label, target.addr, attempt, err)
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
 			case <-deadline.C:
-				return fmt.Errorf("MCP server %s at %s not ready after %s", server.Name, addr, timeout)
+				return fmt.Errorf("%s at %s not ready after %s", target.label, target.addr, timeout)
 			case <-time.After(2 * time.Second):
 			}
 		}
 	}
 	return nil
+}
+
+func waitForMCPServers(ctx context.Context, servers []config.MCPServer, timeout time.Duration) error {
+	targets := make([]tcpServiceTarget, 0, len(servers))
+	for _, server := range servers {
+		targets = append(targets, tcpServiceTarget{
+			label: fmt.Sprintf("MCP server %s", server.Name),
+			addr:  fmt.Sprintf("localhost:%d", server.Port),
+		})
+	}
+	return waitForTCPServices(ctx, targets, timeout)
 }
 
 type codexThreadDefaults struct {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"net/url"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -30,6 +31,7 @@ const (
 	messagePublishTimeout           = 15 * time.Second
 	messageAckTimeout               = 15 * time.Second
 	mcpReadyTimeout                 = 120 * time.Second
+	llmReadyTimeout                 = 120 * time.Second
 	syncRetryInitialBackoff         = 1 * time.Second
 	syncRetryMaxBackoff             = 30 * time.Second
 	opSyncPageFetch                 = "sync_page_fetch"
@@ -553,6 +555,9 @@ func (d *Daemon) handleCodexMessage(ctx context.Context, message platform.Messag
 	if err != nil {
 		return err
 	}
+	if err := waitForZitiLLMService(ctx, d.cfg.LLMBaseURL, llmReadyTimeout); err != nil {
+		return fmt.Errorf("wait for LLM service before codex turn: %w", err)
+	}
 	turnCtx, cancel := context.WithTimeout(ctx, turnStartTimeout)
 	turnResp, err := d.codex.StartTurn(turnCtx, &codex.TurnStartParams{
 		ThreadID: codexThreadID,
@@ -655,6 +660,65 @@ func (d *Daemon) ensureCodexThread(ctx context.Context, platformThreadID string)
 		return "", fmt.Errorf("save codex thread mapping for platform thread %s: %w", platformThreadID, err)
 	}
 	return codexThreadID, nil
+}
+
+func waitForZitiLLMService(ctx context.Context, llmBaseURL string, timeout time.Duration) error {
+	addr, ok, err := zitiLLMServiceAddress(llmBaseURL)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	return waitForTCPService(ctx, addr, timeout, "LLM service")
+}
+
+func zitiLLMServiceAddress(llmBaseURL string) (string, bool, error) {
+	if !isZitiLLMBaseURL(llmBaseURL) {
+		return "", false, nil
+	}
+	parsed, err := url.Parse(strings.TrimSpace(llmBaseURL))
+	if err != nil {
+		return "", false, fmt.Errorf("parse LLM base URL: %w", err)
+	}
+	host := parsed.Hostname()
+	if host == "" {
+		return "", false, fmt.Errorf("LLM base URL missing host")
+	}
+	port := parsed.Port()
+	if port == "" {
+		switch parsed.Scheme {
+		case "http":
+			port = "80"
+		case "https":
+			port = "443"
+		default:
+			return "", false, fmt.Errorf("LLM base URL scheme %q has no default port", parsed.Scheme)
+		}
+	}
+	return net.JoinHostPort(host, port), true, nil
+}
+
+func waitForTCPService(ctx context.Context, addr string, timeout time.Duration, label string) error {
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	attempt := 0
+	for {
+		attempt++
+		conn, err := net.DialTimeout("tcp", addr, 1*time.Second)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+		log.Printf("waiting for %s at %s (attempt %d): %v", label, addr, attempt, err)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline.C:
+			return fmt.Errorf("%s at %s not ready after %s", label, addr, timeout)
+		case <-time.After(2 * time.Second):
+		}
+	}
 }
 
 func waitForMCPServers(ctx context.Context, servers []config.MCPServer, timeout time.Duration) error {

--- a/internal/daemon/daemon_llm_test.go
+++ b/internal/daemon/daemon_llm_test.go
@@ -1,0 +1,100 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWaitForZitiLLMServiceSkipsPublicURL(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	if err := waitForZitiLLMService(ctx, "https://llm.example/v1", 10*time.Millisecond); err != nil {
+		t.Fatalf("expected public LLM URL to be skipped, got %v", err)
+	}
+}
+
+func TestZitiLLMServiceAddress(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		addr string
+		ok   bool
+	}{
+		{name: "default http", url: "http://llm-proxy.ziti/v1", addr: "llm-proxy.ziti:80", ok: true},
+		{name: "default https", url: "https://llm-proxy.ziti/v1", addr: "llm-proxy.ziti:443", ok: true},
+		{name: "explicit port", url: "http://llm-proxy.ziti:8080/v1", addr: "llm-proxy.ziti:8080", ok: true},
+		{name: "public", url: "https://llm.example/v1", ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addr, ok, err := zitiLLMServiceAddress(tt.url)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if ok != tt.ok {
+				t.Fatalf("expected ok=%v, got %v", tt.ok, ok)
+			}
+			if addr != tt.addr {
+				t.Fatalf("expected addr %q, got %q", tt.addr, addr)
+			}
+		})
+	}
+}
+
+func TestZitiLLMServiceAddressRejectsMissingDefaultPort(t *testing.T) {
+	_, _, err := zitiLLMServiceAddress("tcp://llm-proxy.ziti/v1")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "has no default port") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestWaitForTCPServiceReady(t *testing.T) {
+	listener, port := startTCPListener(t)
+	defer listener.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	addr := tcpAddrForPort(port)
+	if err := waitForTCPService(ctx, addr, 500*time.Millisecond, "test service"); err != nil {
+		t.Fatalf("expected service to be ready, got %v", err)
+	}
+}
+
+func TestWaitForTCPServiceTimeout(t *testing.T) {
+	addr := tcpAddrForPort(unusedTCPPort(t))
+
+	err := waitForTCPService(context.Background(), addr, 50*time.Millisecond, "test service")
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not ready after") {
+		t.Fatalf("unexpected timeout error: %v", err)
+	}
+}
+
+func TestWaitForTCPServiceContextCanceled(t *testing.T) {
+	addr := tcpAddrForPort(unusedTCPPort(t))
+	ctx, cancel := context.WithCancel(context.Background())
+	timer := time.AfterFunc(20*time.Millisecond, cancel)
+	defer timer.Stop()
+
+	err := waitForTCPService(ctx, addr, 5*time.Second, "test service")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation, got %v", err)
+	}
+}
+
+func tcpAddrForPort(port int) string {
+	return net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+}


### PR DESCRIPTION
## Summary
- Add a Codex turn preflight gate for Ziti-backed LLM URLs so `agynd` waits for the resolved `llm-proxy.ziti` TCP endpoint before starting each Codex turn.
- Keep public/non-Ziti LLM behavior unchanged.
- Add unit coverage for Ziti LLM address parsing, public URL skip behavior, TCP readiness success, timeout, and cancellation.

## Evidence
- AO current-head E2E consumed `agynd-cli` `0.14.19` / PR #138 but still failed before matching `/v1/responses` reached `llm-proxy`.
- Failing workload diagnostics showed `tracing` sidecar service setup immediately before Codex stream reconnects, while no matching `llm-proxy` request appeared during the failure window.
- This patch gates Codex turns on the same in-pod Ziti endpoint path Codex uses for `http://llm-proxy.ziti/v1/responses`.

Fixes #137

## Validation
- `buf generate buf.build/agynio/api --path agynio/api/gateway/v1 --include-imports`
- `go vet ./...`
- `go test -v ./...` — 206 passed, 0 failed, 0 skipped
- `go build ./...`
- `AGN_REPO_PATH=/workspace/agn-cli go test -v -tags e2e ./test/e2e/` — 3 passed, 0 failed, 0 skipped