### PR TITLE
fix: subscribe to the room inbox deliveries publish to

### DIFF
--- a/internal/platform/notifications.go
+++ b/internal/platform/notifications.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	threadParticipantSelfRoom = "thread_participant:me"
-	agentInstanceSelfRoom     = "agent_instance:me"
+	instanceInboxSelfRoom     = "instance_inbox:me"
 )
 
 type SubscribeStream interface {
@@ -29,7 +29,7 @@ func (n *Notifications) Subscribe(ctx context.Context) (SubscribeStream, error) 
 	// Both rooms: the identity is an agent instance and gets woken through its
 	// inbox, but it is still a participant in the threads it was handed.
 	request := &notificationsv1.SubscribeRequest{
-		Rooms: []string{threadParticipantSelfRoom, agentInstanceSelfRoom},
+		Rooms: []string{threadParticipantSelfRoom, instanceInboxSelfRoom},
 	}
 	stream, err := n.client.Subscribe(ctx, request)
 	if err != nil {

--- a/internal/platform/notifications_test.go
+++ b/internal/platform/notifications_test.go
@@ -45,7 +45,7 @@ func TestNotificationsSubscribe(t *testing.T) {
 	if stream == nil {
 		t.Fatal("expected stream")
 	}
-	want := []string{threadParticipantSelfRoom, agentInstanceSelfRoom}
+	want := []string{threadParticipantSelfRoom, instanceInboxSelfRoom}
 	if fake.request == nil || !reflect.DeepEqual(fake.request.GetRooms(), want) {
 		t.Fatalf("expected rooms %v, got %+v", want, fake.request)
 	}


### PR DESCRIPTION
agynd subscribed to `agent_instance:me`. That room carries `instance.updated`, not inbox deliveries — those publish to `instance_inbox:{id}` (agents `internal/server/notifications.go`).

Worse, `agent_instance:` isn't a prefix the notifications service recognizes, so `classifyRoom` returned `roomKindOther` and never substituted the caller id for `me`. The subscription was to the literal string `agent_instance:me`, which nothing ever publishes to.

Net effect: an instance woke only on thread-participant traffic and never on a new inbox item — the exact wake it exists for.

The `message.created` event name already matches, and the payload has no `thread_id`, which the subscriber tolerates now that an instance doesn't filter by thread.