### PR TITLE
fix(codex): stop retrying terminal turn failures

### DIFF
--- a/internal/codexbridge/bridge.go
+++ b/internal/codexbridge/bridge.go
@@ -18,6 +18,22 @@ type Bridge struct {
 
 var ErrMissingAgentMessage = errors.New("missing agent message")
 
+type ErrorNotificationError struct {
+	ThreadID  string
+	TurnID    string
+	Message   string
+	WillRetry bool
+	Details   string
+}
+
+func (e *ErrorNotificationError) Error() string {
+	base := fmt.Sprintf("codex error notification for turn %s on thread %s: %s", e.TurnID, e.ThreadID, e.Message)
+	if e.Details == "" {
+		return base
+	}
+	return base + ": " + e.Details
+}
+
 type turnItems struct {
 	items         []codex.ThreadItem
 	agentMessages map[string]string
@@ -93,7 +109,32 @@ func (b *Bridge) OnError(notification *codex.ErrorNotification) {
 	if notification == nil {
 		return
 	}
-	log.Printf("codex bridge: error notification: %s", notification.Error.Message)
+	details := ""
+	if notification.Error.AdditionalDetails != nil {
+		details = *notification.Error.AdditionalDetails
+	}
+	log.Printf(
+		"codex bridge: error notification: thread_id=%s turn_id=%s will_retry=%t message=%s details=%s",
+		notification.ThreadID,
+		notification.TurnID,
+		notification.WillRetry,
+		notification.Error.Message,
+		details,
+	)
+	if notification.WillRetry || notification.TurnID == "" {
+		return
+	}
+	b.tracker.Notify(TurnResult{
+		ThreadID: notification.ThreadID,
+		TurnID:   notification.TurnID,
+		Err: &ErrorNotificationError{
+			ThreadID:  notification.ThreadID,
+			TurnID:    notification.TurnID,
+			Message:   notification.Error.Message,
+			WillRetry: notification.WillRetry,
+			Details:   details,
+		},
+	})
 }
 
 func (b *Bridge) OnNotification(string, json.RawMessage) {}

--- a/internal/codexbridge/bridge.go
+++ b/internal/codexbridge/bridge.go
@@ -26,6 +26,10 @@ type ErrorNotificationError struct {
 	Details   string
 }
 
+func (e *ErrorNotificationError) SetTurnID(turnID string) {
+	e.TurnID = turnID
+}
+
 func (e *ErrorNotificationError) Error() string {
 	base := fmt.Sprintf("codex error notification for turn %s on thread %s: %s", e.TurnID, e.ThreadID, e.Message)
 	if e.Details == "" {
@@ -121,20 +125,24 @@ func (b *Bridge) OnError(notification *codex.ErrorNotification) {
 		notification.Error.Message,
 		details,
 	)
-	if notification.WillRetry || notification.TurnID == "" {
+	if notification.WillRetry {
 		return
 	}
-	b.tracker.Notify(TurnResult{
-		ThreadID: notification.ThreadID,
-		TurnID:   notification.TurnID,
-		Err: &ErrorNotificationError{
-			ThreadID:  notification.ThreadID,
-			TurnID:    notification.TurnID,
-			Message:   notification.Error.Message,
-			WillRetry: notification.WillRetry,
-			Details:   details,
-		},
-	})
+	err := &ErrorNotificationError{
+		ThreadID:  notification.ThreadID,
+		TurnID:    notification.TurnID,
+		Message:   notification.Error.Message,
+		WillRetry: notification.WillRetry,
+		Details:   details,
+	}
+	result := TurnResult{ThreadID: notification.ThreadID, TurnID: notification.TurnID, Err: err}
+	if notification.TurnID == "" {
+		if !b.tracker.NotifyActive(result) {
+			log.Printf("codex bridge: terminal error notification had no active turn waiter")
+		}
+		return
+	}
+	b.tracker.Notify(result)
 }
 
 func (b *Bridge) OnNotification(string, json.RawMessage) {}

--- a/internal/codexbridge/bridge_test.go
+++ b/internal/codexbridge/bridge_test.go
@@ -186,6 +186,31 @@ func TestBridgeTerminalErrorNotificationCompletesTurn(t *testing.T) {
 	assertClosed(t, ch)
 }
 
+func TestBridgeTerminalErrorNotificationWithoutTurnCompletesActiveTurn(t *testing.T) {
+	tracker := NewTurnTracker()
+	bridge := New(tracker)
+	ch := tracker.Register("turn-active")
+
+	bridge.OnError(&codex.ErrorNotification{
+		ThreadID:  "thread-1",
+		Error:     codex.TurnError{Message: "failed to read body"},
+		WillRetry: false,
+	})
+
+	result := receiveResult(t, ch)
+	if result.TurnID != "turn-active" {
+		t.Fatalf("expected active turn id, got %q", result.TurnID)
+	}
+	var notificationErr *ErrorNotificationError
+	if !errors.As(result.Err, &notificationErr) {
+		t.Fatalf("expected ErrorNotificationError, got %T", result.Err)
+	}
+	if notificationErr.TurnID != "turn-active" {
+		t.Fatalf("expected error turn id to be set, got %q", notificationErr.TurnID)
+	}
+	assertClosed(t, ch)
+}
+
 func TestBridgeRetryingErrorNotificationDoesNotCompleteTurn(t *testing.T) {
 	tracker := NewTurnTracker()
 	bridge := New(tracker)

--- a/internal/codexbridge/bridge_test.go
+++ b/internal/codexbridge/bridge_test.go
@@ -1,8 +1,10 @@
 package codexbridge
 
 import (
+	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	codex "github.com/agynio/codex-sdk-go"
 )
@@ -150,4 +152,56 @@ func TestBridgeUsesAgentMessageDeltas(t *testing.T) {
 		t.Fatalf("unexpected message: %q", result.Message)
 	}
 	assertClosed(t, ch)
+}
+
+func TestBridgeTerminalErrorNotificationCompletesTurn(t *testing.T) {
+	tracker := NewTurnTracker()
+	bridge := New(tracker)
+	ch := tracker.Register("turn-error")
+	details := "body stream ended"
+
+	bridge.OnError(&codex.ErrorNotification{
+		ThreadID: "thread-1",
+		TurnID:   "turn-error",
+		Error: codex.TurnError{
+			Message:           "failed to read body",
+			AdditionalDetails: &details,
+		},
+		WillRetry: false,
+	})
+
+	result := receiveResult(t, ch)
+	if result.ThreadID != "thread-1" {
+		t.Fatalf("unexpected thread id: %q", result.ThreadID)
+	}
+	var notificationErr *ErrorNotificationError
+	if !errors.As(result.Err, &notificationErr) {
+		t.Fatalf("expected ErrorNotificationError, got %T", result.Err)
+	}
+	for _, expected := range []string{"failed to read body", "turn-error", "thread-1", details} {
+		if !strings.Contains(result.Err.Error(), expected) {
+			t.Fatalf("expected %q in error: %v", expected, result.Err)
+		}
+	}
+	assertClosed(t, ch)
+}
+
+func TestBridgeRetryingErrorNotificationDoesNotCompleteTurn(t *testing.T) {
+	tracker := NewTurnTracker()
+	bridge := New(tracker)
+	ch := tracker.Register("turn-retry")
+
+	bridge.OnError(&codex.ErrorNotification{
+		ThreadID:  "thread-1",
+		TurnID:    "turn-retry",
+		Error:     codex.TurnError{Message: "temporary provider failure"},
+		WillRetry: true,
+	})
+
+	select {
+	case result := <-ch:
+		t.Fatalf("unexpected turn completion: %+v", result)
+	case <-time.After(25 * time.Millisecond):
+	}
+	tracker.Cancel("turn-retry")
 }

--- a/internal/codexbridge/turn_tracker.go
+++ b/internal/codexbridge/turn_tracker.go
@@ -9,10 +9,15 @@ type TurnResult struct {
 	Err      error
 }
 
+type turnIDSetter interface {
+	SetTurnID(string)
+}
+
 type TurnTracker struct {
-	mu      sync.Mutex
-	waiters map[string]chan TurnResult
-	pending map[string]TurnResult
+	mu           sync.Mutex
+	waiters      map[string]chan TurnResult
+	pending      map[string]TurnResult
+	activeTurnID string
 }
 
 func NewTurnTracker() *TurnTracker {
@@ -33,6 +38,7 @@ func (t *TurnTracker) Register(turnID string) <-chan TurnResult {
 		return ch
 	}
 	t.waiters[turnID] = ch
+	t.activeTurnID = turnID
 	t.mu.Unlock()
 	return ch
 }
@@ -41,6 +47,9 @@ func (t *TurnTracker) Cancel(turnID string) {
 	t.mu.Lock()
 	delete(t.waiters, turnID)
 	delete(t.pending, turnID)
+	if t.activeTurnID == turnID {
+		t.activeTurnID = ""
+	}
 	t.mu.Unlock()
 }
 
@@ -49,6 +58,9 @@ func (t *TurnTracker) Notify(result TurnResult) {
 	ch, ok := t.waiters[result.TurnID]
 	if ok {
 		delete(t.waiters, result.TurnID)
+		if t.activeTurnID == result.TurnID {
+			t.activeTurnID = ""
+		}
 	}
 	if !ok {
 		t.pending[result.TurnID] = result
@@ -58,4 +70,29 @@ func (t *TurnTracker) Notify(result TurnResult) {
 	t.mu.Unlock()
 	ch <- result
 	close(ch)
+}
+
+func (t *TurnTracker) NotifyActive(result TurnResult) bool {
+	t.mu.Lock()
+	turnID := t.activeTurnID
+	if turnID == "" {
+		t.mu.Unlock()
+		return false
+	}
+	result.TurnID = turnID
+	if setter, ok := result.Err.(turnIDSetter); ok {
+		setter.SetTurnID(turnID)
+	}
+	ch, ok := t.waiters[turnID]
+	if ok {
+		delete(t.waiters, turnID)
+		t.activeTurnID = ""
+	}
+	t.mu.Unlock()
+	if !ok {
+		return false
+	}
+	ch <- result
+	close(ch)
+	return true
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -391,9 +391,19 @@ func (d *Daemon) Run(ctx context.Context) error {
 		backoff = nextSyncRetryBackoff(backoff)
 		scheduleRetry(delay)
 	}
+	handleSyncFailure := func(operation string, err error) error {
+		if isTerminalAgentProcessingError(err) {
+			log.Printf("%s terminal agent processing failure: %v", operation, err)
+			return err
+		}
+		scheduleFailureRetry(operation, err)
+		return nil
+	}
 
 	if err := d.syncMessages(ctx); err != nil {
-		scheduleFailureRetry("initial sync messages", err)
+		if terminalErr := handleSyncFailure("initial sync messages", err); terminalErr != nil {
+			return terminalErr
+		}
 	} else {
 		clearRetry()
 	}
@@ -404,13 +414,17 @@ func (d *Daemon) Run(ctx context.Context) error {
 			return operationError(opProcessSignalShutdown, 0, ctx.Err())
 		case <-d.subscriber.Wake():
 			if err := d.syncMessages(ctx); err != nil {
-				scheduleFailureRetry("sync messages", err)
+				if terminalErr := handleSyncFailure("sync messages", err); terminalErr != nil {
+					return terminalErr
+				}
 			} else {
 				clearRetry()
 			}
 		case <-retry:
 			if err := d.syncMessages(ctx); err != nil {
-				scheduleFailureRetry("sync messages retry", err)
+				if terminalErr := handleSyncFailure("sync messages retry", err); terminalErr != nil {
+					return terminalErr
+				}
 			} else {
 				clearRetry()
 			}
@@ -418,23 +432,42 @@ func (d *Daemon) Run(ctx context.Context) error {
 	}
 }
 
+type operationFailure struct {
+	op      string
+	timeout time.Duration
+	err     error
+}
+
+func (e *operationFailure) Error() string {
+	if errors.Is(e.err, context.DeadlineExceeded) {
+		if e.timeout > 0 {
+			return fmt.Sprintf("%s timed out after %s: %v", e.op, e.timeout, e.err)
+		}
+		return fmt.Sprintf("%s timed out: %v", e.op, e.err)
+	}
+	if errors.Is(e.err, context.Canceled) {
+		return fmt.Sprintf("%s canceled: %v", e.op, e.err)
+	}
+	if e.timeout > 0 {
+		return fmt.Sprintf("%s failed (timeout %s): %v", e.op, e.timeout, e.err)
+	}
+	return fmt.Sprintf("%s failed: %v", e.op, e.err)
+}
+
+func (e *operationFailure) Unwrap() error {
+	return e.err
+}
+
 func operationError(op string, timeout time.Duration, err error) error {
 	if err == nil {
 		return nil
 	}
-	if errors.Is(err, context.DeadlineExceeded) {
-		if timeout > 0 {
-			return fmt.Errorf("%s timed out after %s: %w", op, timeout, err)
-		}
-		return fmt.Errorf("%s timed out: %w", op, err)
-	}
-	if errors.Is(err, context.Canceled) {
-		return fmt.Errorf("%s canceled: %w", op, err)
-	}
-	if timeout > 0 {
-		return fmt.Errorf("%s failed (timeout %s): %w", op, timeout, err)
-	}
-	return fmt.Errorf("%s failed: %w", op, err)
+	return &operationFailure{op: op, timeout: timeout, err: err}
+}
+
+func isTerminalAgentProcessingError(err error) bool {
+	var failure *operationFailure
+	return errors.As(err, &failure) && failure.op == opCodexTurnResult
 }
 
 func operationContextErr(ctx context.Context, err error) error {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -438,6 +438,22 @@ type operationFailure struct {
 	err     error
 }
 
+type terminalCodexTurnError struct {
+	err error
+}
+
+func (e *terminalCodexTurnError) Error() string {
+	return e.err.Error()
+}
+
+func (e *terminalCodexTurnError) Unwrap() error {
+	return e.err
+}
+
+func terminalCodexTurn(err error) error {
+	return &terminalCodexTurnError{err: err}
+}
+
 func (e *operationFailure) Error() string {
 	if errors.Is(e.err, context.DeadlineExceeded) {
 		if e.timeout > 0 {
@@ -466,8 +482,8 @@ func operationError(op string, timeout time.Duration, err error) error {
 }
 
 func isTerminalAgentProcessingError(err error) bool {
-	var failure *operationFailure
-	return errors.As(err, &failure) && failure.op == opCodexTurnResult
+	var terminalErr *terminalCodexTurnError
+	return errors.As(err, &terminalErr)
 }
 
 func operationContextErr(ctx context.Context, err error) error {
@@ -611,11 +627,11 @@ func (d *Daemon) handleCodexMessage(ctx context.Context, message platform.Messag
 	completionCh := d.tracker.Register(turnID)
 	select {
 	case result := <-completionCh:
-		if result.ThreadID != codexThreadID {
+		if result.ThreadID != "" && result.ThreadID != codexThreadID {
 			return operationError(
 				opCodexTurnResult,
 				0,
-				fmt.Errorf("codex turn %s thread mismatch for message %s", turnID, message.ID),
+				terminalCodexTurn(fmt.Errorf("codex turn %s thread mismatch for message %s", turnID, message.ID)),
 			)
 		}
 		if result.Err != nil {
@@ -623,15 +639,19 @@ func (d *Daemon) handleCodexMessage(ctx context.Context, message platform.Messag
 				return operationError(
 					opCodexTurnResult,
 					0,
-					fmt.Errorf("codex turn %s failed for message %s: %w", turnID, message.ID, result.Err),
+					terminalCodexTurn(fmt.Errorf("codex turn %s failed for message %s: %w", turnID, message.ID, result.Err)),
 				)
 			}
 			readbackMessage, readbackErr := d.readCodexTurnMessage(ctx, codexThreadID, turnID)
 			if readbackErr != nil {
+				turnErr := fmt.Errorf("codex turn %s failed for message %s: %w; readback failed: %w", turnID, message.ID, result.Err, readbackErr)
+				if errors.Is(readbackErr, codexbridge.ErrMissingAgentMessage) {
+					turnErr = terminalCodexTurn(turnErr)
+				}
 				return operationError(
 					opCodexTurnResult,
 					0,
-					fmt.Errorf("codex turn %s failed for message %s: %w; readback failed: %w", turnID, message.ID, result.Err, readbackErr),
+					turnErr,
 				)
 			}
 			result.Message = readbackMessage
@@ -640,7 +660,7 @@ func (d *Daemon) handleCodexMessage(ctx context.Context, message platform.Messag
 			return operationError(
 				opCodexTurnResult,
 				0,
-				fmt.Errorf("codex turn %s completed with empty response for message %s", turnID, message.ID),
+				terminalCodexTurn(fmt.Errorf("codex turn %s completed with empty response for message %s", turnID, message.ID)),
 			)
 		}
 		if err := d.publishResponse(ctx, SDKCodex, threadID, message, result.Message); err != nil {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -101,13 +101,21 @@ type handlingMessageConsumer struct {
 	mu      sync.Mutex
 	calls   int
 	message platform.Message
+	done    chan struct{}
 }
 
 func (h *handlingMessageConsumer) Sync(_ context.Context, _ string, _ string, handle func(platform.Message) error) error {
 	h.mu.Lock()
 	h.calls++
 	h.mu.Unlock()
-	return handle(h.message)
+	err := handle(h.message)
+	if h.done != nil {
+		select {
+		case h.done <- struct{}{}:
+		default:
+		}
+	}
+	return err
 }
 
 func (h *handlingMessageConsumer) Calls() int {
@@ -490,6 +498,72 @@ func TestRunReturnsTerminalCodexTurnFailureWithoutRetry(t *testing.T) {
 	}
 	if calls := consumer.Calls(); calls != 1 {
 		t.Fatalf("expected terminal failure to avoid retry, got %d sync calls", calls)
+	}
+}
+
+func TestRunRetriesReadbackTransportFailure(t *testing.T) {
+	subscriber := newFakeMessageSubscriber()
+	consumer := &handlingMessageConsumer{
+		message: platform.Message{ID: "msg-1", ThreadID: "thread-1", Body: "hello"},
+		done:    make(chan struct{}, 2),
+	}
+	store := codexbridge.NewThreadMappingStore(t.TempDir())
+	readErr := fmt.Errorf("read transport unavailable")
+	client := &fakeCodexClient{readThreadErr: readErr}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	d := &Daemon{
+		sdk:          SDKCodex,
+		cfg:          config.Config{AgentID: uuid.MustParse(testAgentID), WorkDir: "/tmp"},
+		runners:      &fakeRunnersClient{},
+		subscriber:   subscriber,
+		consumer:     consumer,
+		codex:        client,
+		mapping:      codexbridge.NewThreadMapping(),
+		mappingStore: store,
+		tracker:      codexbridge.NewTurnTracker(),
+		agent:        &agentsv1.Agent{},
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- d.Run(ctx)
+	}()
+
+	waitForStartTurn := func() {
+		t.Helper()
+		deadline := time.After(500 * time.Millisecond)
+		for client.StartTurnContext() == nil {
+			select {
+			case err := <-errCh:
+				t.Fatalf("Run returned before codex turn started: %v", err)
+			case <-deadline:
+				t.Fatal("codex turn did not start")
+			case <-time.After(10 * time.Millisecond):
+			}
+		}
+	}
+	waitForStartTurn()
+	d.tracker.Notify(codexbridge.TurnResult{ThreadID: "codex-started", TurnID: "turn-1", Err: codexbridge.ErrMissingAgentMessage})
+
+	select {
+	case <-consumer.done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("first sync did not finish")
+	}
+	select {
+	case err := <-errCh:
+		t.Fatalf("Run returned instead of retrying readback transport failure: %v", err)
+	case <-time.After(1100 * time.Millisecond):
+	}
+	if calls := consumer.Calls(); calls < 2 {
+		t.Fatalf("expected readback transport failure to retry sync, got %d calls", calls)
+	}
+	cancel()
+	select {
+	case <-errCh:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Run did not stop")
 	}
 }
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	agentsv1 "github.com/agynio/agynd-cli/.gen/go/agynio/api/agents/v1"
+	"github.com/agynio/agynd-cli/internal/codexbridge"
 	"github.com/agynio/agynd-cli/internal/config"
 	"github.com/agynio/agynd-cli/internal/platform"
 	"github.com/google/uuid"
@@ -93,6 +95,25 @@ func (f *fakeMessageConsumer) Calls() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.calls
+}
+
+type handlingMessageConsumer struct {
+	mu      sync.Mutex
+	calls   int
+	message platform.Message
+}
+
+func (h *handlingMessageConsumer) Sync(_ context.Context, _ string, _ string, handle func(platform.Message) error) error {
+	h.mu.Lock()
+	h.calls++
+	h.mu.Unlock()
+	return handle(h.message)
+}
+
+func (h *handlingMessageConsumer) Calls() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.calls
 }
 
 type recordingRunnersClient struct {
@@ -406,6 +427,69 @@ func TestRunRetriesSyncAfterFailure(t *testing.T) {
 	case <-errCh:
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("Run did not stop")
+	}
+}
+
+func TestRunReturnsTerminalCodexTurnFailureWithoutRetry(t *testing.T) {
+	subscriber := newFakeMessageSubscriber()
+	consumer := &handlingMessageConsumer{message: platform.Message{ID: "msg-1", ThreadID: "thread-1", Body: "hello"}}
+	store := codexbridge.NewThreadMappingStore(t.TempDir())
+	client := &fakeCodexClient{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	daemon := &Daemon{
+		sdk:          SDKCodex,
+		cfg:          config.Config{AgentID: uuid.MustParse(testAgentID), WorkDir: "/tmp"},
+		runners:      &fakeRunnersClient{},
+		subscriber:   subscriber,
+		consumer:     consumer,
+		codex:        client,
+		mapping:      codexbridge.NewThreadMapping(),
+		mappingStore: store,
+		tracker:      codexbridge.NewTurnTracker(),
+		agent:        &agentsv1.Agent{},
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- daemon.Run(ctx)
+	}()
+
+	deadline := time.After(500 * time.Millisecond)
+	for client.StartTurnContext() == nil {
+		select {
+		case err := <-errCh:
+			t.Fatalf("Run returned before codex turn started: %v", err)
+		case <-deadline:
+			t.Fatal("codex turn did not start")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	turnErr := &codexbridge.ErrorNotificationError{
+		ThreadID: "codex-started",
+		TurnID:   "turn-1",
+		Message:  "failed to read body",
+	}
+	daemon.tracker.Notify(codexbridge.TurnResult{ThreadID: "codex-started", TurnID: "turn-1", Err: turnErr})
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("expected terminal error, got nil")
+		}
+		for _, expected := range []string{"codex_turn_result", "failed to read body", "msg-1", "turn-1"} {
+			if !strings.Contains(err.Error(), expected) {
+				t.Fatalf("expected %q in error: %v", expected, err)
+			}
+		}
+		if !errors.Is(err, turnErr) {
+			t.Fatalf("expected wrapped terminal turn error, got %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Run did not return terminal codex turn failure")
+	}
+	if calls := consumer.Calls(); calls != 1 {
+		t.Fatalf("expected terminal failure to avoid retry, got %d sync calls", calls)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Treat terminal Codex error notifications as turn failures and preserve thread, turn, message, and detail context in logs/errors.
- Return terminal `codex_turn_result` failures from `Daemon.Run` instead of scheduling another sync retry, allowing the workload to fail visibly for Orchestrator handling.
- Preserve retry behavior for transient sync/page/platform failures and retrying Codex error notifications.
- Add unit coverage for terminal Codex notifications, retrying notifications, and daemon Run exiting without reprocessing the same message.

Closes #146

## Validation

- `buf generate buf.build/agynio/api --path agynio/api/gateway/v1 --include-imports`
- `go test ./...`
- `go build ./...`
- `git diff --check`

Tests: 215 passed, 0 failed, 0 skipped.
Lint: `git diff --check` passed with no errors.