### PR TITLE
feat: add sandbox holder mode

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,12 @@ import (
 
 const agentConfigPath = "/agyn-bin/config.json"
 
+const (
+	ModeAgent            = "agent"
+	ModeHolder           = "holder"
+	HolderDefaultWorkDir = "/workspace"
+)
+
 var mcpServerNamePattern = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
 
 type agentConfig struct {
@@ -27,6 +33,7 @@ type MCPServer struct {
 }
 
 type Config struct {
+	Mode           string
 	AgentID        uuid.UUID
 	GatewayAddress string
 	TracingAddress string
@@ -46,6 +53,14 @@ func FromEnv() (Config, error) {
 }
 
 func fromEnv(configPath string) (Config, error) {
+	mode, err := parseMode(os.Getenv("AGYND_MODE"))
+	if err != nil {
+		return Config{}, err
+	}
+	if mode == ModeHolder {
+		return holderConfigFromEnv(), nil
+	}
+
 	agentID, err := uuidutil.ParseUUID(strings.TrimSpace(os.Getenv("AGENT_ID")), "AGENT_ID")
 	if err != nil {
 		return Config{}, err
@@ -107,6 +122,7 @@ func fromEnv(configPath string) (Config, error) {
 	}
 
 	return Config{
+		Mode:           mode,
 		AgentID:        agentID,
 		GatewayAddress: gatewayAddress,
 		TracingAddress: tracingAddress,
@@ -120,6 +136,31 @@ func fromEnv(configPath string) (Config, error) {
 		MCPServers:     mcpServers,
 		MCPPort:        mcpPort,
 	}, nil
+}
+
+func parseMode(raw string) (string, error) {
+	mode := strings.TrimSpace(raw)
+	if mode == "" {
+		return ModeAgent, nil
+	}
+	switch mode {
+	case ModeAgent, ModeHolder:
+		return mode, nil
+	default:
+		return "", fmt.Errorf("AGYND_MODE must be %q or %q", ModeAgent, ModeHolder)
+	}
+}
+
+func holderConfigFromEnv() Config {
+	workDir := strings.TrimSpace(os.Getenv("WORKSPACE_DIR"))
+	if workDir == "" {
+		workDir = HolderDefaultWorkDir
+	}
+	return Config{
+		Mode:    ModeHolder,
+		SDK:     ModeHolder,
+		WorkDir: workDir,
+	}
 }
 
 func loadAgentConfig(path string) (agentConfig, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -426,3 +426,76 @@ func TestFromEnvMissingConfigFields(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestFromEnvAgentModeDefault(t *testing.T) {
+	setRequiredEnv(t)
+	configPath := writeAgentConfig(t, "codex", "/opt/bin/codex")
+	t.Setenv("AGYND_MODE", "")
+
+	cfg, err := fromEnv(configPath)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if cfg.Mode != ModeAgent {
+		t.Fatalf("expected agent mode, got %q", cfg.Mode)
+	}
+}
+
+func TestFromEnvHolderModeMinimal(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "missing-config.json")
+	t.Setenv("AGYND_MODE", ModeHolder)
+	t.Setenv("AGENT_ID", "")
+	t.Setenv("THREAD_ID", "")
+	t.Setenv("WORKLOAD_ID", "")
+	t.Setenv("WORKSPACE_DIR", "")
+
+	cfg, err := fromEnv(configPath)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if cfg.Mode != ModeHolder {
+		t.Fatalf("expected holder mode, got %q", cfg.Mode)
+	}
+	if cfg.SDK != ModeHolder {
+		t.Fatalf("expected holder sdk marker, got %q", cfg.SDK)
+	}
+	if cfg.WorkDir != HolderDefaultWorkDir {
+		t.Fatalf("expected holder default work dir %s, got %s", HolderDefaultWorkDir, cfg.WorkDir)
+	}
+	if cfg.AgentID.String() != "00000000-0000-0000-0000-000000000000" {
+		t.Fatalf("expected zero agent id, got %s", cfg.AgentID.String())
+	}
+	if cfg.ThreadID != "" || cfg.WorkloadID != "" || cfg.GatewayAddress != "" {
+		t.Fatalf("expected holder mode to skip platform config, got thread=%q workload=%q gateway=%q", cfg.ThreadID, cfg.WorkloadID, cfg.GatewayAddress)
+	}
+}
+
+func TestFromEnvHolderModeWorkDir(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "missing-config.json")
+	t.Setenv("AGYND_MODE", ModeHolder)
+	t.Setenv("WORKSPACE_DIR", " /sandbox-workspace ")
+
+	cfg, err := fromEnv(configPath)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if cfg.WorkDir != "/sandbox-workspace" {
+		t.Fatalf("unexpected holder work dir: %q", cfg.WorkDir)
+	}
+}
+
+func TestFromEnvInvalidMode(t *testing.T) {
+	setRequiredEnv(t)
+	configPath := writeAgentConfig(t, "codex", "/opt/bin/codex")
+	t.Setenv("AGYND_MODE", "sandbox")
+
+	_, err := fromEnv(configPath)
+	if err == nil {
+		t.Fatal("expected error for invalid mode")
+	}
+	if !strings.Contains(err.Error(), "AGYND_MODE") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -132,6 +132,9 @@ type platformSetup struct {
 }
 
 func New(ctx context.Context, cfg config.Config, version string) (*Daemon, error) {
+	if cfg.Mode == config.ModeHolder {
+		return newHolderDaemon(cfg), nil
+	}
 	switch cfg.SDK {
 	case SDKCodex:
 		return newCodexDaemon(ctx, cfg, version)
@@ -141,6 +144,13 @@ func New(ctx context.Context, cfg config.Config, version string) (*Daemon, error
 		return newClaudeDaemon(ctx, cfg, version)
 	default:
 		return nil, fmt.Errorf("unknown sdk %q", cfg.SDK)
+	}
+}
+
+func newHolderDaemon(cfg config.Config) *Daemon {
+	return &Daemon{
+		cfg: cfg,
+		sdk: config.ModeHolder,
 	}
 }
 
@@ -347,6 +357,9 @@ func (d *Daemon) Close() {
 }
 
 func (d *Daemon) Run(ctx context.Context) error {
+	if d.sdk == config.ModeHolder {
+		return runHolder(ctx)
+	}
 	d.ensureProcessingWake()
 	go d.runKeepalive(ctx)
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -358,7 +358,7 @@ func (d *Daemon) Close() {
 
 func (d *Daemon) Run(ctx context.Context) error {
 	if d.sdk == config.ModeHolder {
-		return runHolder(ctx)
+		return runHolder(ctx, d.cfg.WorkDir)
 	}
 	d.ensureProcessingWake()
 	go d.runKeepalive(ctx)

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -629,8 +630,30 @@ func TestNewHolderModeDoesNotConnectPlatform(t *testing.T) {
 	}
 }
 
-func TestRunHolderModeWaitsForCancellation(t *testing.T) {
-	daemon, err := New(context.Background(), config.Config{Mode: config.ModeHolder, WorkDir: config.HolderDefaultWorkDir}, "test")
+func TestRunHolderModeUsesDefaultWorkDir(t *testing.T) {
+	cfg := config.Config{Mode: config.ModeHolder, WorkDir: config.HolderDefaultWorkDir}
+	runHolderModeAndAssertWorkDir(t, cfg, config.HolderDefaultWorkDir)
+}
+
+func TestRunHolderModeUsesConfiguredWorkDir(t *testing.T) {
+	workDir := t.TempDir()
+	cfg := config.Config{Mode: config.ModeHolder, WorkDir: workDir}
+	runHolderModeAndAssertWorkDir(t, cfg, workDir)
+}
+
+func runHolderModeAndAssertWorkDir(t *testing.T, cfg config.Config, expectedWorkDir string) {
+	t.Helper()
+	originalWorkDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get original work dir: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(originalWorkDir); err != nil {
+			t.Fatalf("restore original work dir: %v", err)
+		}
+	}()
+
+	daemon, err := New(context.Background(), cfg, "test")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -640,11 +663,7 @@ func TestRunHolderModeWaitsForCancellation(t *testing.T) {
 		errCh <- daemon.Run(ctx)
 	}()
 
-	select {
-	case err := <-errCh:
-		t.Fatalf("holder mode returned before cancellation: %v", err)
-	case <-time.After(100 * time.Millisecond):
-	}
+	waitForWorkDir(t, errCh, expectedWorkDir)
 
 	cancel()
 	select {
@@ -662,5 +681,26 @@ func TestRunHolderModeWaitsForCancellation(t *testing.T) {
 		}
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("holder mode did not stop after cancellation")
+	}
+}
+
+func waitForWorkDir(t *testing.T, errCh <-chan error, expectedWorkDir string) {
+	t.Helper()
+	deadline := time.After(500 * time.Millisecond)
+	for {
+		currentWorkDir, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("get work dir: %v", err)
+		}
+		if currentWorkDir == expectedWorkDir {
+			return
+		}
+		select {
+		case err := <-errCh:
+			t.Fatalf("holder mode returned before work dir was applied: %v", err)
+		case <-deadline:
+			t.Fatalf("expected holder work dir %s, got %s", expectedWorkDir, currentWorkDir)
+		case <-time.After(10 * time.Millisecond):
+		}
 	}
 }

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -631,8 +631,7 @@ func TestNewHolderModeDoesNotConnectPlatform(t *testing.T) {
 }
 
 func TestRunHolderModeUsesDefaultWorkDir(t *testing.T) {
-	cfg := config.Config{Mode: config.ModeHolder, WorkDir: config.HolderDefaultWorkDir}
-	runHolderModeAndAssertWorkDir(t, cfg, config.HolderDefaultWorkDir)
+	runHolderModeAndAssertChdir(t, config.Config{Mode: config.ModeHolder, WorkDir: config.HolderDefaultWorkDir}, config.HolderDefaultWorkDir)
 }
 
 func TestRunHolderModeUsesConfiguredWorkDir(t *testing.T) {
@@ -679,6 +678,45 @@ func runHolderModeAndAssertWorkDir(t *testing.T, cfg config.Config, expectedWork
 		if !errors.Is(err, context.Canceled) {
 			t.Fatalf("expected context.Canceled, got %v", err)
 		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("holder mode did not stop after cancellation")
+	}
+}
+
+func runHolderModeAndAssertChdir(t *testing.T, cfg config.Config, expectedWorkDir string) {
+	t.Helper()
+	originalChdir := holderChdir
+	chdirCalled := make(chan string, 1)
+	holderChdir = func(path string) error {
+		chdirCalled <- path
+		return nil
+	}
+	defer func() { holderChdir = originalChdir }()
+
+	daemon, err := New(context.Background(), cfg, "test")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- daemon.Run(ctx)
+	}()
+
+	select {
+	case got := <-chdirCalled:
+		if got != expectedWorkDir {
+			t.Fatalf("expected holder chdir %s, got %s", expectedWorkDir, got)
+		}
+	case err := <-errCh:
+		t.Fatalf("holder mode returned before chdir: %v", err)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("holder mode did not apply work dir")
+	}
+	cancel()
+	select {
+	case <-errCh:
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("holder mode did not stop after cancellation")
 	}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -612,3 +612,55 @@ func TestNextSyncRetryBackoffCapsAtMaximum(t *testing.T) {
 		t.Fatalf("expected max backoff, got %s", got)
 	}
 }
+
+func TestNewHolderModeDoesNotConnectPlatform(t *testing.T) {
+	daemon, err := New(context.Background(), config.Config{Mode: config.ModeHolder, WorkDir: config.HolderDefaultWorkDir}, "test")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if daemon.sdk != config.ModeHolder {
+		t.Fatalf("expected holder sdk marker, got %q", daemon.sdk)
+	}
+	if daemon.gatewayConn != nil || daemon.subscriber != nil || daemon.consumer != nil || daemon.agents != nil || daemon.runners != nil {
+		t.Fatal("holder mode initialized platform dependencies")
+	}
+	if daemon.codex != nil || daemon.agn != nil || daemon.claude != nil || daemon.tracingProxy != nil {
+		t.Fatal("holder mode initialized agent runtime dependencies")
+	}
+}
+
+func TestRunHolderModeWaitsForCancellation(t *testing.T) {
+	daemon, err := New(context.Background(), config.Config{Mode: config.ModeHolder, WorkDir: config.HolderDefaultWorkDir}, "test")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- daemon.Run(ctx)
+	}()
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("holder mode returned before cancellation: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("expected cancellation error, got nil")
+		}
+		for _, expected := range []string{"process_signal/shutdown", "canceled"} {
+			if !strings.Contains(err.Error(), expected) {
+				t.Fatalf("expected %q in error: %v", expected, err)
+			}
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("holder mode did not stop after cancellation")
+	}
+}

--- a/internal/daemon/holder.go
+++ b/internal/daemon/holder.go
@@ -8,12 +8,14 @@ import (
 	"strings"
 )
 
+var holderChdir = os.Chdir
+
 func runHolder(ctx context.Context, workDir string) error {
 	workDir = strings.TrimSpace(workDir)
 	if workDir == "" {
 		return fmt.Errorf("holder work dir is required")
 	}
-	if err := os.Chdir(workDir); err != nil {
+	if err := holderChdir(workDir); err != nil {
 		return fmt.Errorf("set holder work dir %s: %w", workDir, err)
 	}
 	log.Printf("agynd holder mode started in %s", workDir)

--- a/internal/daemon/holder.go
+++ b/internal/daemon/holder.go
@@ -2,11 +2,21 @@ package daemon
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"os"
+	"strings"
 )
 
-func runHolder(ctx context.Context) error {
-	log.Printf("agynd holder mode started")
+func runHolder(ctx context.Context, workDir string) error {
+	workDir = strings.TrimSpace(workDir)
+	if workDir == "" {
+		return fmt.Errorf("holder work dir is required")
+	}
+	if err := os.Chdir(workDir); err != nil {
+		return fmt.Errorf("set holder work dir %s: %w", workDir, err)
+	}
+	log.Printf("agynd holder mode started in %s", workDir)
 	<-ctx.Done()
 	return operationError(opProcessSignalShutdown, 0, ctx.Err())
 }

--- a/internal/daemon/holder.go
+++ b/internal/daemon/holder.go
@@ -1,0 +1,12 @@
+package daemon
+
+import (
+	"context"
+	"log"
+)
+
+func runHolder(ctx context.Context) error {
+	log.Printf("agynd holder mode started")
+	<-ctx.Done()
+	return operationError(opProcessSignalShutdown, 0, ctx.Err())
+}


### PR DESCRIPTION
## Summary
- Adds `AGYND_MODE=holder` for sandbox holder workloads, referencing agynio/architecture#162.
- Holder mode skips agent-only config requirements (`AGENT_ID`, `THREAD_ID`, `WORKLOAD_ID`, `/agyn-bin/config.json`) and defaults `WORKSPACE_DIR` to `/workspace` when unset.
- Holder mode initializes no Gateway/platform clients, no inbox subscriber/consumer, no skills/MCP/init-script fetches, no tracing proxy, and no agent SDK loop; it waits until context cancellation/SIGTERM.
- Does not depend on unmerged agynio/api#159 contracts.

## Validation
- `buf generate buf.build/agynio/api --path agynio/api/gateway/v1 --include-imports` — passed
- `git diff --check` — passed
- `go vet ./...` — passed
- `go test ./...` — passed: 231 passed, 0 failed, 0 skipped
- `go build ./...` — passed