### PR TITLE
fix(codex): retry transient stream errors

### DIFF
--- a/internal/codexbridge/bridge_test.go
+++ b/internal/codexbridge/bridge_test.go
@@ -230,3 +230,26 @@ func TestBridgeRetryingErrorNotificationDoesNotCompleteTurn(t *testing.T) {
 	}
 	tracker.Cancel("turn-retry")
 }
+
+func TestBridgeStreamDisconnectNotificationCompletesTurn(t *testing.T) {
+	tracker := NewTurnTracker()
+	bridge := New(tracker)
+	ch := tracker.Register("turn-stream-disconnect")
+
+	bridge.OnError(&codex.ErrorNotification{
+		ThreadID:  "thread-1",
+		TurnID:    "turn-stream-disconnect",
+		Error:     codex.TurnError{Message: "stream disconn"},
+		WillRetry: false,
+	})
+
+	result := receiveResult(t, ch)
+	var notificationErr *ErrorNotificationError
+	if !errors.As(result.Err, &notificationErr) {
+		t.Fatalf("expected ErrorNotificationError, got %T", result.Err)
+	}
+	if notificationErr.Message != "stream disconn" {
+		t.Fatalf("unexpected error message: %q", notificationErr.Message)
+	}
+	assertClosed(t, ch)
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -55,6 +55,17 @@ const (
 	mcpLoopbackHost                 = "127.0.0.1"
 )
 
+var retryableCodexErrorNotificationTerms = [...]string{
+	"stream disconn",
+	"stream disconnected",
+	"connection reset",
+	"connection refused",
+	"connection closed",
+	"EOF",
+	"timeout",
+	"temporary network failure",
+}
+
 const (
 	SDKCodex  = "codex"
 	SDKAgn    = "agn"
@@ -509,6 +520,20 @@ func isTerminalAgentProcessingError(err error) bool {
 	return errors.As(err, &terminalErr)
 }
 
+func isRetryableCodexErrorNotification(err error) bool {
+	var notificationErr *codexbridge.ErrorNotificationError
+	if !errors.As(err, &notificationErr) {
+		return false
+	}
+	normalizedMessage := strings.ToLower(strings.TrimSpace(notificationErr.Message))
+	for _, retryableTerm := range retryableCodexErrorNotificationTerms {
+		if strings.Contains(normalizedMessage, strings.ToLower(retryableTerm)) {
+			return true
+		}
+	}
+	return false
+}
+
 func operationContextErr(ctx context.Context, err error) error {
 	if err == nil {
 		return nil
@@ -675,6 +700,14 @@ func (d *Daemon) handleCodexMessage(ctx context.Context, message platform.Messag
 		}
 		if result.Err != nil {
 			if !errors.Is(result.Err, codexbridge.ErrMissingAgentMessage) {
+				if isRetryableCodexErrorNotification(result.Err) {
+					log.Printf("codex turn transient failure: turn_id=%s message_id=%s cause=%s; retrying sync", turnID, message.ID, result.Err)
+					return operationError(
+						opCodexTurnResult,
+						0,
+						fmt.Errorf("codex turn %s transient failure for message %s: %w", turnID, message.ID, result.Err),
+					)
+				}
 				return operationError(
 					opCodexTurnResult,
 					0,

--- a/internal/daemon/daemon_codex_test.go
+++ b/internal/daemon/daemon_codex_test.go
@@ -53,6 +53,12 @@ func (f *fakeCodexClient) StartTurn(ctx context.Context, _ *codex.TurnStartParam
 	return &codex.TurnStartResponse{Turn: codex.Turn{ID: "turn-1"}}, nil
 }
 
+func (f *fakeCodexClient) ResetStartTurnContext() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.startTurnCtx = nil
+}
+
 func (f *fakeCodexClient) StartTurnContext() context.Context {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -320,6 +326,55 @@ func TestHandleCodexMessageWrapsTurnResultError(t *testing.T) {
 	}
 }
 
+func TestHandleCodexMessageReturnsTransientNotificationAsRetryable(t *testing.T) {
+	store := codexbridge.NewThreadMappingStore(t.TempDir())
+	client := &fakeCodexClient{}
+	daemon := &Daemon{
+		sdk:          SDKCodex,
+		cfg:          config.Config{AgentID: uuid.MustParse(testAgentID), WorkDir: "/tmp"},
+		codex:        client,
+		mapping:      codexbridge.NewThreadMapping(),
+		mappingStore: store,
+		tracker:      codexbridge.NewTurnTracker(),
+		agent:        &agentsv1.Agent{},
+	}
+	message := platform.Message{ID: "msg-1", ThreadID: "thread-1", Body: "hello"}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- daemon.handleCodexMessage(context.Background(), message)
+	}()
+	turnErr := &codexbridge.ErrorNotificationError{
+		ThreadID: "codex-started",
+		TurnID:   "turn-1",
+		Message:  "stream disconn",
+	}
+	daemon.tracker.Notify(codexbridge.TurnResult{
+		ThreadID: "codex-started",
+		TurnID:   "turn-1",
+		Err:      turnErr,
+	})
+	var err error
+	select {
+	case err = <-errCh:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("handleCodexMessage did not finish after transient turn failure")
+	}
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	for _, expected := range []string{"codex_turn_result", "transient failure", "stream disconn", "msg-1"} {
+		if !strings.Contains(err.Error(), expected) {
+			t.Fatalf("expected %q in error: %v", expected, err)
+		}
+	}
+	if !errors.Is(err, turnErr) {
+		t.Fatalf("expected wrapped transient turn error, got %v", err)
+	}
+	if isTerminalAgentProcessingError(err) {
+		t.Fatalf("expected transient notification to remain retryable, got terminal error: %v", err)
+	}
+}
+
 func TestHandleCodexMessageReadsBackTurnMessage(t *testing.T) {
 	store := codexbridge.NewThreadMappingStore(t.TempDir())
 	client := &fakeCodexClient{readThreadResp: &codex.ThreadReadResponse{Thread: codex.Thread{Turns: []codex.Turn{{
@@ -463,5 +518,39 @@ func TestReadCodexTurnMessageTimeoutWrapsRetryableCause(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "context deadline exceeded") {
 		t.Fatalf("expected timeout text without double wrapping context deadline: %v", err)
+	}
+}
+
+func TestIsRetryableCodexErrorNotification(t *testing.T) {
+	tests := []struct {
+		name    string
+		message string
+	}{
+		{name: "stream disconn", message: "stream disconn"},
+		{name: "stream disconnected", message: "stream disconnected"},
+		{name: "connection reset", message: "provider connection reset by peer"},
+		{name: "connection refused", message: "connection refused"},
+		{name: "connection closed", message: "connection closed before response"},
+		{name: "EOF", message: "EOF"},
+		{name: "timeout", message: "request timeout"},
+		{name: "temporary network failure", message: "temporary network failure"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := &codexbridge.ErrorNotificationError{Message: tt.message}
+			if !isRetryableCodexErrorNotification(err) {
+				t.Fatalf("expected %q to be retryable", tt.message)
+			}
+		})
+	}
+}
+
+func TestIsRetryableCodexErrorNotificationRejectsUnknown(t *testing.T) {
+	unknownErr := &codexbridge.ErrorNotificationError{Message: "failed to read body"}
+	if isRetryableCodexErrorNotification(unknownErr) {
+		t.Fatal("expected unknown codex notification to remain terminal")
+	}
+	if isRetryableCodexErrorNotification(fmt.Errorf("stream disconn")) {
+		t.Fatal("expected non-notification error to remain non-retryable")
 	}
 }

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -127,6 +127,48 @@ func (h *handlingMessageConsumer) Calls() int {
 	return h.calls
 }
 
+type recordingMessageConsumer struct {
+	mu       sync.Mutex
+	calls    int
+	messages []platform.Message
+	started  chan struct{}
+	done     chan struct{}
+}
+
+func (r *recordingMessageConsumer) Sync(ctx context.Context, _ string, _ string, handle func(platform.Message) error) error {
+	r.mu.Lock()
+	r.calls++
+	callIndex := r.calls - 1
+	if callIndex >= len(r.messages) {
+		r.mu.Unlock()
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	message := r.messages[callIndex]
+	r.mu.Unlock()
+	if r.started != nil {
+		select {
+		case r.started <- struct{}{}:
+		default:
+		}
+	}
+
+	err := handle(message)
+	if r.done != nil {
+		select {
+		case r.done <- struct{}{}:
+		default:
+		}
+	}
+	return err
+}
+
+func (r *recordingMessageConsumer) Calls() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls
+}
+
 type recordingRunnersClient struct {
 	touched chan struct{}
 }
@@ -501,6 +543,111 @@ func TestRunReturnsTerminalCodexTurnFailureWithoutRetry(t *testing.T) {
 	}
 	if calls := consumer.Calls(); calls != 1 {
 		t.Fatalf("expected terminal failure to avoid retry, got %d sync calls", calls)
+	}
+}
+
+func TestRunRetriesTransientCodexStreamFailure(t *testing.T) {
+	subscriber := newFakeMessageSubscriber()
+	consumer := &recordingMessageConsumer{
+		messages: []platform.Message{
+			{ID: "msg-1", ThreadID: "thread-1", Body: "hello"},
+			{ID: "msg-1", ThreadID: "thread-1", Body: "hello"},
+		},
+		started: make(chan struct{}, 2),
+		done:    make(chan struct{}, 2),
+	}
+	store := codexbridge.NewThreadMappingStore(t.TempDir())
+	client := &fakeCodexClient{}
+	threadsClient := &fakeClaudeThreadsClient{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	daemon := &Daemon{
+		sdk:          SDKCodex,
+		cfg:          config.Config{AgentID: uuid.MustParse(testAgentID), WorkDir: "/tmp"},
+		runners:      &fakeRunnersClient{},
+		subscriber:   subscriber,
+		consumer:     consumer,
+		codex:        client,
+		mapping:      codexbridge.NewThreadMapping(),
+		mappingStore: store,
+		tracker:      codexbridge.NewTurnTracker(),
+		agent:        &agentsv1.Agent{},
+		threads:      platform.NewThreads(threadsClient),
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- daemon.Run(ctx)
+	}()
+
+	select {
+	case <-consumer.started:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("initial sync did not start")
+	}
+
+	waitForStartTurn := func() {
+		t.Helper()
+		deadline := time.After(500 * time.Millisecond)
+		for client.StartTurnContext() == nil {
+			select {
+			case err := <-errCh:
+				t.Fatalf("Run returned before codex turn started: %v", err)
+			case <-deadline:
+				t.Fatal("codex turn did not start")
+			case <-time.After(10 * time.Millisecond):
+			}
+		}
+	}
+
+	waitForStartTurn()
+	turnErr := &codexbridge.ErrorNotificationError{
+		ThreadID: "codex-started",
+		TurnID:   "turn-1",
+		Message:  "stream disconn",
+	}
+	daemon.tracker.Notify(codexbridge.TurnResult{ThreadID: "codex-started", TurnID: "turn-1", Err: turnErr})
+	select {
+	case <-consumer.done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("first sync did not finish")
+	}
+	if len(threadsClient.ackRequests) != 0 {
+		t.Fatalf("expected no ack for retryable failure, got %d", len(threadsClient.ackRequests))
+	}
+	client.ResetStartTurnContext()
+	select {
+	case err := <-errCh:
+		t.Fatalf("Run returned instead of retrying transient codex failure: %v", err)
+	case <-time.After(1100 * time.Millisecond):
+	}
+	if calls := consumer.Calls(); calls < 2 {
+		t.Fatalf("expected transient codex failure to retry sync, got %d calls", calls)
+	}
+
+	select {
+	case <-consumer.started:
+	case <-time.After(1500 * time.Millisecond):
+		t.Fatal("retry sync did not start")
+	}
+	waitForStartTurn()
+	daemon.tracker.Notify(codexbridge.TurnResult{ThreadID: "codex-started", TurnID: "turn-1", Message: "recovered response"})
+	select {
+	case <-consumer.done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("retry sync did not finish")
+	}
+	if len(threadsClient.ackRequests) != 1 {
+		t.Fatalf("expected ack after successful retry, got %d", len(threadsClient.ackRequests))
+	}
+	if got := threadsClient.ackRequests[0].GetMessageIds(); len(got) != 1 || got[0] != "msg-1" {
+		t.Fatalf("unexpected ack message ids: %#v", got)
+	}
+	cancel()
+	select {
+	case <-errCh:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Run did not stop")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Treat known transient Codex error notifications such as `stream disconn`, EOF, timeouts, and connection failures as retryable daemon sync failures.
- Preserve terminal Codex turn behavior for unknown/semantic notifications, thread mismatches, empty responses, and missing readback responses.
- Add coverage for retry classification, daemon-level retry, no ack before retry, terminal notification behavior, and bridge notification propagation.

Closes #153

## Test & Lint Summary

Commands run:

```sh
buf generate buf.build/agynio/api --path agynio/api/gateway/v1 --include-imports
go test ./internal/codexbridge ./internal/daemon
go test ./...
go test -json ./... > /tmp/agynd-go-test.json
go vet ./...
gofmt -l internal/codexbridge/bridge_test.go internal/daemon/daemon.go internal/daemon/daemon_codex_test.go internal/daemon/daemon_test.go
go build ./...
```

Results:

- `go test ./internal/codexbridge ./internal/daemon`: passed.
- `go test ./...`: 245 passed, 0 failed, 0 skipped. Package summary: 7 passed, 0 failed, 1 skipped/no-test-files package.
- `go vet ./...`: passed with no errors.
- `gofmt -l ...`: no files reported; formatting passed.
- `go build ./...`: passed.
