### PR TITLE
Fetch the environment's MCPs and init scripts

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,8 +37,12 @@ type MCPServer struct {
 }
 
 type Config struct {
-	Mode            string
-	AgentID         uuid.UUID
+	Mode    string
+	AgentID uuid.UUID
+	// EnvironmentID names the environment this workload runs, whose MCPs and
+	// init scripts apply alongside the agent's. Empty for an agent that names no
+	// environment.
+	EnvironmentID   string
 	AgentInstanceID uuid.UUID
 	GatewayAddress  string
 	TracingAddress  string
@@ -73,6 +77,7 @@ func fromEnv(configPath string) (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	environmentID := strings.TrimSpace(os.Getenv("ENVIRONMENT_ID"))
 	gatewayAddress := strings.TrimSpace(os.Getenv("GATEWAY_ADDRESS"))
 	if gatewayAddress == "" {
 		gatewayAddress = "gateway.ziti:443"
@@ -145,6 +150,7 @@ func fromEnv(configPath string) (Config, error) {
 	return Config{
 		Mode:            mode,
 		AgentID:         agentID,
+		EnvironmentID:   environmentID,
 		AgentInstanceID: agentInstanceID,
 		GatewayAddress:  gatewayAddress,
 		TracingAddress:  tracingAddress,

--- a/internal/daemon/agn.go
+++ b/internal/daemon/agn.go
@@ -47,7 +47,7 @@ func newAgnDaemon(ctx context.Context, cfg config.Config, version string) (*Daem
 		return nil, err
 	}
 
-	if err := runInitScripts(ctx, setup.agents, cfg.AgentID.String(), cfg.WorkDir); err != nil {
+	if err := runInitScripts(ctx, setup.agents, cfg.AgentID.String(), cfg.EnvironmentID, cfg.WorkDir); err != nil {
 		_ = setup.gatewayConn.Close()
 		return nil, err
 	}

--- a/internal/daemon/claude.go
+++ b/internal/daemon/claude.go
@@ -32,7 +32,7 @@ func newClaudeDaemon(ctx context.Context, cfg config.Config, version string) (*D
 		return nil, err
 	}
 
-	if err := runInitScripts(ctx, setup.agents, cfg.AgentID.String(), cfg.WorkDir); err != nil {
+	if err := runInitScripts(ctx, setup.agents, cfg.AgentID.String(), cfg.EnvironmentID, cfg.WorkDir); err != nil {
 		_ = setup.gatewayConn.Close()
 		return nil, err
 	}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -258,7 +258,7 @@ func tryConnectPlatform(ctx context.Context, cfg config.Config) (*platformSetup,
 		return nil, config.Config{}, fmt.Errorf("list skills: %w", err)
 	}
 
-	mcpDefinitions, err := listMCPs(ctx, agentsClient, cfg.AgentID.String())
+	mcpDefinitions, err := listMCPs(ctx, agentsClient, cfg.AgentID.String(), cfg.EnvironmentID)
 	if err != nil {
 		_ = gatewayConn.Close()
 		return nil, config.Config{}, fmt.Errorf("list MCPs: %w", err)
@@ -322,7 +322,7 @@ func newCodexDaemon(ctx context.Context, cfg config.Config, version string) (*Da
 		return nil, err
 	}
 
-	if err := runInitScripts(ctx, setup.agents, cfg.AgentID.String(), cfg.WorkDir); err != nil {
+	if err := runInitScripts(ctx, setup.agents, cfg.AgentID.String(), cfg.EnvironmentID, cfg.WorkDir); err != nil {
 		tracingProxy.Close()
 		_ = setup.gatewayConn.Close()
 		return nil, err

--- a/internal/daemon/environment_scope_test.go
+++ b/internal/daemon/environment_scope_test.go
@@ -1,0 +1,83 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	agentsv1 "github.com/agynio/agynd-cli/.gen/go/agynio/api/agents/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type scopedMcpsClient struct {
+	byTarget map[string][]*agentsv1.Mcp
+	requests []string
+}
+
+func (c *scopedMcpsClient) ListMcps(_ context.Context, in *agentsv1.ListMcpsRequest, _ ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error) {
+	target := "agent:" + in.GetAgentId()
+	if in.GetEnvironmentId() != "" {
+		target = "environment:" + in.GetEnvironmentId()
+	}
+	c.requests = append(c.requests, target)
+	return &agentsv1.ListMcpsResponse{Mcps: c.byTarget[target]}, nil
+}
+
+// Environment-level and agent-level servers compose as a union, and on a name
+// collision the agent's wins -- the rule ENV already follows.
+func TestListMCPsMergesEnvironmentAndAgentByName(t *testing.T) {
+	client := &scopedMcpsClient{byTarget: map[string][]*agentsv1.Mcp{
+		"environment:env-1": {
+			{Meta: &agentsv1.EntityMeta{Id: "env-shared", CreatedAt: timestamppb.New(time.Now())}, Name: "files"},
+			{Meta: &agentsv1.EntityMeta{Id: "env-only", CreatedAt: timestamppb.New(time.Now())}, Name: "search"},
+		},
+		"agent:agent-1": {
+			{Meta: &agentsv1.EntityMeta{Id: "agent-shared", CreatedAt: timestamppb.New(time.Now())}, Name: "files"},
+		},
+	}}
+
+	mcps, err := listMCPs(context.Background(), client, "agent-1", "env-1")
+	if err != nil {
+		t.Fatalf("list mcps: %v", err)
+	}
+	byName := map[string]string{}
+	for _, mcp := range mcps {
+		byName[mcp.Name] = mcp.ID
+	}
+	if len(byName) != 2 {
+		t.Fatalf("expected 2 servers, got %d: %v", len(byName), byName)
+	}
+	if byName["files"] != "agent-shared" {
+		t.Fatalf("expected the agent-level server to win on a name collision, got %q", byName["files"])
+	}
+	if byName["search"] != "env-only" {
+		t.Fatalf("expected the environment-only server to survive, got %q", byName["search"])
+	}
+}
+
+// A sandbox has no agent, so it runs the environment's servers alone.
+func TestListMCPsWithoutAnAgentReadsTheEnvironmentOnly(t *testing.T) {
+	client := &scopedMcpsClient{byTarget: map[string][]*agentsv1.Mcp{
+		"environment:env-1": {{Meta: &agentsv1.EntityMeta{Id: "env-only", CreatedAt: timestamppb.New(time.Now())}, Name: "files"}},
+	}}
+
+	mcps, err := listMCPs(context.Background(), client, "", "env-1")
+	if err != nil {
+		t.Fatalf("list mcps: %v", err)
+	}
+	if len(mcps) != 1 || mcps[0].ID != "env-only" {
+		t.Fatalf("unexpected servers: %+v", mcps)
+	}
+	for _, req := range client.requests {
+		if req == "agent:" {
+			t.Fatal("expected no agent-scoped request without an agent")
+		}
+	}
+}
+
+func TestListMCPsRequiresATarget(t *testing.T) {
+	if _, err := listMCPs(context.Background(), &scopedMcpsClient{}, "", ""); err == nil {
+		t.Fatal("expected an error with neither an agent nor an environment")
+	}
+}

--- a/internal/daemon/init_scripts.go
+++ b/internal/daemon/init_scripts.go
@@ -28,8 +28,8 @@ type initScript struct {
 	Description string
 }
 
-func runInitScripts(ctx context.Context, client initScriptsClient, agentID string, workDir string) error {
-	scripts, err := listInitScripts(ctx, client, agentID)
+func runInitScripts(ctx context.Context, client initScriptsClient, agentID string, environmentID string, workDir string) error {
+	scripts, err := listInitScripts(ctx, client, agentID, environmentID)
 	if err != nil {
 		return err
 	}
@@ -41,21 +41,45 @@ func runInitScripts(ctx context.Context, client initScriptsClient, agentID strin
 	return nil
 }
 
-func listInitScripts(ctx context.Context, client initScriptsClient, agentID string) ([]initScript, error) {
+// listInitScripts returns the environment's scripts first, then the agent's,
+// each in creation order. Names do not collide -- every script runs -- so the
+// order is the whole contract.
+func listInitScripts(ctx context.Context, client initScriptsClient, agentID string, environmentID string) ([]initScript, error) {
 	if client == nil {
 		return nil, fmt.Errorf("init scripts client is required")
 	}
 	agentID = strings.TrimSpace(agentID)
-	if agentID == "" {
-		return nil, fmt.Errorf("agent id is required")
+	environmentID = strings.TrimSpace(environmentID)
+	if agentID == "" && environmentID == "" {
+		return nil, fmt.Errorf("agent id or environment id is required")
 	}
+	var ordered []initScript
+	if environmentID != "" {
+		scripts, err := listInitScriptsForTarget(ctx, client, &agentsv1.ListInitScriptsRequest{EnvironmentId: environmentID})
+		if err != nil {
+			return nil, err
+		}
+		ordered = append(ordered, scripts...)
+	}
+	if agentID != "" {
+		scripts, err := listInitScriptsForTarget(ctx, client, &agentsv1.ListInitScriptsRequest{AgentId: agentID})
+		if err != nil {
+			return nil, err
+		}
+		ordered = append(ordered, scripts...)
+	}
+	return ordered, nil
+}
+
+func listInitScriptsForTarget(ctx context.Context, client initScriptsClient, req *agentsv1.ListInitScriptsRequest) ([]initScript, error) {
 	var scripts []initScript
 	pageToken := ""
 	for {
 		resp, err := client.ListInitScripts(ctx, &agentsv1.ListInitScriptsRequest{
-			AgentId:   agentID,
-			PageSize:  initScriptsPageSize,
-			PageToken: pageToken,
+			AgentId:       req.GetAgentId(),
+			EnvironmentId: req.GetEnvironmentId(),
+			PageSize:      initScriptsPageSize,
+			PageToken:     pageToken,
 		})
 		if err != nil {
 			return nil, err

--- a/internal/daemon/init_scripts_test.go
+++ b/internal/daemon/init_scripts_test.go
@@ -114,7 +114,7 @@ func TestListInitScriptsOrdersByCreatedAtThenID(t *testing.T) {
 		},
 	}
 	fake := &fakeInitScriptsClient{responses: []*agentsv1.ListInitScriptsResponse{resp1, resp2}}
-	scripts, err := listInitScripts(context.Background(), fake, "agent-1")
+	scripts, err := listInitScripts(context.Background(), fake, "agent-1", "")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -152,7 +152,7 @@ func TestRunInitScriptsExecutesInOrder(t *testing.T) {
 			},
 		},
 	}}}
-	if err := runInitScripts(context.Background(), fake, "agent-1", workDir); err != nil {
+	if err := runInitScripts(context.Background(), fake, "agent-1", "", workDir); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	data, err := os.ReadFile(outputPath)

--- a/internal/daemon/mcps.go
+++ b/internal/daemon/mcps.go
@@ -24,21 +24,59 @@ type mcpDefinition struct {
 	CreatedAt time.Time
 }
 
-func listMCPs(ctx context.Context, client mcpsClient, agentID string) ([]mcpDefinition, error) {
+// listMCPs merges the environment's servers with the agent's. Both run in an
+// agent workload; a sandbox has no agent and gets the environment's alone. On a
+// name collision the agent-level server wins, the rule ENV follows.
+func listMCPs(ctx context.Context, client mcpsClient, agentID string, environmentID string) ([]mcpDefinition, error) {
 	if client == nil {
 		return nil, fmt.Errorf("mcps client is required")
 	}
 	agentID = strings.TrimSpace(agentID)
-	if agentID == "" {
-		return nil, fmt.Errorf("agent id is required")
+	environmentID = strings.TrimSpace(environmentID)
+	if agentID == "" && environmentID == "" {
+		return nil, fmt.Errorf("agent id or environment id is required")
 	}
+	byName := map[string]mcpDefinition{}
+	if environmentID != "" {
+		environmentMCPs, err := listMCPsForTarget(ctx, client, &agentsv1.ListMcpsRequest{EnvironmentId: environmentID})
+		if err != nil {
+			return nil, err
+		}
+		for _, mcp := range environmentMCPs {
+			byName[mcp.Name] = mcp
+		}
+	}
+	if agentID != "" {
+		agentMCPs, err := listMCPsForTarget(ctx, client, &agentsv1.ListMcpsRequest{AgentId: agentID})
+		if err != nil {
+			return nil, err
+		}
+		for _, mcp := range agentMCPs {
+			byName[mcp.Name] = mcp
+		}
+	}
+	mcps := make([]mcpDefinition, 0, len(byName))
+	for _, mcp := range byName {
+		mcps = append(mcps, mcp)
+	}
+	sort.Slice(mcps, func(i, j int) bool {
+		if mcps[i].CreatedAt.Equal(mcps[j].CreatedAt) {
+			return mcps[i].ID < mcps[j].ID
+		}
+		return mcps[i].CreatedAt.Before(mcps[j].CreatedAt)
+	})
+	return mcps, nil
+}
+
+func listMCPsForTarget(ctx context.Context, client mcpsClient, req *agentsv1.ListMcpsRequest) ([]mcpDefinition, error) {
 	var mcps []mcpDefinition
 	pageToken := ""
 	for {
 		resp, err := client.ListMcps(ctx, &agentsv1.ListMcpsRequest{
-			AgentId:   agentID,
-			PageSize:  mcpsPageSize,
-			PageToken: pageToken,
+			AgentId:       req.GetAgentId(),
+			EnvironmentId: req.GetEnvironmentId(),
+			PageSize:      mcpsPageSize,
+			PageToken:     pageToken,
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
agynd read the agent scope alone, so an environment-level MCP or init script ran
nowhere and a sandbox — which has no agent at all — got neither.

Servers compose as a union keyed by name, the agent's winning a collision, which
is the rule ENV already follows. Init scripts never collide, so order is the
whole contract: the environment's first, then the agent's, each in creation
order.

The environment is read from `ENVIRONMENT_ID` rather than resolved through the
agent, because a sandbox has no agent to resolve it from.

Requires agynio/agents#86 (`ListMcps` accepting an environment) and the
Orchestrator PR (`ENVIRONMENT_ID` injection).