### PR TITLE
fix(codex): tighten readback retries

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -640,14 +640,21 @@ func (d *Daemon) readCodexTurnMessage(ctx context.Context, codexThreadID, turnID
 		if err == nil {
 			return message, nil
 		}
+		if !isRetryableCodexReadbackError(err) {
+			return "", err
+		}
 		lastErr = err
 
 		select {
 		case <-readbackCtx.Done():
-			return "", fmt.Errorf("read codex turn %s after completion: %w: %w", turnID, lastErr, readbackCtx.Err())
+			return "", fmt.Errorf("read codex turn %s after completion timed out after %s: %w", turnID, codexReadbackTimeout, lastErr)
 		case <-ticker.C:
 		}
 	}
+}
+
+func isRetryableCodexReadbackError(err error) bool {
+	return errors.Is(err, codexbridge.ErrMissingAgentMessage)
 }
 
 func (d *Daemon) readCodexTurnMessageOnce(ctx context.Context, codexThreadID, turnID string) (string, error) {

--- a/internal/daemon/daemon_codex_test.go
+++ b/internal/daemon/daemon_codex_test.go
@@ -407,3 +407,61 @@ func TestHandleCodexMessagePollsReadbackUntilAgentMessage(t *testing.T) {
 		t.Fatalf("expected readback polling, got %d calls", calls)
 	}
 }
+
+func TestHandleCodexMessageReturnsReadbackTransportError(t *testing.T) {
+	store := codexbridge.NewThreadMappingStore(t.TempDir())
+	readErr := fmt.Errorf("read transport unavailable")
+	client := &fakeCodexClient{readThreadErr: readErr}
+	daemon := &Daemon{
+		sdk:          SDKCodex,
+		cfg:          config.Config{AgentID: uuid.MustParse(testAgentID), WorkDir: "/tmp"},
+		codex:        client,
+		mapping:      codexbridge.NewThreadMapping(),
+		mappingStore: store,
+		tracker:      codexbridge.NewTurnTracker(),
+		agent:        &agentsv1.Agent{},
+		threads:      platform.NewThreads(&fakeClaudeThreadsClient{}),
+	}
+	message := platform.Message{ID: "msg-1", ThreadID: "thread-1", Body: "hello"}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- daemon.handleCodexMessage(context.Background(), message)
+	}()
+	daemon.tracker.Notify(codexbridge.TurnResult{
+		ThreadID: "codex-started",
+		TurnID:   "turn-1",
+		Err:      codexbridge.ErrMissingAgentMessage,
+	})
+	var err error
+	select {
+	case err = <-errCh:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("handleCodexMessage did not finish after readback transport error")
+	}
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, readErr) {
+		t.Fatalf("expected readback transport error to remain unwrap-able, got %v", err)
+	}
+	if calls := client.ReadThreadCalls(); calls != 1 {
+		t.Fatalf("expected readback transport error to fail without retry, got %d calls", calls)
+	}
+}
+
+func TestReadCodexTurnMessageTimeoutWrapsRetryableCause(t *testing.T) {
+	client := &fakeCodexClient{readThreadResp: &codex.ThreadReadResponse{Thread: codex.Thread{Turns: []codex.Turn{{ID: "turn-1"}}}}}
+	daemon := &Daemon{codex: client}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	_, err := daemon.readCodexTurnMessage(ctx, "codex-thread-1", "turn-1")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, codexbridge.ErrMissingAgentMessage) {
+		t.Fatalf("expected retryable cause to remain unwrap-able, got %v", err)
+	}
+	if strings.Contains(err.Error(), "context deadline exceeded") {
+		t.Fatalf("expected timeout text without double wrapping context deadline: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Retry Codex completed-turn readback only for the explicit missing-agent-message state.
- Return `ReadThread` transport/API errors immediately so they are not hidden behind polling.
- Replace the timeout error with single-cause wrapping so the retryable root cause remains unwrap-able.
- Add regression coverage for non-retryable readback errors and timeout wrapping.

Follow-up to #144 for Noa's merged-PR review comments:
- https://github.com/agynio/agynd-cli/pull/144#discussion_r3525477191
- https://github.com/agynio/agynd-cli/pull/144#discussion_r3525477271

Refs #137.

## Test & lint summary
- `git diff --check`: passed with no whitespace errors.
- `nix shell nixpkgs#buf nixpkgs#gcc -c sh -c 'buf generate buf.build/agynio/api --path agynio/api/gateway/v1 --include-imports && go test ./... && go build ./...'`: 7 packages passed, 1 package with no tests, 0 failed; build passed.