### PR TITLE
Key agn state on the instance, not the thread

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ permissions:
 
 env:
   IMAGE_NAME: ghcr.io/agynio/agynd-cli
+  INIT_IMAGE_NAME: ghcr.io/agynio/agynd-cli-init
   CHART_DIR: charts/agynd
   CHART_REGISTRY: oci://ghcr.io/agynio/charts
 
@@ -118,6 +119,50 @@ jobs:
             exit 1
           fi
           echo "Manifest $IMAGE_NAME:$TAG includes linux/amd64 and linux/arm64"
+
+      # The init-container form, injected into every workload. Same binary,
+      # same version - only the delivery differs, so it releases here rather
+      # than from a repository of its own.
+      - name: Extract Docker metadata for the init image
+        id: meta-init
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.INIT_IMAGE_NAME }}
+          tags: |
+            type=sha,format=short,prefix=sha-
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+
+      - name: Build and push the init image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.init
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta-init.outputs.tags }}
+          labels: ${{ steps.meta-init.outputs.labels }}
+          cache-from: type=gha,scope=agynd-cli-init
+          cache-to: type=gha,scope=agynd-cli-init,mode=max
+
+      - name: Verify multi-arch manifest for the init image
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          INSPECT="$(docker buildx imagetools inspect "$INIT_IMAGE_NAME:$TAG" --raw)"
+          FOUND="$(echo "$INSPECT" | jq -r '[.manifests[].platform.architecture] | sort | join(",")')"
+          MISSING=()
+          for ARCH in amd64 arm64; do
+            if ! echo "$FOUND" | grep -q "$ARCH"; then
+              MISSING+=("linux/$ARCH")
+            fi
+          done
+          if [ ${#MISSING[@]} -gt 0 ]; then
+            echo "::error::Missing architectures in $INIT_IMAGE_NAME:$TAG: ${MISSING[*]}"
+            exit 1
+          fi
+          echo "Manifest $INIT_IMAGE_NAME:$TAG includes linux/amd64 and linux/arm64"
 
   helm:
     name: Package and push Helm chart

--- a/Dockerfile.init
+++ b/Dockerfile.init
@@ -1,0 +1,58 @@
+# syntax=docker/dockerfile:1.8
+#
+# The init-container form of agynd. Its entire job is to copy the binary into
+# the shared /agyn-bin volume every workload mounts, which is what the -init
+# suffix records: an image from this repository that ran as something other than
+# an init container would take a different suffix rather than overload this one.
+#
+# agynd ships with the platform rather than inside a user-selected image,
+# because its platform side must never lag the platform. An old agynd on a new
+# platform fails wire-compatibly and silently - deprecated fields still
+# deserialize, and a flow it does not know to perform simply does not happen.
+ARG GO_VERSION=1.26
+ARG BUF_VERSION=1.66.0
+
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS buf
+ARG BUF_VERSION
+RUN apk add --no-cache curl
+RUN curl -sSL \
+      "https://github.com/bufbuild/buf/releases/download/v${BUF_VERSION}/buf-$(uname -s)-$(uname -m)" \
+      -o /usr/local/bin/buf && \
+    chmod +x /usr/local/bin/buf
+
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS build
+
+WORKDIR /src
+
+COPY --from=buf /usr/local/bin/buf /usr/local/bin/buf
+RUN apk add --no-cache git
+
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go mod download
+
+COPY buf.gen.yaml buf.yaml ./
+RUN buf generate buf.build/agynio/api \
+    --path agynio/api/gateway/v1 \
+    --include-imports
+
+COPY . .
+
+ARG TARGETOS TARGETARCH
+# Statically linked, so it runs on any Linux base image the workspace uses.
+ENV CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH
+
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -trimpath -ldflags "-s -w" -o /out/agynd ./cmd/agynd
+
+FROM busybox:1.37-musl AS runtime
+
+COPY --from=build /out/agynd /opt/agyn/agynd
+
+# The Orchestrator sets no command: the image describes how it delivers itself.
+# It runs as root because the emptyDir it writes into is root-owned on a fresh
+# Pod; the copied binary is world-executable so the main container can run it
+# whatever user its image defines.
+ENTRYPOINT ["/bin/sh", "-c", "set -e; mkdir -p /agyn-bin; cp /opt/agyn/agynd /agyn-bin/agynd; chmod 0755 /agyn-bin/agynd"]

--- a/internal/daemon/agn.go
+++ b/internal/daemon/agn.go
@@ -102,16 +102,18 @@ func newAgnDaemon(ctx context.Context, cfg config.Config, version string) (*Daem
 
 func (d *Daemon) handleAgnMessage(ctx context.Context, message platform.Message) error {
 	threadID := strings.TrimSpace(message.ThreadID)
-	if threadID == "" {
-		return fmt.Errorf("message %s missing thread id", message.ID)
-	}
 	inputText, err := buildInput(message)
 	if err != nil {
 		return err
 	}
+	// The instance, not the thread. Agent state is instance-scoped -- an
+	// instance serves many threads and they share one conversation -- and
+	// keying it by thread meant a reply arriving on another thread began a
+	// conversation with no memory of the one that started it. Which thread a
+	// message came from is in its header.
 	result, err := d.agn.Turn(ctx, agnsdk.TurnParams{
 		Prompt:   inputText,
-		ThreadID: threadID,
+		ThreadID: d.selfID(),
 	}, nil)
 	if err != nil {
 		return operationError(


### PR DESCRIPTION
[state.md](https://github.com/agynio/architecture/blob/main/architecture/agent/state.md) is explicit:

> **Instance-scoped.** State is keyed by agent instance, **not by thread** or by class. Multiple threads that route to the same instance share the same state.

agynd passed the incoming message's thread id as agn's conversation key, and agn loads state by exactly that. So:

- Vitalii → Rowan arrives on thread A; state A holds the request
- Rowan → Casey happens on thread B
- Casey → Rowan arrives on thread B; agn loads state B, which is empty

Rowan saw one message from Casey and read it as the start of a conversation, with no memory of what Vitalii had asked. Keying on the instance gives the instance one conversation across its threads; which thread a message came from is already in its header.

No unit test: `d.agn` is a concrete `*agnsdk.Client`, so faking it needs a refactor I did not want to fold in here. Verified against the platform VM instead.