### PR TITLE
fix(codex): clear proxies for Ziti LLM

### DIFF
--- a/internal/daemon/codexconfig.go
+++ b/internal/daemon/codexconfig.go
@@ -43,6 +43,12 @@ const (
 	codexEnvOTELExporterOTLPEndpoint = "OTEL_EXPORTER_OTLP_ENDPOINT"
 	codexEnvNoProxy                  = "NO_PROXY"
 	codexEnvNoProxyLower             = "no_proxy"
+	codexEnvHTTPProxy                = "HTTP_PROXY"
+	codexEnvHTTPProxyLower           = "http_proxy"
+	codexEnvHTTPSProxy               = "HTTPS_PROXY"
+	codexEnvHTTPSProxyLower          = "https_proxy"
+	codexEnvAllProxy                 = "ALL_PROXY"
+	codexEnvAllProxyLower            = "all_proxy"
 )
 
 var codexZitiNoProxyHosts = []string{
@@ -58,6 +64,15 @@ var codexAuthEnvVars = []string{
 	codexEnvOpenAIAPIKey,
 	codexEnvCodexAPIKey,
 	codexEnvCodexAccessToken,
+}
+
+var codexProxyEnvVars = []string{
+	codexEnvHTTPProxy,
+	codexEnvHTTPProxyLower,
+	codexEnvHTTPSProxy,
+	codexEnvHTTPSProxyLower,
+	codexEnvAllProxy,
+	codexEnvAllProxyLower,
 }
 
 func writeCodexConfig(llmBaseURL string, mcpServers []config.MCPServer, otlpEndpoint string) (string, error) {
@@ -105,6 +120,9 @@ func codexEnv(cfg config.Config, codexHome, codexHomeValue, otlpEndpoint string)
 		)
 		env[codexEnvNoProxy] = noProxyValue
 		env[codexEnvNoProxyLower] = noProxyValue
+		for _, key := range codexProxyEnvVars {
+			env[key] = ""
+		}
 	} else {
 		env[codexEnvOpenAIAPIKey] = cfg.LLMAPIToken
 	}

--- a/internal/daemon/codexconfig_test.go
+++ b/internal/daemon/codexconfig_test.go
@@ -204,6 +204,26 @@ func TestCodexEnvMergesNoProxySpellingsForZitiLLM(t *testing.T) {
 	}
 }
 
+func TestCodexEnvClearsProxyVarsForZitiLLM(t *testing.T) {
+	t.Setenv("PATH", "/usr/bin")
+	for _, key := range codexProxyEnvVars {
+		t.Setenv(key, "http://proxy.invalid:8080")
+	}
+	cfg := config.Config{LLMBaseURL: "http://llm-proxy.ziti:443/v1"}
+
+	env := codexEnv(cfg, "/tmp/.codex", "/tmp", testCodexOTLPEndpoint)
+
+	for _, key := range codexProxyEnvVars {
+		value, ok := env[key]
+		if !ok {
+			t.Fatalf("expected %s override", key)
+		}
+		if value != "" {
+			t.Fatalf("expected %s to be cleared, got %q", key, value)
+		}
+	}
+}
+
 func TestCodexEnvDoesNotSetNoProxyForPublicLLM(t *testing.T) {
 	t.Setenv("PATH", "/usr/bin")
 	cfg := config.Config{
@@ -218,6 +238,11 @@ func TestCodexEnvDoesNotSetNoProxyForPublicLLM(t *testing.T) {
 	}
 	if _, ok := env[codexEnvNoProxyLower]; ok {
 		t.Fatalf("expected public LLM env to omit %s", codexEnvNoProxyLower)
+	}
+	for _, key := range codexProxyEnvVars {
+		if _, ok := env[key]; ok {
+			t.Fatalf("expected public LLM env to omit %s", key)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Clear inherited `HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY` env variants for spawned Codex when the configured LLM endpoint is `.ziti`.
- Keep the existing merged `NO_PROXY`/`no_proxy` Ziti bypass list from PR #138/#139.
- Preserve public/non-Ziti behavior by only applying proxy clearing on Ziti LLM URLs.

## Evidence
- AO current-head E2E consumed `agent-init-codex:0.13.31` with PR #139 but still failed before requests reached `llm-proxy`.
- Failing workload sidecars had the expected `llm-proxy.ziti` resolver/tproxy setup and showed short `llm-proxy` tproxy connections closing with `0 bytes sent; 0 bytes received` while `llm-proxy` logged no matching `/v1/responses` arrivals.
- This points to Codex process transport/env behavior before the request reaches `llm-proxy`; inherited proxy env can preempt direct `.ziti` transport despite `NO_PROXY`, so Ziti Codex children now receive explicit empty proxy overrides.

Fixes #137

## Validation
- `buf generate buf.build/agynio/api --path agynio/api/gateway/v1 --include-imports`
- `go vet ./...`
- `go test -v ./...` — 207 passed, 0 failed, 0 skipped
- `go build ./...`
- `AGN_REPO_PATH=/workspace/agn-cli go test -v -tags e2e ./test/e2e/` — 3 passed, 0 failed, 0 skipped