### PR TITLE
fix(codex): retain delta-only responses

### DIFF
--- a/internal/codexbridge/bridge.go
+++ b/internal/codexbridge/bridge.go
@@ -12,13 +12,18 @@ import (
 type Bridge struct {
 	tracker *TurnTracker
 	mu      sync.Mutex
-	items   map[string][]codex.ThreadItem
+	items   map[string]*turnItems
+}
+
+type turnItems struct {
+	items         []codex.ThreadItem
+	agentMessages map[string]string
 }
 
 func New(tracker *TurnTracker) *Bridge {
 	return &Bridge{
 		tracker: tracker,
-		items:   make(map[string][]codex.ThreadItem),
+		items:   make(map[string]*turnItems),
 	}
 }
 
@@ -36,8 +41,8 @@ func (b *Bridge) OnTurnCompleted(notification *codex.TurnCompletedNotification) 
 	b.mu.Unlock()
 
 	turn := notification.Turn
-	if len(turn.Items) == 0 && len(accumulated) > 0 {
-		turn.Items = accumulated
+	if accumulated != nil {
+		turn.Items = mergeTurnItems(turn.Items, accumulated)
 	}
 
 	result := TurnResult{
@@ -60,11 +65,20 @@ func (b *Bridge) OnItemCompleted(notification *codex.ItemCompletedNotification) 
 		return
 	}
 	b.mu.Lock()
-	b.items[notification.TurnID] = append(b.items[notification.TurnID], notification.Item)
+	items := b.itemsForTurn(notification.TurnID)
+	items.items = append(items.items, notification.Item)
 	b.mu.Unlock()
 }
 
-func (b *Bridge) OnAgentMessageDelta(*codex.AgentMessageDeltaNotification) {}
+func (b *Bridge) OnAgentMessageDelta(notification *codex.AgentMessageDeltaNotification) {
+	if notification == nil || notification.TurnID == "" || notification.ItemID == "" || notification.Delta == "" {
+		return
+	}
+	b.mu.Lock()
+	items := b.itemsForTurn(notification.TurnID)
+	items.agentMessages[notification.ItemID] += notification.Delta
+	b.mu.Unlock()
+}
 
 func (b *Bridge) OnCommandOutputDelta(*codex.CommandExecutionOutputDeltaNotification) {}
 
@@ -80,6 +94,44 @@ func (b *Bridge) OnError(notification *codex.ErrorNotification) {
 }
 
 func (b *Bridge) OnNotification(string, json.RawMessage) {}
+
+func (b *Bridge) itemsForTurn(turnID string) *turnItems {
+	items := b.items[turnID]
+	if items == nil {
+		items = &turnItems{agentMessages: make(map[string]string)}
+		b.items[turnID] = items
+	}
+	return items
+}
+
+func mergeTurnItems(items []codex.ThreadItem, accumulated *turnItems) []codex.ThreadItem {
+	if len(items) == 0 && len(accumulated.items) > 0 {
+		items = accumulated.items
+	}
+	if len(accumulated.agentMessages) == 0 {
+		return items
+	}
+	merged := append([]codex.ThreadItem(nil), items...)
+	seen := make(map[string]struct{}, len(merged))
+	for _, item := range merged {
+		if item.AgentMessage != nil && item.AgentMessage.ID != "" {
+			seen[item.AgentMessage.ID] = struct{}{}
+		}
+	}
+	for itemID, text := range accumulated.agentMessages {
+		if _, ok := seen[itemID]; ok {
+			continue
+		}
+		merged = append(merged, codex.ThreadItem{
+			AgentMessage: &codex.AgentMessageThreadItem{
+				ID:   itemID,
+				Type: codex.ThreadItemTypeAgentMessage,
+				Text: text,
+			},
+		})
+	}
+	return merged
+}
 
 func extractFinalAnswer(turn codex.Turn) (string, error) {
 	for _, item := range turn.Items {

--- a/internal/codexbridge/bridge_test.go
+++ b/internal/codexbridge/bridge_test.go
@@ -114,3 +114,40 @@ func TestBridgeAccumulatesItems(t *testing.T) {
 	}
 	assertClosed(t, ch)
 }
+
+func TestBridgeUsesAgentMessageDeltas(t *testing.T) {
+	tracker := NewTurnTracker()
+	bridge := New(tracker)
+	ch := tracker.Register("turn-delta")
+
+	bridge.OnAgentMessageDelta(&codex.AgentMessageDeltaNotification{
+		ThreadID: "thread-1",
+		TurnID:   "turn-delta",
+		ItemID:   "item-agent-1",
+		Delta:    "Hello",
+	})
+	bridge.OnAgentMessageDelta(&codex.AgentMessageDeltaNotification{
+		ThreadID: "thread-1",
+		TurnID:   "turn-delta",
+		ItemID:   "item-agent-1",
+		Delta:    " from delta",
+	})
+
+	bridge.OnTurnCompleted(&codex.TurnCompletedNotification{
+		ThreadID: "thread-1",
+		Turn: codex.Turn{
+			ID:     "turn-delta",
+			Status: codex.TurnStatusCompleted,
+			Items:  nil,
+		},
+	})
+
+	result := receiveResult(t, ch)
+	if result.Err != nil {
+		t.Fatalf("unexpected error: %v", result.Err)
+	}
+	if result.Message != "Hello from delta" {
+		t.Fatalf("unexpected message: %q", result.Message)
+	}
+	assertClosed(t, ch)
+}


### PR DESCRIPTION
## Summary
- collect Codex `item/agentMessage/delta` notifications per turn
- synthesize an agent-message item from deltas when completed turns do not include an agent message
- keep existing completed-item accumulation behavior intact

Fixes #137

## Evidence
AO PR #220 current-head E2E run `28745684873` consumed `agent-init-codex:0.13.33` but still failed with repeated `codex_turn_result` missing-agent-message errors. The workload logs show Codex emitted `stream disconnected before completion` against `http://llm-proxy.ziti/v1/responses`; llm-proxy logs show `/v1/responses` requests returned HTTP 200, so the remaining gap is in Codex bridge result extraction rather than AO env/config.

## Test & lint summary
- `git diff --check` — passed, no whitespace errors
- `nix shell nixpkgs#buf nixpkgs#gcc -c sh -c 'buf generate buf.build/agynio/api --path agynio/api/gateway/v1 --include-imports && go test ./... && go build ./...'` — Go tests passed: 7 package(s) passed, 1 package(s) with no test files, 0 failed; build passed