### PR TITLE
fix(codex): recover completed turn messages

### DIFF
--- a/internal/codexbridge/bridge.go
+++ b/internal/codexbridge/bridge.go
@@ -49,7 +49,7 @@ func (b *Bridge) OnTurnCompleted(notification *codex.TurnCompletedNotification) 
 		ThreadID: notification.ThreadID,
 		TurnID:   turnID,
 	}
-	message, err := extractFinalAnswer(turn)
+	message, err := ExtractFinalAnswer(turn)
 	if err != nil {
 		result.Err = err
 	} else {
@@ -133,7 +133,7 @@ func mergeTurnItems(items []codex.ThreadItem, accumulated *turnItems) []codex.Th
 	return merged
 }
 
-func extractFinalAnswer(turn codex.Turn) (string, error) {
+func ExtractFinalAnswer(turn codex.Turn) (string, error) {
 	for _, item := range turn.Items {
 		if item.AgentMessage == nil {
 			continue

--- a/internal/codexbridge/bridge_test.go
+++ b/internal/codexbridge/bridge_test.go
@@ -24,7 +24,7 @@ func TestExtractFinalAnswerFinalPhase(t *testing.T) {
 			agentMessageItem("final response", &phase),
 		},
 	}
-	got, err := extractFinalAnswer(turn)
+	got, err := ExtractFinalAnswer(turn)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -41,7 +41,7 @@ func TestExtractFinalAnswerFallback(t *testing.T) {
 			agentMessageItem("last response", nil),
 		},
 	}
-	got, err := extractFinalAnswer(turn)
+	got, err := ExtractFinalAnswer(turn)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -52,7 +52,7 @@ func TestExtractFinalAnswerFallback(t *testing.T) {
 
 func TestExtractFinalAnswerEmptyTurn(t *testing.T) {
 	turn := codex.Turn{ID: "turn-empty"}
-	got, err := extractFinalAnswer(turn)
+	got, err := ExtractFinalAnswer(turn)
 	if err == nil {
 		t.Fatal("expected error for empty turn")
 	}
@@ -73,7 +73,7 @@ func TestExtractFinalAnswerNoAgentMessages(t *testing.T) {
 			},
 		},
 	}
-	got, err := extractFinalAnswer(turn)
+	got, err := ExtractFinalAnswer(turn)
 	if err == nil {
 		t.Fatal("expected error for missing agent messages")
 	}

--- a/internal/daemon/codexconfig_test.go
+++ b/internal/daemon/codexconfig_test.go
@@ -22,6 +22,10 @@ func (noopCodexClient) ResumeThread(context.Context, *codex.ThreadResumeParams) 
 	return nil, nil
 }
 
+func (noopCodexClient) ReadThread(context.Context, *codex.ThreadReadParams) (*codex.ThreadReadResponse, error) {
+	return nil, nil
+}
+
 func (noopCodexClient) StartTurn(context.Context, *codex.TurnStartParams) (*codex.TurnStartResponse, error) {
 	return nil, nil
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -85,6 +85,7 @@ type platformConn interface {
 type codexClient interface {
 	StartThread(ctx context.Context, params *codex.ThreadStartParams) (*codex.ThreadStartResponse, error)
 	ResumeThread(ctx context.Context, params *codex.ThreadResumeParams) (*codex.ThreadResumeResponse, error)
+	ReadThread(ctx context.Context, params *codex.ThreadReadParams) (*codex.ThreadReadResponse, error)
 	StartTurn(ctx context.Context, params *codex.TurnStartParams) (*codex.TurnStartResponse, error)
 	Close() error
 }
@@ -575,19 +576,23 @@ func (d *Daemon) handleCodexMessage(ctx context.Context, message platform.Messag
 	completionCh := d.tracker.Register(turnID)
 	select {
 	case result := <-completionCh:
-		if result.Err != nil {
-			return operationError(
-				opCodexTurnResult,
-				0,
-				fmt.Errorf("codex turn %s failed for message %s: %w", turnID, message.ID, result.Err),
-			)
-		}
 		if result.ThreadID != codexThreadID {
 			return operationError(
 				opCodexTurnResult,
 				0,
 				fmt.Errorf("codex turn %s thread mismatch for message %s", turnID, message.ID),
 			)
+		}
+		if result.Err != nil {
+			readbackMessage, readbackErr := d.readCodexTurnMessage(ctx, codexThreadID, turnID)
+			if readbackErr != nil {
+				return operationError(
+					opCodexTurnResult,
+					0,
+					fmt.Errorf("codex turn %s failed for message %s: %w; readback failed: %w", turnID, message.ID, result.Err, readbackErr),
+				)
+			}
+			result.Message = readbackMessage
 		}
 		if strings.TrimSpace(result.Message) == "" {
 			return operationError(
@@ -611,6 +616,27 @@ func (d *Daemon) handleCodexMessage(ctx context.Context, message platform.Messag
 			fmt.Errorf("wait for codex turn %s completion for message %s: %w", turnID, message.ID, ctx.Err()),
 		)
 	}
+}
+
+func (d *Daemon) readCodexTurnMessage(ctx context.Context, codexThreadID, turnID string) (string, error) {
+	threadResp, err := d.codex.ReadThread(ctx, &codex.ThreadReadParams{
+		ThreadID:     codexThreadID,
+		IncludeTurns: true,
+	})
+	if err != nil {
+		return "", fmt.Errorf("read codex thread %s: %w", codexThreadID, err)
+	}
+	for _, turn := range threadResp.Thread.Turns {
+		if turn.ID != turnID {
+			continue
+		}
+		message, err := codexbridge.ExtractFinalAnswer(turn)
+		if err != nil {
+			return "", err
+		}
+		return message, nil
+	}
+	return "", fmt.Errorf("codex turn %s not found in thread %s", turnID, codexThreadID)
 }
 
 func (d *Daemon) ensureCodexThread(ctx context.Context, platformThreadID string) (string, error) {

--- a/internal/daemon/daemon_codex_test.go
+++ b/internal/daemon/daemon_codex_test.go
@@ -25,6 +25,8 @@ type fakeCodexClient struct {
 	resumeParams      *codex.ThreadResumeParams
 	startTurnCtx      context.Context
 	startTurnErr      error
+	readThreadResp    *codex.ThreadReadResponse
+	readThreadErr     error
 }
 
 func (f *fakeCodexClient) StartThread(_ context.Context, params *codex.ThreadStartParams) (*codex.ThreadStartResponse, error) {
@@ -53,6 +55,16 @@ func (f *fakeCodexClient) StartTurnContext() context.Context {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.startTurnCtx
+}
+
+func (f *fakeCodexClient) ReadThread(_ context.Context, _ *codex.ThreadReadParams) (*codex.ThreadReadResponse, error) {
+	if f.readThreadErr != nil {
+		return nil, f.readThreadErr
+	}
+	if f.readThreadResp != nil {
+		return f.readThreadResp, nil
+	}
+	return &codex.ThreadReadResponse{}, nil
 }
 
 func (f *fakeCodexClient) Close() error {
@@ -289,5 +301,46 @@ func TestHandleCodexMessageWrapsTurnResultError(t *testing.T) {
 	}
 	if !errors.Is(err, turnErr) {
 		t.Fatalf("expected wrapped turn error, got %v", err)
+	}
+}
+
+func TestHandleCodexMessageReadsBackTurnMessage(t *testing.T) {
+	store := codexbridge.NewThreadMappingStore(t.TempDir())
+	client := &fakeCodexClient{readThreadResp: &codex.ThreadReadResponse{Thread: codex.Thread{Turns: []codex.Turn{{
+		ID: "turn-1",
+		Items: []codex.ThreadItem{{AgentMessage: &codex.AgentMessageThreadItem{
+			ID:   "agent-message-1",
+			Type: codex.ThreadItemTypeAgentMessage,
+			Text: "readback response",
+		}}},
+	}}}}}
+	daemon := &Daemon{
+		sdk:          SDKCodex,
+		cfg:          config.Config{AgentID: uuid.MustParse(testAgentID), WorkDir: "/tmp"},
+		codex:        client,
+		mapping:      codexbridge.NewThreadMapping(),
+		mappingStore: store,
+		tracker:      codexbridge.NewTurnTracker(),
+		agent:        &agentsv1.Agent{},
+		threads:      platform.NewThreads(&fakeClaudeThreadsClient{}),
+	}
+	message := platform.Message{ID: "msg-1", ThreadID: "thread-1", Body: "hello"}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- daemon.handleCodexMessage(context.Background(), message)
+	}()
+	turnErr := fmt.Errorf("turn missing agent message")
+	daemon.tracker.Notify(codexbridge.TurnResult{
+		ThreadID: "codex-started",
+		TurnID:   "turn-1",
+		Err:      turnErr,
+	})
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("expected readback response to recover turn result, got %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("handleCodexMessage did not finish after turn readback")
 	}
 }


### PR DESCRIPTION
## Summary
- export Codex final-answer extraction for daemon readback
- when a Codex turn completion reports a missing agent message, read the completed thread/turn before failing
- retain the delta-only response handling from PR #142

Fixes #137

## Evidence
AO PR #220 run `28747738497` consumed `agent-init-codex:0.13.35` (`agynd-cli v0.14.23`) and still failed with `codex_turn_result ... missing agent message` after Codex `stream disconnected before completion`. The bridge can receive an error completion before the SDK completion payload has usable items; reading the completed thread/turn is the next downstream-safe recovery point.

## Test & lint summary
- `git diff --check` — passed, no whitespace errors
- `nix shell nixpkgs#buf nixpkgs#gcc -c sh -c 'buf generate buf.build/agynio/api --path agynio/api/gateway/v1 --include-imports && go test ./... && go build ./...'` — Go tests passed: 7 package(s) passed, 1 package(s) with no test files, 0 failed; build passed