### PR TITLE
Tell the agent where a message came from

### DIFF
--- a/internal/daemon/claude_test.go
+++ b/internal/daemon/claude_test.go
@@ -135,7 +135,6 @@ func TestHandleClaudeMessageSuccess(t *testing.T) {
 	if client.turnCalls != 1 {
 		t.Fatalf("expected Turn to be called once, got %d", client.turnCalls)
 	}
-	// The prompt carries the source header now; see buildInput.
 	if want := "thread: thread-1\n---\nhello"; client.params.Prompt != want {
 		t.Fatalf("expected prompt %q, got %q", want, client.params.Prompt)
 	}

--- a/internal/daemon/claude_test.go
+++ b/internal/daemon/claude_test.go
@@ -135,8 +135,9 @@ func TestHandleClaudeMessageSuccess(t *testing.T) {
 	if client.turnCalls != 1 {
 		t.Fatalf("expected Turn to be called once, got %d", client.turnCalls)
 	}
-	if client.params.Prompt != "hello" {
-		t.Fatalf("expected prompt %q, got %q", "hello", client.params.Prompt)
+	// The prompt carries the source header now; see buildInput.
+	if want := "thread: thread-1\nhello"; client.params.Prompt != want {
+		t.Fatalf("expected prompt %q, got %q", want, client.params.Prompt)
 	}
 	if _, ok := client.ctx.Deadline(); ok {
 		t.Fatal("expected claude turn context without completion deadline")

--- a/internal/daemon/claude_test.go
+++ b/internal/daemon/claude_test.go
@@ -136,7 +136,7 @@ func TestHandleClaudeMessageSuccess(t *testing.T) {
 		t.Fatalf("expected Turn to be called once, got %d", client.turnCalls)
 	}
 	// The prompt carries the source header now; see buildInput.
-	if want := "thread: thread-1\nhello"; client.params.Prompt != want {
+	if want := "thread: thread-1\n---\nhello"; client.params.Prompt != want {
 		t.Fatalf("expected prompt %q, got %q", want, client.params.Prompt)
 	}
 	if _, ok := client.ctx.Deadline(); ok {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1224,14 +1224,8 @@ func buildInput(message platform.Message) (string, error) {
 }
 
 // messageHeader names where an item came from, per agynd-cli.md "Message
-// Formatting". Without it an agent saw a bare body: it could not tell one
-// thread from another, nor who was asking, and an instance serves many of both.
-//
-// A thread-sourced item names its thread; a direct one says so, because it has
-// none and the agent has to fall back to its default thread. from carries the
-// sender's identity rather than a handle -- nothing resolves an identity back
-// to one, which is the same gap that leaves the chat UI showing "unknown
-// participant" -- so it is emitted as an id until that lookup exists.
+// Formatting". A direct item has no thread and says so, so the agent falls back
+// to its default one.
 func messageHeader(message platform.Message) string {
 	var header strings.Builder
 	if threadID := strings.TrimSpace(message.ThreadID); threadID != "" {
@@ -1242,9 +1236,6 @@ func messageHeader(message platform.Message) string {
 	if senderID := strings.TrimSpace(message.SenderID); senderID != "" {
 		fmt.Fprintf(&header, "from: %s\n", senderID)
 	}
-	// A rule between the fields and the body. Without it a message opening with
-	// something header-shaped reads as another field, and one that does not
-	// still leaves the model to guess where the metadata stops.
 	header.WriteString("---\n")
 	return header.String()
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1242,5 +1242,9 @@ func messageHeader(message platform.Message) string {
 	if senderID := strings.TrimSpace(message.SenderID); senderID != "" {
 		fmt.Fprintf(&header, "from: %s\n", senderID)
 	}
+	// A rule between the fields and the body. Without it a message opening with
+	// something header-shaped reads as another field, and one that does not
+	// still leaves the model to guess where the metadata stops.
+	header.WriteString("---\n")
 	return header.String()
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1223,9 +1223,6 @@ func buildInput(message platform.Message) (string, error) {
 	return messageHeader(message) + text, nil
 }
 
-// messageHeader names where an item came from, per agynd-cli.md "Message
-// Formatting". A direct item has no thread and says so, so the agent falls back
-// to its default one.
 func messageHeader(message platform.Message) string {
 	var header strings.Builder
 	if threadID := strings.TrimSpace(message.ThreadID); threadID != "" {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1220,5 +1220,27 @@ func buildInput(message platform.Message) (string, error) {
 	if text == "" {
 		return "", fmt.Errorf("message %s has no content", message.ID)
 	}
-	return text, nil
+	return messageHeader(message) + text, nil
+}
+
+// messageHeader names where an item came from, per agynd-cli.md "Message
+// Formatting". Without it an agent saw a bare body: it could not tell one
+// thread from another, nor who was asking, and an instance serves many of both.
+//
+// A thread-sourced item names its thread; a direct one says so, because it has
+// none and the agent has to fall back to its default thread. from carries the
+// sender's identity rather than a handle -- nothing resolves an identity back
+// to one, which is the same gap that leaves the chat UI showing "unknown
+// participant" -- so it is emitted as an id until that lookup exists.
+func messageHeader(message platform.Message) string {
+	var header strings.Builder
+	if threadID := strings.TrimSpace(message.ThreadID); threadID != "" {
+		fmt.Fprintf(&header, "thread: %s\n", threadID)
+	} else {
+		header.WriteString("source: direct\n")
+	}
+	if senderID := strings.TrimSpace(message.SenderID); senderID != "" {
+		fmt.Fprintf(&header, "from: %s\n", senderID)
+	}
+	return header.String()
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1230,7 +1230,9 @@ func messageHeader(message platform.Message) string {
 	} else {
 		header.WriteString("source: direct\n")
 	}
-	if senderID := strings.TrimSpace(message.SenderID); senderID != "" {
+	if handle := strings.TrimSpace(message.SenderHandle); handle != "" {
+		fmt.Fprintf(&header, "from: @%s\n", handle)
+	} else if senderID := strings.TrimSpace(message.SenderID); senderID != "" {
 		fmt.Fprintf(&header, "from: %s\n", senderID)
 	}
 	header.WriteString("---\n")

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -225,7 +225,7 @@ func TestBuildInputText(t *testing.T) {
 	}
 	// Direct, because the message names no thread: the agent has to know that
 	// to fall back to its default thread rather than guess.
-	if got != "source: direct\nhello" {
+	if got != "source: direct\n---\nhello" {
 		t.Fatalf("expected the header and trimmed text, got %q", got)
 	}
 }
@@ -239,7 +239,7 @@ func TestBuildInputFilesOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if got != "source: direct\nagyn://file/file-a\nagyn://file/file-b" {
+	if got != "source: direct\n---\nagyn://file/file-a\nagyn://file/file-b" {
 		t.Fatalf("unexpected file-only input: %q", got)
 	}
 }
@@ -254,7 +254,7 @@ func TestBuildInputTextWithFiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if got != "source: direct\nstatus\nagyn://file/file-a\nagyn://file/file-b" {
+	if got != "source: direct\n---\nstatus\nagyn://file/file-a\nagyn://file/file-b" {
 		t.Fatalf("unexpected text-with-files input: %q", got)
 	}
 }
@@ -914,7 +914,7 @@ func TestBuildInputCarriesTheThreadAndSender(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if got != "thread: thread-7\nfrom: identity-3\nstatus?" {
+	if got != "thread: thread-7\nfrom: identity-3\n---\nstatus?" {
 		t.Fatalf("unexpected input: %q", got)
 	}
 }
@@ -927,7 +927,7 @@ func TestBuildInputMarksDirectItems(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if got != "source: direct\nfrom: identity-4\nping" {
+	if got != "source: direct\nfrom: identity-4\n---\nping" {
 		t.Fatalf("unexpected input: %q", got)
 	}
 }

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -923,3 +923,20 @@ func TestBuildInputMarksDirectItems(t *testing.T) {
 		t.Fatalf("unexpected input: %q", got)
 	}
 }
+
+func TestBuildInputPrefersTheSenderHandle(t *testing.T) {
+	message := platform.Message{
+		ID:           "msg-7",
+		ThreadID:     "thread-9",
+		SenderID:     "identity-5",
+		SenderHandle: "rowan",
+		Body:         "status?",
+	}
+	got, err := buildInput(message)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got != "thread: thread-9\nfrom: @rowan\n---\nstatus?" {
+		t.Fatalf("unexpected input: %q", got)
+	}
+}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -223,8 +223,10 @@ func TestBuildInputText(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if got != "hello" {
-		t.Fatalf("expected trimmed text, got %q", got)
+	// Direct, because the message names no thread: the agent has to know that
+	// to fall back to its default thread rather than guess.
+	if got != "source: direct\nhello" {
+		t.Fatalf("expected the header and trimmed text, got %q", got)
 	}
 }
 
@@ -237,7 +239,7 @@ func TestBuildInputFilesOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if got != "agyn://file/file-a\nagyn://file/file-b" {
+	if got != "source: direct\nagyn://file/file-a\nagyn://file/file-b" {
 		t.Fatalf("unexpected file-only input: %q", got)
 	}
 }
@@ -252,7 +254,7 @@ func TestBuildInputTextWithFiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if got != "status\nagyn://file/file-a\nagyn://file/file-b" {
+	if got != "source: direct\nstatus\nagyn://file/file-a\nagyn://file/file-b" {
 		t.Fatalf("unexpected text-with-files input: %q", got)
 	}
 }
@@ -894,5 +896,38 @@ func waitForWorkDir(t *testing.T, errCh <-chan error, expectedWorkDir string) {
 			t.Fatalf("expected holder work dir %s, got %s", expectedWorkDir, currentWorkDir)
 		case <-time.After(10 * time.Millisecond):
 		}
+	}
+}
+
+// An instance serves many threads and many senders. Without a header the agent
+// received a bare body and could tell neither apart -- it could not address a
+// reply to the right thread, which is the whole point of the format in
+// agynd-cli.md "Message Formatting".
+func TestBuildInputCarriesTheThreadAndSender(t *testing.T) {
+	message := platform.Message{
+		ID:       "msg-5",
+		ThreadID: "thread-7",
+		SenderID: "identity-3",
+		Body:     "status?",
+	}
+	got, err := buildInput(message)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got != "thread: thread-7\nfrom: identity-3\nstatus?" {
+		t.Fatalf("unexpected input: %q", got)
+	}
+}
+
+// A direct item has no thread, and saying so is what tells the agent to use its
+// default thread instead of inventing one.
+func TestBuildInputMarksDirectItems(t *testing.T) {
+	message := platform.Message{ID: "msg-6", SenderID: "identity-4", Body: "ping"}
+	got, err := buildInput(message)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got != "source: direct\nfrom: identity-4\nping" {
+		t.Fatalf("unexpected input: %q", got)
 	}
 }

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -223,8 +223,6 @@ func TestBuildInputText(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	// Direct, because the message names no thread: the agent has to know that
-	// to fall back to its default thread rather than guess.
 	if got != "source: direct\n---\nhello" {
 		t.Fatalf("expected the header and trimmed text, got %q", got)
 	}
@@ -899,10 +897,6 @@ func waitForWorkDir(t *testing.T, errCh <-chan error, expectedWorkDir string) {
 	}
 }
 
-// An instance serves many threads and many senders. Without a header the agent
-// received a bare body and could tell neither apart -- it could not address a
-// reply to the right thread, which is the whole point of the format in
-// agynd-cli.md "Message Formatting".
 func TestBuildInputCarriesTheThreadAndSender(t *testing.T) {
 	message := platform.Message{
 		ID:       "msg-5",
@@ -919,8 +913,6 @@ func TestBuildInputCarriesTheThreadAndSender(t *testing.T) {
 	}
 }
 
-// A direct item has no thread, and saying so is what tells the agent to use its
-// default thread instead of inventing one.
 func TestBuildInputMarksDirectItems(t *testing.T) {
 	message := platform.Message{ID: "msg-6", SenderID: "identity-4", Body: "ping"}
 	got, err := buildInput(message)

--- a/internal/platform/agents.go
+++ b/internal/platform/agents.go
@@ -104,12 +104,13 @@ func inboxItemFromProto(item *agentsv1.InboxItem) (Message, error) {
 	}
 
 	return Message{
-		ID:          messageID,
-		InboxItemID: id,
-		ThreadID:    threadID,
-		SenderID:    senderID,
-		Body:        item.GetBody(),
-		FileIDs:     fileIDs,
-		CreatedAt:   acceptedAt.AsTime(),
+		ID:           messageID,
+		InboxItemID:  id,
+		ThreadID:     threadID,
+		SenderID:     senderID,
+		SenderHandle: item.GetSenderHandle(),
+		Body:         item.GetBody(),
+		FileIDs:      fileIDs,
+		CreatedAt:    acceptedAt.AsTime(),
 	}, nil
 }

--- a/internal/platform/threads.go
+++ b/internal/platform/threads.go
@@ -16,9 +16,11 @@ type Message struct {
 	InboxItemID string
 	ThreadID    string
 	SenderID    string
-	Body        string
-	FileIDs     []string
-	CreatedAt   time.Time
+	// SenderHandle is the sender's nickname when the organization holds one.
+	SenderHandle string
+	Body         string
+	FileIDs      []string
+	CreatedAt    time.Time
 }
 
 type Threads struct {


### PR DESCRIPTION
An inbox item reached the agent CLI as a bare body:

```
hello
```

An instance serves many threads and many senders, so the agent could tell neither apart and could not address a reply to the thread the message arrived on. [agynd-cli.md §2 Message Formatting](https://github.com/agynio/architecture/blob/main/architecture/agynd-cli.md) specifies a header; nothing emitted it.

Now:

```
thread: <thread-id>
from: <sender-identity>
hello
```

with `source: direct` in place of `thread:` for app-written items, which carry no thread and fall back to the instance's default.

**Not spec-complete:** the spec says `from: @sender-handle`, and `InboxItem` carries only `sender_id`. Identity exposes `ResolveNickname` (handle → identity) but nothing reverses it, so the id is emitted for now. That same missing lookup is why the chat UI renders every agent as "(unknown participant)" — worth fixing once, as either a reverse RPC or a denormalised `sender_handle` on the item.