### PR TITLE
Export codex traces over OTLP/HTTP, and deadline the handshake

### DIFF
--- a/internal/daemon/codexconfig.go
+++ b/internal/daemon/codexconfig.go
@@ -18,7 +18,12 @@ approval_policy = "never"
 sandbox_mode = "danger-full-access"
 
 [otel]
-trace_exporter = { otlp-grpc = { endpoint = %q } }
+# OTLP/HTTP, not gRPC: codex's otlp-grpc exporter fails to build at all in the
+# version shipped in the init image -- it reports "error loading otel config:
+# transport error" against any address, a live listener or a closed port alike --
+# and codex then exits before answering the initialize handshake. protocol is
+# required and binary is the OTLP default encoding.
+trace_exporter = { otlp-http = { endpoint = %q, protocol = "binary" } }
 metrics_exporter = "none"
 exporter = "none"
 

--- a/internal/daemon/codexconfig_test.go
+++ b/internal/daemon/codexconfig_test.go
@@ -380,7 +380,12 @@ approval_policy = "never"
 sandbox_mode = "danger-full-access"
 
 [otel]
-trace_exporter = { otlp-grpc = { endpoint = %q } }
+# OTLP/HTTP, not gRPC: codex's otlp-grpc exporter fails to build at all in the
+# version shipped in the init image -- it reports "error loading otel config:
+# transport error" against any address, a live listener or a closed port alike --
+# and codex then exits before answering the initialize handshake. protocol is
+# required and binary is the OTLP default encoding.
+trace_exporter = { otlp-http = { endpoint = %q, protocol = "binary" } }
 metrics_exporter = "none"
 exporter = "none"
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -33,29 +33,32 @@ import (
 )
 
 const (
-	pageSize                  int32 = 100
-	pageTimeout                     = 30 * time.Second
-	turnStartTimeout                = 5 * time.Minute
-	messagePublishTimeout           = 15 * time.Second
-	messageAckTimeout               = 15 * time.Second
-	mcpReadyTimeout                 = 4 * time.Minute
-	llmReadyTimeout                 = 120 * time.Second
-	codexReadbackTimeout            = 10 * time.Second
-	codexReadbackPollInterval       = 250 * time.Millisecond
-	syncRetryInitialBackoff         = 1 * time.Second
-	syncRetryMaxBackoff             = 30 * time.Second
-	opSyncPageFetch                 = "sync_page_fetch"
-	opCodexStartTurn                = "codex_start_turn"
-	opMessagePublish                = "publish"
-	opMessageAck                    = "ack"
-	opKeepaliveTouch                = "keepalive_touch"
-	opCodexWaitTurnCompletion       = "codex_wait_turn_completion"
-	opCodexTurnResult               = "codex_turn_result"
-	opAgnTurn                       = "agn_turn"
-	opClaudeTurn                    = "claude_turn"
-	opProcessSignalShutdown         = "process_signal/shutdown"
-	tracingProxyListenAddress       = "127.0.0.1:0"
-	mcpLoopbackHost                 = "127.0.0.1"
+	pageSize              int32 = 100
+	pageTimeout                 = 30 * time.Second
+	turnStartTimeout            = 5 * time.Minute
+	messagePublishTimeout       = 15 * time.Second
+	messageAckTimeout           = 15 * time.Second
+	mcpReadyTimeout             = 4 * time.Minute
+	// codexHandshakeTimeout bounds the initialize exchange with the agent
+	// process. Generous, because it also covers the binary starting up.
+	codexHandshakeTimeout     = 2 * time.Minute
+	llmReadyTimeout           = 120 * time.Second
+	codexReadbackTimeout      = 10 * time.Second
+	codexReadbackPollInterval = 250 * time.Millisecond
+	syncRetryInitialBackoff   = 1 * time.Second
+	syncRetryMaxBackoff       = 30 * time.Second
+	opSyncPageFetch           = "sync_page_fetch"
+	opCodexStartTurn          = "codex_start_turn"
+	opMessagePublish          = "publish"
+	opMessageAck              = "ack"
+	opKeepaliveTouch          = "keepalive_touch"
+	opCodexWaitTurnCompletion = "codex_wait_turn_completion"
+	opCodexTurnResult         = "codex_turn_result"
+	opAgnTurn                 = "agn_turn"
+	opClaudeTurn              = "claude_turn"
+	opProcessSignalShutdown   = "process_signal/shutdown"
+	tracingProxyListenAddress = "127.0.0.1:0"
+	mcpLoopbackHost           = "127.0.0.1"
 )
 
 var retryableCodexErrorNotificationTerms = [...]string{
@@ -309,7 +312,10 @@ func newCodexDaemon(ctx context.Context, cfg config.Config, version string) (*Da
 		return nil, err
 	}
 	otlpEndpoint := "http://" + tracingProxy.Address()
-	codexHome, err := writeCodexConfig(cfg.LLMBaseURL, cfg.MCPServers, otlpEndpoint)
+	// Codex exports over OTLP/HTTP and everything else over gRPC; see the otel
+	// block in the codex config for why.
+	codexOTLPEndpoint := "http://" + tracingProxy.HTTPAddress() + "/v1/traces"
+	codexHome, err := writeCodexConfig(cfg.LLMBaseURL, cfg.MCPServers, codexOTLPEndpoint)
 	if err != nil {
 		tracingProxy.Close()
 		_ = setup.gatewayConn.Close()
@@ -331,8 +337,15 @@ func newCodexDaemon(ctx context.Context, cfg config.Config, version string) (*Da
 		codex.WithApprovalHandler(codex.AutoApprovalHandler{}),
 		codex.WithClientInfo("agynd", version),
 	}
-	codexClient, err := newCodexClient(ctx, cfg, options...)
+	// Deadlined, because the handshake is a request to a child process that can
+	// fail to answer -- a codex that rejects its own config exits without a
+	// reply -- and without one the daemon blocked here for good: no logs, no
+	// inbox drain, a container that looks healthy and does nothing.
+	codexCtx, cancelCodex := context.WithTimeout(ctx, codexHandshakeTimeout)
+	codexClient, err := newCodexClient(codexCtx, cfg, options...)
+	cancelCodex()
 	if err != nil {
+		log.Printf("start codex: %v", err)
 		tracingProxy.Close()
 		_ = setup.gatewayConn.Close()
 		return nil, err

--- a/internal/tracingproxy/proxy.go
+++ b/internal/tracingproxy/proxy.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net"
+	"net/http"
 	"sync"
 	"time"
 
@@ -17,6 +19,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -25,6 +28,7 @@ const (
 	threadIDAttributeKey   = "agyn.thread.id"
 	messageIDAttributeKey  = "agyn.thread.message.id"
 	workloadIDAttributeKey = "agyn.workload.id"
+	maxHTTPExportBytes     = 32 << 20
 )
 
 type Config struct {
@@ -37,11 +41,13 @@ type Config struct {
 type Proxy struct {
 	collectortracev1.UnimplementedTraceServiceServer
 
-	server     *grpc.Server
-	upstream   collectortracev1.TraceServiceClient
-	conn       *grpc.ClientConn
-	address    string
-	workloadID string
+	server      *grpc.Server
+	httpServer  *http.Server
+	upstream    collectortracev1.TraceServiceClient
+	conn        *grpc.ClientConn
+	address     string
+	httpAddress string
+	workloadID  string
 	// An instance serves many threads, so the thread is per-message and set
 	// from the consumer goroutine while Export runs on gRPC's.
 	threadMu  sync.RWMutex
@@ -85,11 +91,73 @@ func Start(ctx context.Context, cfg Config) (*Proxy, error) {
 		}
 	}()
 
+	// The same exporter over OTLP/HTTP, on its own port. Codex cannot use the
+	// gRPC one -- its otlp-grpc exporter fails to build at all, against any
+	// address -- and the console and any other OTLP client still can, so this
+	// serves both rather than replacing one with the other.
+	httpListener, err := net.Listen("tcp", httpListenAddress(listenAddress))
+	if err != nil {
+		server.Stop()
+		_ = conn.Close()
+		return nil, fmt.Errorf("listen for OTLP/HTTP: %w", err)
+	}
+	proxy.httpAddress = httpListener.Addr().String()
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v1/traces", proxy.serveHTTPTraces)
+	proxy.httpServer = &http.Server{Handler: mux, ReadHeaderTimeout: 10 * time.Second}
+	go func() {
+		if err := proxy.httpServer.Serve(httpListener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Printf("tracing proxy OTLP/HTTP stopped: %v", err)
+		}
+	}()
+
 	return proxy, nil
+}
+
+// httpListenAddress keeps the OTLP/HTTP listener on the same host as the gRPC
+// one and lets the kernel choose its port, so the two never collide.
+func httpListenAddress(grpcAddress string) string {
+	host, _, err := net.SplitHostPort(grpcAddress)
+	if err != nil || host == "" {
+		return "127.0.0.1:0"
+	}
+	return net.JoinHostPort(host, "0")
+}
+
+// serveHTTPTraces accepts the binary protobuf encoding, which is what the OTLP
+// specification defaults to and the only one codex emits.
+func (p *Proxy) serveHTTPTraces(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxHTTPExportBytes))
+	if err != nil {
+		http.Error(w, "read body", http.StatusBadRequest)
+		return
+	}
+	request := &collectortracev1.ExportTraceServiceRequest{}
+	if err := proto.Unmarshal(body, request); err != nil {
+		http.Error(w, "decode OTLP request", http.StatusBadRequest)
+		return
+	}
+	response, err := p.Export(r.Context(), request)
+	if err != nil {
+		http.Error(w, "export traces", http.StatusBadGateway)
+		return
+	}
+	encoded, err := proto.Marshal(response)
+	if err != nil {
+		http.Error(w, "encode OTLP response", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/x-protobuf")
+	_, _ = w.Write(encoded)
 }
 
 func (p *Proxy) Address() string {
 	return p.address
+}
+
+// HTTPAddress is the OTLP/HTTP endpoint; append /v1/traces for the exporter.
+func (p *Proxy) HTTPAddress() string {
+	return p.httpAddress
 }
 
 func (p *Proxy) Export(ctx context.Context, req *collectortracev1.ExportTraceServiceRequest) (*collectortracev1.ExportTraceServiceResponse, error) {
@@ -148,6 +216,11 @@ func (p *Proxy) Close() {
 	case <-done:
 	case <-time.After(5 * time.Second):
 		p.server.Stop()
+	}
+	if p.httpServer != nil {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		_ = p.httpServer.Shutdown(shutdownCtx)
+		cancel()
 	}
 	_ = p.conn.Close()
 }

--- a/internal/tracingproxy/proxy_test.go
+++ b/internal/tracingproxy/proxy_test.go
@@ -1,8 +1,11 @@
 package tracingproxy
 
 import (
+	"bytes"
 	"context"
 	"net"
+	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,6 +15,7 @@ import (
 	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/proto"
 )
 
 type captureTraceServer struct {
@@ -454,4 +458,86 @@ func findSpanAttribute(span *tracev1.Span, key string) (*commonv1.AnyValue, bool
 		}
 	}
 	return nil, false
+}
+
+// Codex exports over OTLP/HTTP because its gRPC exporter will not build, so the
+// proxy has to accept that encoding as well and enrich it identically -- a
+// forwarder that only spoke gRPC left codex unable to start at all.
+func TestProxyForwardsOTLPOverHTTP(t *testing.T) {
+	server, listener, requests := startCaptureServer(t)
+	defer server.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	proxy, err := Start(ctx, Config{TracingAddress: listener.Addr().String(), ListenAddress: "127.0.0.1:0", ThreadID: "thread-http", WorkloadID: "workload-http"})
+	if err != nil {
+		t.Fatalf("start proxy: %v", err)
+	}
+	defer proxy.Close()
+	proxy.SetMessageID("message-http")
+
+	if proxy.HTTPAddress() == "" || proxy.HTTPAddress() == proxy.Address() {
+		t.Fatalf("expected a distinct OTLP/HTTP address, got %q and %q", proxy.HTTPAddress(), proxy.Address())
+	}
+
+	body, err := proto.Marshal(&collectortracev1.ExportTraceServiceRequest{
+		ResourceSpans: []*tracev1.ResourceSpans{{Resource: &resourcev1.Resource{}}},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://"+proxy.HTTPAddress()+"/v1/traces", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	request.Header.Set("Content-Type", "application/x-protobuf")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("post traces: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", response.StatusCode)
+	}
+
+	forwarded := awaitRequest(t, requests)
+	for key, want := range map[string]string{
+		threadIDAttributeKey:   "thread-http",
+		workloadIDAttributeKey: "workload-http",
+		messageIDAttributeKey:  "message-http",
+	} {
+		value, ok := findAttribute(forwarded.ResourceSpans[0].Resource, key)
+		if !ok || value.GetStringValue() != want {
+			t.Fatalf("expected %s=%s, got %v", key, want, value)
+		}
+	}
+}
+
+// A body that is not an OTLP request is the client's error, not the upstream's.
+func TestProxyRejectsMalformedHTTPBody(t *testing.T) {
+	server, listener, _ := startCaptureServer(t)
+	defer server.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	proxy, err := Start(ctx, Config{TracingAddress: listener.Addr().String(), ListenAddress: "127.0.0.1:0"})
+	if err != nil {
+		t.Fatalf("start proxy: %v", err)
+	}
+	defer proxy.Close()
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://"+proxy.HTTPAddress()+"/v1/traces", strings.NewReader("not protobuf at all"))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("post traces: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", response.StatusCode)
+	}
 }


### PR DESCRIPTION
Every codex agent hangs at startup, silently.

The codex binary in the init image (0.116.0) cannot build an `otlp-grpc` exporter at all — verified inside a running workload, it fails identically against a live listener and a closed port:

```
Error: error loading otel config: Reason: transport error
```

It exits before answering `initialize`, and `newCodexClient` waited on that with no deadline, so the daemon never reached `Run`: no logs, no inbox drain, an inbox item unacked for hours, and a pod reporting 3/3 Running.

- The tracing proxy now also serves OTLP/HTTP on its own port and enriches identically; codex points at that, everything else keeps gRPC. (`otlp-http` additionally requires `protocol`, which is why the naive switch alone would not have worked.)
- The handshake gets a 2-minute deadline and logs the failure, so a codex that will not start fails loudly instead of hanging forever.