### PR TITLE
feat: post the turn's final message to the default thread

### DIFF
--- a/internal/daemon/agn.go
+++ b/internal/daemon/agn.go
@@ -121,14 +121,7 @@ func (d *Daemon) handleAgnMessage(ctx context.Context, message platform.Message)
 		)
 	}
 	response := strings.TrimSpace(result.Response)
-	if response == "" {
-		return operationError(
-			opAgnTurn,
-			0,
-			fmt.Errorf("agn turn completed with empty response for message %s on thread %s", message.ID, threadID),
-		)
-	}
-	if err := d.publishResponse(ctx, SDKAgn, threadID, message, response); err != nil {
+	if err := d.publishFinalMessage(ctx, SDKAgn, message, response); err != nil {
 		return err
 	}
 	if err := d.ackMessage(ctx, message); err != nil {

--- a/internal/daemon/claude.go
+++ b/internal/daemon/claude.go
@@ -132,14 +132,7 @@ func (d *Daemon) handleClaudeMessage(ctx context.Context, message platform.Messa
 		)
 	}
 	response := strings.TrimSpace(result.Response)
-	if response == "" {
-		return operationError(
-			opClaudeTurn,
-			0,
-			fmt.Errorf("claude turn completed with empty response for message %s on thread %s", message.ID, threadID),
-		)
-	}
-	if err := d.publishResponse(ctx, SDKClaude, threadID, message, response); err != nil {
+	if err := d.publishFinalMessage(ctx, SDKClaude, message, response); err != nil {
 		return err
 	}
 	if err := d.ackMessage(ctx, message); err != nil {

--- a/internal/daemon/claude_test.go
+++ b/internal/daemon/claude_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	agentsv1 "github.com/agynio/agynd-cli/.gen/go/agynio/api/agents/v1"
 	gatewayv1 "github.com/agynio/agynd-cli/.gen/go/agynio/api/gateway/v1"
 	threadsv1 "github.com/agynio/agynd-cli/.gen/go/agynio/api/threads/v1"
 	"github.com/agynio/agynd-cli/internal/config"
@@ -58,10 +59,16 @@ func (f *fakeClaudeThreadsClient) AddParticipant(ctx context.Context, in *thread
 
 func (f *fakeClaudeThreadsClient) SendMessage(ctx context.Context, in *threadsv1.SendMessageRequest, opts ...grpc.CallOption) (*threadsv1.SendMessageResponse, error) {
 	f.sendRequests = append(f.sendRequests, in)
+	// The server echoes back the thread it resolved, which is how a caller that
+	// left thread_id off learns where the message landed.
+	threadID := in.GetThreadId()
+	if threadID == "" {
+		threadID = "resolved-default-thread"
+	}
 	return &threadsv1.SendMessageResponse{
 		Message: &threadsv1.Message{
 			Id:        "msg-out",
-			ThreadId:  in.GetThreadId(),
+			ThreadId:  threadID,
 			SenderId:  in.GetSenderId(),
 			Body:      in.GetBody(),
 			FileIds:   append([]string{}, in.GetFileIds()...),
@@ -113,6 +120,7 @@ func TestHandleClaudeMessageSuccess(t *testing.T) {
 		cfg:     config.Config{AgentID: agentID},
 		threads: threads,
 		claude:  client,
+		agent:   &agentsv1.Agent{FinalMessage: agentsv1.AgentFinalMessage_AGENT_FINAL_MESSAGE_DEFAULT_THREAD},
 	}
 
 	message := platform.Message{
@@ -137,8 +145,10 @@ func TestHandleClaudeMessageSuccess(t *testing.T) {
 		t.Fatalf("expected SendMessage to be called once, got %d", len(threadsClient.sendRequests))
 	}
 	sendReq := threadsClient.sendRequests[0]
-	if sendReq.GetThreadId() != "thread-1" {
-		t.Fatalf("expected thread id %q, got %q", "thread-1", sendReq.GetThreadId())
+	// Left off the wire: Threads resolves the instance's default thread from
+	// the caller identity, so a stale value in the container cannot misroute it.
+	if sendReq.GetThreadId() != "" {
+		t.Fatalf("expected no thread id, got %q", sendReq.GetThreadId())
 	}
 	if sendReq.GetSenderId() != agentID.String() {
 		t.Fatalf("expected sender id %q, got %q", agentID.String(), sendReq.GetSenderId())
@@ -158,6 +168,9 @@ func TestHandleClaudeMessageSuccess(t *testing.T) {
 	}
 }
 
+// An agent that sent explicitly during its turn has nothing left to say. That
+// is ordinary, so the turn completes and the item is acked -- failing here
+// would leave it unacked and the turn repeating forever.
 func TestHandleClaudeMessageEmptyResponse(t *testing.T) {
 	client := &fakeClaudeClient{result: &claude.TurnResult{Response: " "}}
 	threadsClient := &fakeClaudeThreadsClient{}
@@ -166,19 +179,18 @@ func TestHandleClaudeMessageEmptyResponse(t *testing.T) {
 		cfg:     config.Config{AgentID: uuid.MustParse(testAgentID)},
 		threads: platform.NewThreads(threadsClient),
 		claude:  client,
+		agent:   &agentsv1.Agent{FinalMessage: agentsv1.AgentFinalMessage_AGENT_FINAL_MESSAGE_DEFAULT_THREAD},
 	}
 
 	message := platform.Message{ID: "msg-1", ThreadID: "thread-1", Body: "hello"}
-	if err := daemon.handleClaudeMessage(context.Background(), message); err == nil {
-		t.Fatal("expected error, got nil")
-	} else if !strings.Contains(err.Error(), "empty response") {
-		t.Fatalf("unexpected error: %v", err)
+	if err := daemon.handleClaudeMessage(context.Background(), message); err != nil {
+		t.Fatalf("expected no error, got %v", err)
 	}
 	if len(threadsClient.sendRequests) != 0 {
 		t.Fatalf("expected no send requests, got %d", len(threadsClient.sendRequests))
 	}
-	if len(threadsClient.ackRequests) != 0 {
-		t.Fatalf("expected no ack requests, got %d", len(threadsClient.ackRequests))
+	if len(threadsClient.ackRequests) != 1 {
+		t.Fatalf("expected the message to be acked, got %d ack requests", len(threadsClient.ackRequests))
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -28,6 +28,8 @@ import (
 	claude "github.com/agynio/claude-sdk-go"
 	codex "github.com/agynio/codex-sdk-go"
 	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -550,16 +552,40 @@ func operationContextErr(ctx context.Context, err error) error {
 	return err
 }
 
-func (d *Daemon) publishResponse(ctx context.Context, sdk string, threadID string, message platform.Message, response string) error {
+// publishFinalMessage delivers the text an agent CLI produced at the end of a
+// turn. Whether that text is a deliverable at all is the class's to say, and
+// where it goes is the instance's: the thread_id is left off the wire so
+// Threads resolves the instance's default from the caller identity.
+//
+// Not the thread the message arrived on. An agent woken by a reply on a
+// sub-thread still owes its answer to the thread it was created to serve.
+//
+// Nothing to say and nowhere to say it are both ordinary: an agent that
+// already sent explicitly has an empty final text, and an instance whose class
+// asked for no default has no destination. Both log and carry on, because
+// failing here would leave the item unacked and the turn repeating forever.
+func (d *Daemon) publishFinalMessage(ctx context.Context, sdk string, message platform.Message, response string) error {
+	if d.agent.GetFinalMessage() != agentsv1.AgentFinalMessage_AGENT_FINAL_MESSAGE_DEFAULT_THREAD {
+		return nil
+	}
+	response = strings.TrimSpace(response)
+	if response == "" {
+		log.Printf("final message: %s turn produced no text for message %s; nothing to post", sdk, message.ID)
+		return nil
+	}
 	publishCtx, cancel := context.WithTimeout(ctx, messagePublishTimeout)
-	_, err := d.threads.SendMessage(publishCtx, threadID, d.selfID(), response, nil)
+	_, err := d.threads.SendMessage(publishCtx, "", d.selfID(), response, nil)
 	err = operationContextErr(publishCtx, err)
 	cancel()
+	if status.Code(err) == codes.FailedPrecondition {
+		log.Printf("final message: no default thread for message %s; not posting: %v", message.ID, err)
+		return nil
+	}
 	if err != nil {
 		return operationError(
 			opMessagePublish,
 			messagePublishTimeout,
-			fmt.Errorf("publish %s response for message %s on thread %s: %w", sdk, message.ID, threadID, err),
+			fmt.Errorf("publish %s final message for message %s: %w", sdk, message.ID, err),
 		)
 	}
 	return nil
@@ -761,7 +787,7 @@ func (d *Daemon) handleCodexMessage(ctx context.Context, message platform.Messag
 				terminalCodexTurn(fmt.Errorf("codex turn %s completed with empty response for message %s", turnID, message.ID)),
 			)
 		}
-		if err := d.publishResponse(ctx, SDKCodex, threadID, message, result.Message); err != nil {
+		if err := d.publishFinalMessage(ctx, SDKCodex, message, result.Message); err != nil {
 			return err
 		}
 		if err := d.ackMessage(ctx, message); err != nil {

--- a/internal/daemon/instance_test.go
+++ b/internal/daemon/instance_test.go
@@ -45,6 +45,7 @@ func TestInstanceRepliesAndAcksAsItself(t *testing.T) {
 		threads:    platform.NewThreads(threadsClient),
 		agentInbox: platform.NewAgents(inboxClient),
 		claude:     client,
+		agent:      &agentsv1.Agent{FinalMessage: agentsv1.AgentFinalMessage_AGENT_FINAL_MESSAGE_DEFAULT_THREAD},
 	}
 
 	message := platform.Message{
@@ -93,6 +94,7 @@ func TestThreadScopedDaemonStillAcksOnTheThread(t *testing.T) {
 		threads:    platform.NewThreads(threadsClient),
 		agentInbox: platform.NewAgents(inboxClient),
 		claude:     client,
+		agent:      &agentsv1.Agent{FinalMessage: agentsv1.AgentFinalMessage_AGENT_FINAL_MESSAGE_DEFAULT_THREAD},
 	}
 
 	message := platform.Message{ID: "msg-1", ThreadID: "thread-1", Body: "hello"}
@@ -123,5 +125,36 @@ func TestSelfIDPrefersTheInstance(t *testing.T) {
 	withoutInstance := &Daemon{cfg: config.Config{AgentID: agentID}}
 	if got := withoutInstance.selfID(); got != agentID.String() {
 		t.Fatalf("expected the agent id, got %q", got)
+	}
+}
+
+// discard is the default, so an agent that was never configured to deliver its
+// final text posts nothing on turn end -- only its explicit sends appear.
+func TestFinalMessageDiscardPostsNothing(t *testing.T) {
+	client := &fakeClaudeClient{result: &claude.TurnResult{Response: "hello"}}
+	threadsClient := &fakeClaudeThreadsClient{}
+	inboxClient := &fakeAgentsInboxClient{}
+	daemon := &Daemon{
+		sdk: SDKClaude,
+		cfg: config.Config{
+			AgentID:         uuid.MustParse(testAgentID),
+			AgentInstanceID: uuid.MustParse(testAgentInstanceID),
+		},
+		threads:    platform.NewThreads(threadsClient),
+		agentInbox: platform.NewAgents(inboxClient),
+		claude:     client,
+		agent:      &agentsv1.Agent{},
+	}
+
+	message := platform.Message{ID: "msg-1", InboxItemID: "item-1", ThreadID: "thread-1", Body: "hello"}
+	if err := daemon.handleClaudeMessage(context.Background(), message); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(threadsClient.sendRequests) != 0 {
+		t.Fatalf("expected nothing posted, got %d sends", len(threadsClient.sendRequests))
+	}
+	// Still acked: the turn ran, there was simply nothing to deliver.
+	if len(inboxClient.ackRequests) != 1 {
+		t.Fatalf("expected the item to be acked, got %d", len(inboxClient.ackRequests))
 	}
 }

--- a/internal/platform/threads.go
+++ b/internal/platform/threads.go
@@ -57,10 +57,10 @@ func (t *Threads) GetUnackedMessages(ctx context.Context, participantID string, 
 	return messages, resp.GetNextPageToken(), nil
 }
 
+// SendMessage leaves thread_id on the wire exactly as given. An agent instance
+// may pass none, in which case Threads resolves the instance's default thread
+// from the caller identity -- the daemon does not need to know it.
 func (t *Threads) SendMessage(ctx context.Context, threadID, senderID, body string, fileIDs []string) (Message, error) {
-	if threadID == "" {
-		return Message{}, fmt.Errorf("thread id is required")
-	}
 	if senderID == "" {
 		return Message{}, fmt.Errorf("sender id is required")
 	}


### PR DESCRIPTION
agynd half of [2026-08-01-agent-default-thread](https://github.com/agynio/architecture/blob/main/changes/2026-08-01-agent-default-thread.md). Needs [threads#42](https://github.com/agynio/threads/pull/42) and [agents#71](https://github.com/agynio/agents/pull/71).

The final turn text was sent to the thread the incoming message arrived on. That is wrong as soon as agents delegate — in A → B → C, B is woken by C's reply on thread BC while owing its answer to A on thread AB — and it had nowhere to go at all for an item with no thread, which is every `source_kind=direct` write.

- The class decides whether the text is a deliverable (`final_message`); the instance decides where it goes.
- The daemon knows neither. It leaves `thread_id` off the wire and Threads resolves the instance's default from the caller identity, so nothing in the container can misroute it.
- **An empty final text is no longer a turn failure.** An agent that already sent explicitly has nothing left to say, and an instance with no default has nowhere to say it — both log and ack. Failing there would leave the item unacked and the turn repeating forever.

Default is `discard`, so an agent that already sends explicitly does not start posting everything twice.