### PR TITLE
fix(mcp): wait for MCP readiness in agynd

### DIFF
--- a/internal/daemon/agn.go
+++ b/internal/daemon/agn.go
@@ -95,6 +95,7 @@ func newAgnDaemon(ctx context.Context, cfg config.Config, version string) (*Daem
 		agn:          agnClient,
 		agent:        setup.agent,
 		tracingProxy: tracingProxy,
+		mcpReady:     true,
 	}, nil
 }
 

--- a/internal/daemon/agnconfig.go
+++ b/internal/daemon/agnconfig.go
@@ -62,7 +62,7 @@ func agnConfig(llmBaseURL, apiKey, model, tokenCountingAddress, systemPrompt str
 	if len(mcpServers) > 0 {
 		builder.WriteString("mcp:\n  servers:\n")
 		for _, server := range mcpServers {
-			url := fmt.Sprintf("http://localhost:%d/mcp", server.Port)
+			url := mcpEndpoint(server.Port)
 			fmt.Fprintf(&builder, "    %s:\n      url: %s\n", server.Name, url)
 		}
 	}

--- a/internal/daemon/agnconfig_test.go
+++ b/internal/daemon/agnconfig_test.go
@@ -110,8 +110,8 @@ func TestWriteAgnConfigWithMCPServers(t *testing.T) {
 
 	expected := fmt.Sprintf(agnConfigTemplate, baseURL, apiKey, model, testTokenCountingAddress) +
 		"mcp:\n  servers:\n" +
-		"    memory:\n      url: http://localhost:8100/mcp\n" +
-		"    filesystem:\n      url: http://localhost:8200/mcp\n"
+		"    memory:\n      url: http://127.0.0.1:8100/mcp\n" +
+		"    filesystem:\n      url: http://127.0.0.1:8200/mcp\n"
 	if string(content) != expected {
 		t.Fatalf("expected config %q, got %q", expected, string(content))
 	}

--- a/internal/daemon/claude.go
+++ b/internal/daemon/claude.go
@@ -103,7 +103,7 @@ func (d *Daemon) ensureClaudeReady(ctx context.Context) error {
 	if d.claudeReady {
 		return nil
 	}
-	if err := waitForMCPServers(ctx, d.cfg.MCPServers, mcpReadyTimeout); err != nil {
+	if err := d.ensureMCPReady(ctx); err != nil {
 		return err
 	}
 	d.claudeReady = true

--- a/internal/daemon/claudeconfig.go
+++ b/internal/daemon/claudeconfig.go
@@ -68,7 +68,7 @@ func writeClaudeSettings(llmBaseURL, apiKey string, mcpServers []config.MCPServe
 		for _, server := range mcpServers {
 			settings.MCPServers[server.Name] = claudeMCPServer{
 				Type: "http",
-				URL:  fmt.Sprintf("http://localhost:%d/mcp", server.Port),
+				URL:  mcpEndpoint(server.Port),
 			}
 		}
 	}

--- a/internal/daemon/claudeconfig_test.go
+++ b/internal/daemon/claudeconfig_test.go
@@ -115,8 +115,8 @@ func TestWriteClaudeSettingsWithMCPServers(t *testing.T) {
 			"DISABLE_AUTOUPDATER":                      "1",
 		},
 		MCPServers: map[string]claudeMCPServer{
-			"memory": {Type: "http", URL: "http://localhost:8100/mcp"},
-			"cache":  {Type: "http", URL: "http://localhost:8200/mcp"},
+			"memory": {Type: "http", URL: "http://127.0.0.1:8100/mcp"},
+			"cache":  {Type: "http", URL: "http://127.0.0.1:8200/mcp"},
 		},
 	}
 	if !reflect.DeepEqual(got, expected) {

--- a/internal/daemon/codexconfig.go
+++ b/internal/daemon/codexconfig.go
@@ -103,7 +103,7 @@ func codexConfig(llmBaseURL string, mcpServers []config.MCPServer, otlpEndpoint 
 	var builder strings.Builder
 	builder.WriteString(payload)
 	for _, server := range mcpServers {
-		url := fmt.Sprintf("http://localhost:%d/mcp", server.Port)
+		url := mcpEndpoint(server.Port)
 		fmt.Fprintf(&builder, "\n[mcp_servers.%s]\nurl = %q\nrequired = true\nstartup_timeout_sec = 120\n", server.Name, url)
 	}
 	return builder.String()

--- a/internal/daemon/codexconfig_test.go
+++ b/internal/daemon/codexconfig_test.go
@@ -138,11 +138,11 @@ func TestWriteCodexConfigWithMCPServers(t *testing.T) {
 
 	expected := codexConfigWithAPIKey(baseURL) +
 		"\n[mcp_servers.memory]\n" +
-		"url = \"http://localhost:8100/mcp\"\n" +
+		"url = \"http://127.0.0.1:8100/mcp\"\n" +
 		"required = true\n" +
 		"startup_timeout_sec = 120\n" +
 		"\n[mcp_servers.cache]\n" +
-		"url = \"http://localhost:8200/mcp\"\n" +
+		"url = \"http://127.0.0.1:8200/mcp\"\n" +
 		"required = true\n" +
 		"startup_timeout_sec = 120\n"
 	if string(content) != expected {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1,8 +1,10 @@
 package daemon
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -58,6 +60,8 @@ const (
 	SDKAgn    = "agn"
 	SDKClaude = "claude"
 )
+
+const mcpProbeID = "agynd-mcp-ready"
 
 type Daemon struct {
 	cfg           config.Config
@@ -927,7 +931,7 @@ func waitForMCPServices(ctx context.Context, targets []mcpServiceTarget, timeout
 }
 
 func probeMCPService(ctx context.Context, client *http.Client, endpoint string) error {
-	body := []byte(`{"jsonrpc":"2.0","id":"agynd-mcp-ready","method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"agynd","version":"mcp-ready"}}}`)
+	body := []byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":%q,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"agynd","version":"mcp-ready"}}}`, mcpProbeID))
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
 		return err
@@ -945,29 +949,87 @@ func probeMCPService(ctx context.Context, client *http.Client, endpoint string) 
 	return readMCPProbeResult(resp.Body)
 }
 
+type mcpProbeResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      string          `json:"id"`
+	Result  json.RawMessage `json:"result"`
+	Error   json.RawMessage `json:"error"`
+}
+
 func readMCPProbeResult(body io.Reader) error {
-	reader := io.LimitReader(body, 64*1024)
-	buffer := make([]byte, 0, 4096)
-	chunk := make([]byte, 1024)
+	reader := bufio.NewReader(io.LimitReader(body, 64*1024))
+	var raw bytes.Buffer
+	var eventData []string
+	var lastEventErr error
+	sawSSE := false
+
 	for {
-		n, err := reader.Read(chunk)
-		if n > 0 {
-			buffer = append(buffer, chunk[:n]...)
-			if bytes.Contains(buffer, []byte(`"result"`)) {
-				return nil
+		line, err := reader.ReadString('\n')
+		if line != "" {
+			raw.WriteString(line)
+			trimmed := strings.TrimRight(line, "\r\n")
+			if data, ok := strings.CutPrefix(trimmed, "data:"); ok {
+				sawSSE = true
+				eventData = append(eventData, strings.TrimSpace(data))
+			} else if sawSSE && strings.TrimSpace(trimmed) == "" {
+				if len(eventData) > 0 {
+					if err := validateMCPProbePayload([]byte(strings.Join(eventData, "\n"))); err == nil {
+						return nil
+					} else {
+						lastEventErr = err
+					}
+				}
+				eventData = nil
 			}
+		}
+		if err == nil {
+			continue
 		}
 		if errors.Is(err, io.EOF) {
 			break
 		}
-		if err != nil {
-			if bytes.Contains(buffer, []byte(`"result"`)) {
-				return nil
-			}
-			return err
-		}
+		return err
 	}
-	return fmt.Errorf("initialize response missing result")
+
+	if sawSSE {
+		if len(eventData) > 0 {
+			if err := validateMCPProbePayload([]byte(strings.Join(eventData, "\n"))); err == nil {
+				return nil
+			} else {
+				lastEventErr = err
+			}
+		}
+		if lastEventErr != nil {
+			return lastEventErr
+		}
+		return fmt.Errorf("initialize SSE response missing data")
+	}
+	return validateMCPProbePayload(raw.Bytes())
+}
+
+func validateMCPProbePayload(payload []byte) error {
+	payload = bytes.TrimSpace(payload)
+	if len(payload) == 0 {
+		return fmt.Errorf("initialize response is empty")
+	}
+	var response mcpProbeResponse
+	if err := json.Unmarshal(payload, &response); err != nil {
+		return fmt.Errorf("parse initialize response: %w", err)
+	}
+	if response.JSONRPC != "2.0" {
+		return fmt.Errorf("initialize response jsonrpc %q does not match 2.0", response.JSONRPC)
+	}
+	if response.ID != mcpProbeID {
+		return fmt.Errorf("initialize response id %q does not match %q", response.ID, mcpProbeID)
+	}
+	if len(bytes.TrimSpace(response.Error)) > 0 && !bytes.Equal(bytes.TrimSpace(response.Error), []byte("null")) {
+		return fmt.Errorf("initialize response contains error")
+	}
+	result := bytes.TrimSpace(response.Result)
+	if len(result) == 0 || bytes.Equal(result, []byte("null")) {
+		return fmt.Errorf("initialize response missing result")
+	}
+	return nil
 }
 
 type codexThreadDefaults struct {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1,11 +1,14 @@
 package daemon
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net"
+	"net/http"
 	"net/url"
 	"strings"
 	"sync"
@@ -30,7 +33,7 @@ const (
 	turnStartTimeout                = 5 * time.Minute
 	messagePublishTimeout           = 15 * time.Second
 	messageAckTimeout               = 15 * time.Second
-	mcpReadyTimeout                 = 120 * time.Second
+	mcpReadyTimeout                 = 4 * time.Minute
 	llmReadyTimeout                 = 120 * time.Second
 	codexReadbackTimeout            = 10 * time.Second
 	codexReadbackPollInterval       = 250 * time.Millisecond
@@ -47,6 +50,7 @@ const (
 	opClaudeTurn                    = "claude_turn"
 	opProcessSignalShutdown         = "process_signal/shutdown"
 	tracingProxyListenAddress       = "127.0.0.1:0"
+	mcpLoopbackHost                 = "127.0.0.1"
 )
 
 const (
@@ -74,6 +78,8 @@ type Daemon struct {
 	tracingProxy  *tracingproxy.Proxy
 	claudeReadyMu sync.Mutex
 	claudeReady   bool
+	mcpReadyMu    sync.Mutex
+	mcpReady      bool
 
 	processing     atomic.Bool
 	processingWake chan struct{}
@@ -566,6 +572,9 @@ func (d *Daemon) syncMessages(ctx context.Context) error {
 		if d.tracingProxy != nil {
 			d.tracingProxy.SetMessageID(message.ID)
 		}
+		if err := d.ensureMCPReady(ctx); err != nil {
+			return fmt.Errorf("wait for MCP servers before processing message %s: %w", message.ID, err)
+		}
 		return d.handleMessage(ctx, message)
 	}); err != nil {
 		var pageFetchErr *platform.PageFetchError
@@ -578,6 +587,19 @@ func (d *Daemon) syncMessages(ctx context.Context) error {
 			fmt.Errorf("sync unacked messages for participant %s thread %s: %w", d.cfg.AgentID.String(), d.cfg.ThreadID, pageFetchErr),
 		)
 	}
+	return nil
+}
+
+func (d *Daemon) ensureMCPReady(ctx context.Context) error {
+	d.mcpReadyMu.Lock()
+	defer d.mcpReadyMu.Unlock()
+	if d.mcpReady {
+		return nil
+	}
+	if err := waitForMCPServers(ctx, d.cfg.MCPServers, mcpReadyTimeout); err != nil {
+		return err
+	}
+	d.mcpReady = true
 	return nil
 }
 
@@ -744,9 +766,6 @@ func (d *Daemon) ensureCodexThread(ctx context.Context, platformThreadID string)
 		}
 		return record.CodexThreadID, nil
 	}
-	if err := waitForMCPServers(ctx, d.cfg.MCPServers, mcpReadyTimeout); err != nil {
-		return "", fmt.Errorf("wait for MCP servers before codex thread: %w", err)
-	}
 	record, ok, err := d.mappingStore.Load(platformThreadID)
 	if err != nil {
 		return "", fmt.Errorf("load codex thread mapping for platform thread %s: %w", platformThreadID, err)
@@ -822,6 +841,12 @@ type tcpServiceTarget struct {
 	addr  string
 }
 
+type mcpServiceTarget struct {
+	label string
+	addr  string
+	url   string
+}
+
 func waitForTCPService(ctx context.Context, addr string, timeout time.Duration, label string) error {
 	return waitForTCPServices(ctx, []tcpServiceTarget{{label: label, addr: addr}}, timeout)
 }
@@ -839,6 +864,7 @@ func waitForTCPServices(ctx context.Context, targets []tcpServiceTarget, timeout
 			conn, err := net.DialTimeout("tcp", target.addr, 1*time.Second)
 			if err == nil {
 				_ = conn.Close()
+				log.Printf("%s at %s ready after %d attempt(s)", target.label, target.addr, attempt)
 				break
 			}
 			log.Printf("waiting for %s at %s (attempt %d): %v", target.label, target.addr, attempt, err)
@@ -855,14 +881,93 @@ func waitForTCPServices(ctx context.Context, targets []tcpServiceTarget, timeout
 }
 
 func waitForMCPServers(ctx context.Context, servers []config.MCPServer, timeout time.Duration) error {
-	targets := make([]tcpServiceTarget, 0, len(servers))
+	targets := make([]mcpServiceTarget, 0, len(servers))
 	for _, server := range servers {
-		targets = append(targets, tcpServiceTarget{
+		addr := net.JoinHostPort(mcpLoopbackHost, fmt.Sprintf("%d", server.Port))
+		targets = append(targets, mcpServiceTarget{
 			label: fmt.Sprintf("MCP server %s", server.Name),
-			addr:  fmt.Sprintf("localhost:%d", server.Port),
+			addr:  addr,
+			url:   mcpEndpoint(server.Port),
 		})
 	}
-	return waitForTCPServices(ctx, targets, timeout)
+	return waitForMCPServices(ctx, targets, timeout)
+}
+
+func mcpEndpoint(port int) string {
+	return fmt.Sprintf("http://%s/mcp", net.JoinHostPort(mcpLoopbackHost, fmt.Sprintf("%d", port)))
+}
+
+func waitForMCPServices(ctx context.Context, targets []mcpServiceTarget, timeout time.Duration) error {
+	if len(targets) == 0 {
+		return nil
+	}
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	client := &http.Client{Timeout: 10 * time.Second}
+	for _, target := range targets {
+		attempt := 0
+		for {
+			attempt++
+			if err := probeMCPService(ctx, client, target.url); err == nil {
+				log.Printf("%s at %s ready after %d attempt(s)", target.label, target.addr, attempt)
+				break
+			} else {
+				log.Printf("waiting for %s at %s (attempt %d): %v", target.label, target.addr, attempt, err)
+			}
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-deadline.C:
+				return fmt.Errorf("%s at %s not ready after %s", target.label, target.addr, timeout)
+			case <-time.After(2 * time.Second):
+			}
+		}
+	}
+	return nil
+}
+
+func probeMCPService(ctx context.Context, client *http.Client, endpoint string) error {
+	body := []byte(`{"jsonrpc":"2.0","id":"agynd-mcp-ready","method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"agynd","version":"mcp-ready"}}}`)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("http status %s", resp.Status)
+	}
+	return readMCPProbeResult(resp.Body)
+}
+
+func readMCPProbeResult(body io.Reader) error {
+	reader := io.LimitReader(body, 64*1024)
+	buffer := make([]byte, 0, 4096)
+	chunk := make([]byte, 1024)
+	for {
+		n, err := reader.Read(chunk)
+		if n > 0 {
+			buffer = append(buffer, chunk[:n]...)
+			if bytes.Contains(buffer, []byte(`"result"`)) {
+				return nil
+			}
+		}
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			if bytes.Contains(buffer, []byte(`"result"`)) {
+				return nil
+			}
+			return err
+		}
+	}
+	return fmt.Errorf("initialize response missing result")
 }
 
 type codexThreadDefaults struct {

--- a/internal/daemon/daemon_mcp_test.go
+++ b/internal/daemon/daemon_mcp_test.go
@@ -55,6 +55,53 @@ func TestWaitForMCPServersWaitsForInitializeResponse(t *testing.T) {
 	}
 }
 
+func TestReadMCPProbeResultRejectsInvalidPayloads(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+	}{
+		{
+			name:    "json rpc error containing result text",
+			payload: `{"jsonrpc":"2.0","id":"agynd-mcp-ready","error":{"message":"no result yet"}}`,
+		},
+		{
+			name:    "unrelated payload containing result text",
+			payload: `{"message":"result is almost ready"}`,
+		},
+		{
+			name:    "wrong response id",
+			payload: `{"jsonrpc":"2.0","id":"other","result":{"protocolVersion":"2025-06-18"}}`,
+		},
+		{
+			name:    "null result",
+			payload: `{"jsonrpc":"2.0","id":"agynd-mcp-ready","result":null}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := readMCPProbeResult(strings.NewReader(tt.payload)); err == nil {
+				t.Fatal("expected invalid MCP initialize response to be rejected")
+			}
+		})
+	}
+}
+
+func TestReadMCPProbeResultAcceptsSSEInitializeResult(t *testing.T) {
+	payload := strings.Join([]string{
+		`event: message`,
+		`data: {"jsonrpc":"2.0","id":"unrelated","result":{"protocolVersion":"2025-06-18"}}`,
+		``,
+		`event: message`,
+		`data: {"jsonrpc":"2.0","id":"agynd-mcp-ready","result":{"protocolVersion":"2025-06-18"}}`,
+		``,
+	}, "\n")
+
+	if err := readMCPProbeResult(strings.NewReader(payload)); err != nil {
+		t.Fatalf("expected SSE initialize result to be accepted, got %v", err)
+	}
+}
+
 func TestWaitForMCPServersEmpty(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()

--- a/internal/daemon/daemon_mcp_test.go
+++ b/internal/daemon/daemon_mcp_test.go
@@ -3,8 +3,11 @@ package daemon
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
+	"net/http"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -12,10 +15,8 @@ import (
 )
 
 func TestWaitForMCPServersReady(t *testing.T) {
-	listenerA, portA := startTCPListener(t)
-	defer listenerA.Close()
-	listenerB, portB := startTCPListener(t)
-	defer listenerB.Close()
+	_, portA := startMCPReadyServer(t)
+	_, portB := startMCPReadyServer(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
@@ -26,6 +27,31 @@ func TestWaitForMCPServersReady(t *testing.T) {
 	}
 	if err := waitForMCPServers(ctx, servers, 500*time.Millisecond); err != nil {
 		t.Fatalf("expected MCP servers to be ready, got %v", err)
+	}
+}
+
+func TestWaitForMCPServersWaitsForInitializeResponse(t *testing.T) {
+	var requests atomic.Int32
+	server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempt := requests.Add(1)
+		if attempt < 3 {
+			http.Error(w, "starting", http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"agynd-mcp-ready","result":{"protocolVersion":"2025-06-18"}}`))
+	})}
+	listener, port := startHTTPListener(t, server)
+	defer listener.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	servers := []config.MCPServer{{Name: "memory", Port: port}}
+	if err := waitForMCPServers(ctx, servers, 5*time.Second); err != nil {
+		t.Fatalf("expected MCP server to become ready, got %v", err)
+	}
+	if got := requests.Load(); got < 3 {
+		t.Fatalf("expected readiness probe retries, got %d request(s)", got)
 	}
 }
 
@@ -74,6 +100,39 @@ func startTCPListener(t *testing.T) (net.Listener, int) {
 		_ = listener.Close()
 		t.Fatalf("unexpected listener address type %T", listener.Addr())
 	}
+	return listener, addr.Port
+}
+
+func startMCPReadyServer(t *testing.T) (*http.Server, int) {
+	t.Helper()
+	server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mcp" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"agynd-mcp-ready","result":{"protocolVersion":"2025-06-18"}}`))
+	})}
+	listener, port := startHTTPListener(t, server)
+	t.Cleanup(func() { _ = listener.Close() })
+	return server, port
+}
+
+func startHTTPListener(t *testing.T, server *http.Server) (net.Listener, int) {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		_ = listener.Close()
+		t.Fatalf("unexpected listener address type %T", listener.Addr())
+	}
+	go func() {
+		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) && !strings.Contains(err.Error(), "use of closed network connection") {
+			panic(fmt.Sprintf("serve MCP ready test server: %v", err))
+		}
+	}()
 	return listener, addr.Port
 }
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -564,6 +566,38 @@ func TestRunRetriesReadbackTransportFailure(t *testing.T) {
 	case <-errCh:
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("Run did not stop")
+	}
+}
+
+func TestSyncMessagesWaitsForMCPReadyBeforeHandling(t *testing.T) {
+	var requests atomic.Int32
+	server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempt := requests.Add(1)
+		if attempt < 3 {
+			http.Error(w, "starting", http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"agynd-mcp-ready","result":{"protocolVersion":"2025-06-18"}}`))
+	})}
+	listener, port := startHTTPListener(t, server)
+	defer listener.Close()
+
+	consumer := &handlingMessageConsumer{message: platform.Message{ID: "msg-1", ThreadID: "thread-1", Body: "hello"}}
+	daemon := &Daemon{
+		sdk:      "unknown",
+		cfg:      config.Config{AgentID: uuid.MustParse(testAgentID), MCPServers: []config.MCPServer{{Name: "memory", Port: port}}},
+		consumer: consumer,
+	}
+
+	err := daemon.syncMessages(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "unknown sdk") {
+		t.Fatalf("expected handler to run after MCP readiness, got %v", err)
+	}
+	if got := requests.Load(); got < 3 {
+		t.Fatalf("expected MCP readiness retries before handling, got %d request(s)", got)
+	}
+	if calls := consumer.Calls(); calls != 1 {
+		t.Fatalf("expected one sync call, got %d", calls)
 	}
 }
 


### PR DESCRIPTION
Closes #148

## Summary
- Move MCP readiness into agynd's platform-owned message processing path before agent work is handled.
- Probe MCP sidecars with JSON-RPC `initialize` over the streamable HTTP endpoint instead of raw TCP readiness.
- Use IPv4 loopback MCP endpoints (`127.0.0.1`) in generated agent SDK configs and readiness probes to avoid localhost resolving to `::1` while sidecars listen on IPv4.
- Increase MCP readiness budget for slow npm-backed sidecar startup and cache readiness after success.
- Add regression coverage for readiness retry behavior and message-handling ordering.

## Validation
- `git diff --check`: passed with no whitespace errors.
- `CGO_ENABLED=0 go test ./...`: 7 packages passed / 0 failed / 1 package with no test files.
- `CGO_ENABLED=0 go build ./...`: build passed.
- `helm dependency build charts/agynd && helm lint charts/agynd`: 1 chart linted / 0 failed.
- `AGN_REPO_PATH=/workspace/agn-cli CGO_ENABLED=0 go test -v -count=1 -tags e2e ./test/e2e/`: 3 passed / 0 failed / 0 skipped.
- `CGO_ENABLED=0 go test ./internal/daemon -run 'TestWaitForMCPServers|TestSyncMessagesWaitsForMCPReadyBeforeHandling'`: package passed.