### PR TITLE
refactor: mount the shared tools at /agyn/bin

### DIFF
--- a/Dockerfile.init
+++ b/Dockerfile.init
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.8
 #
 # The init-container form of agynd. Its entire job is to copy the binary into
-# the shared /agyn-bin volume every workload mounts, which is what the -init
+# the shared /agyn/bin volume every workload mounts, which is what the -init
 # suffix records: an image from this repository that ran as something other than
 # an init container would take a different suffix rather than overload this one.
 #
@@ -55,4 +55,4 @@ COPY --from=build /out/agynd /opt/agyn/agynd
 # It runs as root because the emptyDir it writes into is root-owned on a fresh
 # Pod; the copied binary is world-executable so the main container can run it
 # whatever user its image defines.
-ENTRYPOINT ["/bin/sh", "-c", "set -e; mkdir -p /agyn-bin; cp /opt/agyn/agynd /agyn-bin/agynd; chmod 0755 /agyn-bin/agynd"]
+ENTRYPOINT ["/bin/sh", "-c", "set -e; mkdir -p /agyn/bin; cp /opt/agyn/agynd /agyn/bin/agynd; chmod 0755 /agyn/bin/agynd"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Those tests validate the local agent CLI bridge behavior against deterministic
 TestLLM endpoints through the Codex and AGN SDK flows. The workflow checks out
 `agynio/agn-cli` so the AGN coverage builds and runs the current AGN CLI during
 the test. They also build and execute this repository's `cmd/agynd` binary with
-`/agyn-bin/config.json` installed by the test harness. That test uses a stub
+`/agyn/bin/config.json` installed by the test harness. That test uses a stub
 Gateway and fake AGN agent to verify daemon startup, platform initialization,
 and subscriber startup without requiring a full cluster.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/uuid"
 )
 
-const agentConfigPath = "/agyn-bin/config.json"
+const agentConfigPath = "/agyn/bin/config.json"
 
 const (
 	ModeAgent            = "agent"

--- a/internal/daemon/claude.go
+++ b/internal/daemon/claude.go
@@ -54,7 +54,7 @@ func newClaudeDaemon(ctx context.Context, cfg config.Config, version string) (*D
 		WorkDir:    cfg.WorkDir,
 		Env: []string{
 			"PATH=" + agentPathValue(),
-			"LD_LIBRARY_PATH=/agyn-bin/lib",
+			"LD_LIBRARY_PATH=/agyn/bin/lib",
 			"CLAUDE_CODE_ENABLE_TELEMETRY=1",
 			"CLAUDE_CODE_ENHANCED_TELEMETRY_BETA=1",
 			"OTEL_TRACES_EXPORTER=otlp",

--- a/internal/daemon/env.go
+++ b/internal/daemon/env.go
@@ -6,8 +6,8 @@ import (
 )
 
 const (
-	cliPathPrefix    = "/agyn-bin/cli"
-	agentBinPath     = "/agyn-bin"
+	cliPathPrefix    = "/agyn/bin/cli"
+	agentBinPath     = "/agyn/bin"
 	codexDefaultHome = "/tmp"
 )
 

--- a/test/e2e/agynd_daemon_test.go
+++ b/test/e2e/agynd_daemon_test.go
@@ -143,19 +143,19 @@ func buildAgynd(t *testing.T) string {
 func installAgentRuntimeConfig(t *testing.T, agentBinary string) {
 	t.Helper()
 	runner := newPrivilegedRunner(t)
-	runner.run(t, "mkdir", "-p", "/agyn-bin")
+	runner.run(t, "mkdir", "-p", "/agyn/bin")
 
 	backupPath := filepath.Join(t.TempDir(), "config.json.backup")
-	hadExisting := fileExists("/agyn-bin/config.json")
+	hadExisting := fileExists("/agyn/bin/config.json")
 	if hadExisting {
-		runner.run(t, "cp", "/agyn-bin/config.json", backupPath)
+		runner.run(t, "cp", "/agyn/bin/config.json", backupPath)
 	}
 	t.Cleanup(func() {
 		if hadExisting {
-			runner.run(t, "cp", backupPath, "/agyn-bin/config.json")
+			runner.run(t, "cp", backupPath, "/agyn/bin/config.json")
 			return
 		}
-		runner.run(t, "rm", "-f", "/agyn-bin/config.json")
+		runner.run(t, "rm", "-f", "/agyn/bin/config.json")
 	})
 
 	configPath := filepath.Join(t.TempDir(), "config.json")
@@ -163,8 +163,8 @@ func installAgentRuntimeConfig(t *testing.T, agentBinary string) {
 	if err := os.WriteFile(configPath, []byte(payload), 0o600); err != nil {
 		t.Fatalf("write test config: %v", err)
 	}
-	runner.run(t, "cp", configPath, "/agyn-bin/config.json")
-	runner.run(t, "chmod", "0644", "/agyn-bin/config.json")
+	runner.run(t, "cp", configPath, "/agyn/bin/config.json")
+	runner.run(t, "chmod", "0644", "/agyn/bin/config.json")
 }
 
 type privilegedRunner struct {
@@ -179,7 +179,7 @@ func newPrivilegedRunner(t *testing.T) privilegedRunner {
 	if os.Geteuid() == 0 {
 		return privilegedRunner{}
 	}
-	t.Fatal("sudo is required to install /agyn-bin/config.json for agynd e2e")
+	t.Fatal("sudo is required to install /agyn/bin/config.json for agynd e2e")
 	return privilegedRunner{}
 }
 


### PR DESCRIPTION
`/agyn-bin` becomes `/agyn/bin`. One flat name at the root becomes a directory the platform can extend without claiming another top-level path.

Coordinated with the init and runtime images that write into the volume, and the Orchestrator that mounts it.