### PR TITLE
fix(codex): poll completed turn readback

### DIFF
--- a/internal/codexbridge/bridge.go
+++ b/internal/codexbridge/bridge.go
@@ -2,6 +2,7 @@ package codexbridge
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"sync"
@@ -14,6 +15,8 @@ type Bridge struct {
 	mu      sync.Mutex
 	items   map[string]*turnItems
 }
+
+var ErrMissingAgentMessage = errors.New("missing agent message")
 
 type turnItems struct {
 	items         []codex.ThreadItem
@@ -148,5 +151,5 @@ func ExtractFinalAnswer(turn codex.Turn) (string, error) {
 			return item.AgentMessage.Text, nil
 		}
 	}
-	return "", fmt.Errorf("turn %s missing agent message", turn.ID)
+	return "", fmt.Errorf("turn %s: %w", turn.ID, ErrMissingAgentMessage)
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -32,6 +32,8 @@ const (
 	messageAckTimeout               = 15 * time.Second
 	mcpReadyTimeout                 = 120 * time.Second
 	llmReadyTimeout                 = 120 * time.Second
+	codexReadbackTimeout            = 10 * time.Second
+	codexReadbackPollInterval       = 250 * time.Millisecond
 	syncRetryInitialBackoff         = 1 * time.Second
 	syncRetryMaxBackoff             = 30 * time.Second
 	opSyncPageFetch                 = "sync_page_fetch"
@@ -584,6 +586,13 @@ func (d *Daemon) handleCodexMessage(ctx context.Context, message platform.Messag
 			)
 		}
 		if result.Err != nil {
+			if !errors.Is(result.Err, codexbridge.ErrMissingAgentMessage) {
+				return operationError(
+					opCodexTurnResult,
+					0,
+					fmt.Errorf("codex turn %s failed for message %s: %w", turnID, message.ID, result.Err),
+				)
+			}
 			readbackMessage, readbackErr := d.readCodexTurnMessage(ctx, codexThreadID, turnID)
 			if readbackErr != nil {
 				return operationError(
@@ -619,6 +628,29 @@ func (d *Daemon) handleCodexMessage(ctx context.Context, message platform.Messag
 }
 
 func (d *Daemon) readCodexTurnMessage(ctx context.Context, codexThreadID, turnID string) (string, error) {
+	readbackCtx, cancel := context.WithTimeout(ctx, codexReadbackTimeout)
+	defer cancel()
+
+	ticker := time.NewTicker(codexReadbackPollInterval)
+	defer ticker.Stop()
+
+	var lastErr error
+	for {
+		message, err := d.readCodexTurnMessageOnce(readbackCtx, codexThreadID, turnID)
+		if err == nil {
+			return message, nil
+		}
+		lastErr = err
+
+		select {
+		case <-readbackCtx.Done():
+			return "", fmt.Errorf("read codex turn %s after completion: %w: %w", turnID, lastErr, readbackCtx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func (d *Daemon) readCodexTurnMessageOnce(ctx context.Context, codexThreadID, turnID string) (string, error) {
 	threadResp, err := d.codex.ReadThread(ctx, &codex.ThreadReadParams{
 		ThreadID:     codexThreadID,
 		IncludeTurns: true,

--- a/internal/daemon/daemon_codex_test.go
+++ b/internal/daemon/daemon_codex_test.go
@@ -26,7 +26,9 @@ type fakeCodexClient struct {
 	startTurnCtx      context.Context
 	startTurnErr      error
 	readThreadResp    *codex.ThreadReadResponse
+	readThreadQueue   []*codex.ThreadReadResponse
 	readThreadErr     error
+	readThreadCalls   int
 }
 
 func (f *fakeCodexClient) StartThread(_ context.Context, params *codex.ThreadStartParams) (*codex.ThreadStartResponse, error) {
@@ -58,13 +60,27 @@ func (f *fakeCodexClient) StartTurnContext() context.Context {
 }
 
 func (f *fakeCodexClient) ReadThread(_ context.Context, _ *codex.ThreadReadParams) (*codex.ThreadReadResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.readThreadCalls++
 	if f.readThreadErr != nil {
 		return nil, f.readThreadErr
+	}
+	if len(f.readThreadQueue) > 0 {
+		resp := f.readThreadQueue[0]
+		f.readThreadQueue = f.readThreadQueue[1:]
+		return resp, nil
 	}
 	if f.readThreadResp != nil {
 		return f.readThreadResp, nil
 	}
 	return &codex.ThreadReadResponse{}, nil
+}
+
+func (f *fakeCodexClient) ReadThreadCalls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.readThreadCalls
 }
 
 func (f *fakeCodexClient) Close() error {
@@ -329,7 +345,7 @@ func TestHandleCodexMessageReadsBackTurnMessage(t *testing.T) {
 	go func() {
 		errCh <- daemon.handleCodexMessage(context.Background(), message)
 	}()
-	turnErr := fmt.Errorf("turn missing agent message")
+	turnErr := codexbridge.ErrMissingAgentMessage
 	daemon.tracker.Notify(codexbridge.TurnResult{
 		ThreadID: "codex-started",
 		TurnID:   "turn-1",
@@ -342,5 +358,52 @@ func TestHandleCodexMessageReadsBackTurnMessage(t *testing.T) {
 		}
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("handleCodexMessage did not finish after turn readback")
+	}
+}
+
+func TestHandleCodexMessagePollsReadbackUntilAgentMessage(t *testing.T) {
+	store := codexbridge.NewThreadMappingStore(t.TempDir())
+	client := &fakeCodexClient{readThreadQueue: []*codex.ThreadReadResponse{
+		{Thread: codex.Thread{Turns: []codex.Turn{{ID: "turn-1"}}}},
+		{Thread: codex.Thread{Turns: []codex.Turn{{
+			ID: "turn-1",
+			Items: []codex.ThreadItem{{AgentMessage: &codex.AgentMessageThreadItem{
+				ID:   "agent-message-1",
+				Type: codex.ThreadItemTypeAgentMessage,
+				Text: "eventually visible response",
+			}}},
+		}}}},
+	}}
+	daemon := &Daemon{
+		sdk:          SDKCodex,
+		cfg:          config.Config{AgentID: uuid.MustParse(testAgentID), WorkDir: "/tmp"},
+		codex:        client,
+		mapping:      codexbridge.NewThreadMapping(),
+		mappingStore: store,
+		tracker:      codexbridge.NewTurnTracker(),
+		agent:        &agentsv1.Agent{},
+		threads:      platform.NewThreads(&fakeClaudeThreadsClient{}),
+	}
+	message := platform.Message{ID: "msg-1", ThreadID: "thread-1", Body: "hello"}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- daemon.handleCodexMessage(context.Background(), message)
+	}()
+	turnErr := codexbridge.ErrMissingAgentMessage
+	daemon.tracker.Notify(codexbridge.TurnResult{
+		ThreadID: "codex-started",
+		TurnID:   "turn-1",
+		Err:      turnErr,
+	})
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("expected delayed readback response to recover turn result, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleCodexMessage did not finish after delayed turn readback")
+	}
+	if calls := client.ReadThreadCalls(); calls < 2 {
+		t.Fatalf("expected readback polling, got %d calls", calls)
 	}
 }


### PR DESCRIPTION
## Summary
- Poll Codex `ReadThread` briefly when a completed-turn notification is missing an agent message.
- Restrict readback recovery to the explicit missing-agent-message condition so other Codex errors still fail loudly.
- Add regression coverage for delayed thread readback visibility.

Closes #137 follow-up.

## Evidence
AO PR #220 current head `c8abc8e22b53087fd2df6c53d1c50251d2aa8a74` failed E2E run `28749655542` while consuming `agent-init-codex:0.13.36` / `agynd-cli v0.14.24`.

Current-run logs show the workload pod was ready and Ziti was healthy, but Codex completion/readback raced persistence:

- `codex bridge: error notification: stream disconnected before completion: error sending request for url (http://llm-proxy.ziti/v1/responses)`
- `codex_turn_result failed ... missing agent message; readback failed: turn ... missing agent message`
- `llm-proxy` evidence from prior current artifacts showed `/v1/responses` requests authorized and upstreamed with `status=200`.

That points to downstream Codex bridge/readback timing, not AO rendered env/config.

## Test & lint summary
- `git diff --check`: passed with no whitespace errors.
- `nix shell nixpkgs#buf nixpkgs#gcc -c sh -c 'buf generate buf.build/agynio/api --path agynio/api/gateway/v1 --include-imports && go test ./... && go build ./...'`: 7 packages passed, 1 package with no tests, 0 failed; build passed.