### PR TITLE
fix: read config.json from /agyn

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Those tests validate the local agent CLI bridge behavior against deterministic
 TestLLM endpoints through the Codex and AGN SDK flows. The workflow checks out
 `agynio/agn-cli` so the AGN coverage builds and runs the current AGN CLI during
 the test. They also build and execute this repository's `cmd/agynd` binary with
-`/agyn/bin/config.json` installed by the test harness. That test uses a stub
+`/agyn/config.json` installed by the test harness. That test uses a stub
 Gateway and fake AGN agent to verify daemon startup, platform initialization,
 and subscriber startup without requiring a full cluster.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/uuid"
 )
 
-const agentConfigPath = "/agyn/bin/config.json"
+const agentConfigPath = "/agyn/config.json"
 
 const (
 	ModeAgent            = "agent"

--- a/test/e2e/agynd_daemon_test.go
+++ b/test/e2e/agynd_daemon_test.go
@@ -146,16 +146,16 @@ func installAgentRuntimeConfig(t *testing.T, agentBinary string) {
 	runner.run(t, "mkdir", "-p", "/agyn/bin")
 
 	backupPath := filepath.Join(t.TempDir(), "config.json.backup")
-	hadExisting := fileExists("/agyn/bin/config.json")
+	hadExisting := fileExists("/agyn/config.json")
 	if hadExisting {
-		runner.run(t, "cp", "/agyn/bin/config.json", backupPath)
+		runner.run(t, "cp", "/agyn/config.json", backupPath)
 	}
 	t.Cleanup(func() {
 		if hadExisting {
-			runner.run(t, "cp", backupPath, "/agyn/bin/config.json")
+			runner.run(t, "cp", backupPath, "/agyn/config.json")
 			return
 		}
-		runner.run(t, "rm", "-f", "/agyn/bin/config.json")
+		runner.run(t, "rm", "-f", "/agyn/config.json")
 	})
 
 	configPath := filepath.Join(t.TempDir(), "config.json")
@@ -163,8 +163,8 @@ func installAgentRuntimeConfig(t *testing.T, agentBinary string) {
 	if err := os.WriteFile(configPath, []byte(payload), 0o600); err != nil {
 		t.Fatalf("write test config: %v", err)
 	}
-	runner.run(t, "cp", configPath, "/agyn/bin/config.json")
-	runner.run(t, "chmod", "0644", "/agyn/bin/config.json")
+	runner.run(t, "cp", configPath, "/agyn/config.json")
+	runner.run(t, "chmod", "0644", "/agyn/config.json")
 }
 
 type privilegedRunner struct {
@@ -179,7 +179,7 @@ func newPrivilegedRunner(t *testing.T) privilegedRunner {
 	if os.Geteuid() == 0 {
 		return privilegedRunner{}
 	}
-	t.Fatal("sudo is required to install /agyn/bin/config.json for agynd e2e")
+	t.Fatal("sudo is required to install /agyn/config.json for agynd e2e")
 	return privilegedRunner{}
 }
 


### PR DESCRIPTION
[agent-init.md](https://github.com/agynio/architecture/blob/main/architecture/agent-init.md): binaries under `/agyn/bin`, the agent runtime's `config.json` beside them at `/agyn`. Paired with agynio/agyn-runtime-codex#74, agynio/agyn-runtime-claude#63, agynio/agyn-runtime-agn#75.