### PR TITLE
fix(codex): disable provider stream retries

### DIFF
--- a/internal/daemon/codexconfig.go
+++ b/internal/daemon/codexconfig.go
@@ -26,6 +26,9 @@ exporter = "none"
 name = "Agyn LLM"
 base_url = %q
 %swire_api = "responses"
+request_max_retries = 0
+stream_max_retries = 0
+supports_websockets = false
 `
 
 const codexAPIKeyEnv = `env_key = "OPENAI_API_KEY"

--- a/internal/daemon/codexconfig_test.go
+++ b/internal/daemon/codexconfig_test.go
@@ -384,5 +384,8 @@ exporter = "none"
 name = "Agyn LLM"
 base_url = %q
 %swire_api = "responses"
+request_max_retries = 0
+stream_max_retries = 0
+supports_websockets = false
 `, otlpEndpoint, baseURL, apiKeyEnv)
 }


### PR DESCRIPTION
## Summary

- align generated Codex provider config with the repo-local Codex E2E config
- disable Codex provider request/stream retries for the platform responses provider
- disable websocket support for the platform provider

## Current AO evidence

AO PR #220 current head `f9e7fba` consumes `agynd-cli v0.14.21` / `agent-init-codex:0.13.32`, but E2E run `28743479458` still fails with Codex bridge reconnects and `codex_turn_result ... missing agent message`. The remaining difference I found is that agynd's generated runtime Codex provider config still lacks the retry/websocket settings used by agynd-cli's own Codex E2E config.

Refs #137

## Validation

```sh
git diff --check
nix shell nixpkgs#buf nixpkgs#gcc -c sh -c 'buf generate buf.build/agynio/api --path agynio/api/gateway/v1 --include-imports && go test ./... && go build ./...'
```

Results:

- Go tests: passed (`ok` packages: 7; packages with no test files: 1; failed: 0)
- Go build: passed
- Lint/diff check: passed with no errors