### PR TITLE
Export codex's event stream, not just its traces

### DIFF
--- a/internal/daemon/codexconfig.go
+++ b/internal/daemon/codexconfig.go
@@ -24,8 +24,11 @@ sandbox_mode = "danger-full-access"
 # and codex then exits before answering the initialize handshake. protocol is
 # required and binary is the OTLP default encoding.
 trace_exporter = { otlp-http = { endpoint = %q, protocol = "binary" } }
+# Prompts, tool calls and SSE events ship over logs, not traces; log_user_prompt
+# is the opt-in that stops codex reducing the prompt to prompt_length.
+exporter = { otlp-http = { endpoint = %q, protocol = "binary" } }
+log_user_prompt = true
 metrics_exporter = "none"
-exporter = "none"
 
 [model_providers.platform]
 name = "Agyn LLM"
@@ -96,12 +99,19 @@ func writeCodexConfig(llmBaseURL string, mcpServers []config.MCPServer, otlpEndp
 	return codexHome, nil
 }
 
+// Codex wants a per-signal URL, not a base, so the caller passes the collector
+// root and the signal path is appended here.
+func otlpSignalEndpoint(otlpEndpoint, signal string) string {
+	return strings.TrimSuffix(otlpEndpoint, "/") + "/v1/" + signal
+}
+
 func codexConfig(llmBaseURL string, mcpServers []config.MCPServer, otlpEndpoint string) string {
 	apiKeyEnv := codexAPIKeyEnv
 	if isZitiLLMBaseURL(llmBaseURL) {
 		apiKeyEnv = ""
 	}
-	payload := fmt.Sprintf(codexConfigTemplate, otlpEndpoint, llmBaseURL, apiKeyEnv)
+	payload := fmt.Sprintf(codexConfigTemplate, otlpSignalEndpoint(otlpEndpoint, "traces"),
+		otlpSignalEndpoint(otlpEndpoint, "logs"), llmBaseURL, apiKeyEnv)
 	if len(mcpServers) == 0 {
 		return payload
 	}

--- a/internal/daemon/codexconfig_test.go
+++ b/internal/daemon/codexconfig_test.go
@@ -386,8 +386,11 @@ sandbox_mode = "danger-full-access"
 # and codex then exits before answering the initialize handshake. protocol is
 # required and binary is the OTLP default encoding.
 trace_exporter = { otlp-http = { endpoint = %q, protocol = "binary" } }
+# Prompts, tool calls and SSE events ship over logs, not traces; log_user_prompt
+# is the opt-in that stops codex reducing the prompt to prompt_length.
+exporter = { otlp-http = { endpoint = %q, protocol = "binary" } }
+log_user_prompt = true
 metrics_exporter = "none"
-exporter = "none"
 
 [model_providers.platform]
 name = "Agyn LLM"
@@ -396,5 +399,5 @@ base_url = %q
 request_max_retries = 0
 stream_max_retries = 0
 supports_websockets = false
-`, otlpEndpoint, baseURL, apiKeyEnv)
+`, otlpEndpoint+"/v1/traces", otlpEndpoint+"/v1/logs", baseURL, apiKeyEnv)
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -313,7 +313,7 @@ func newCodexDaemon(ctx context.Context, cfg config.Config, version string) (*Da
 	otlpEndpoint := "http://" + tracingProxy.Address()
 	// Codex exports over OTLP/HTTP and everything else over gRPC; see the otel
 	// block in the codex config for why.
-	codexOTLPEndpoint := "http://" + tracingProxy.HTTPAddress() + "/v1/traces"
+	codexOTLPEndpoint := "http://" + tracingProxy.HTTPAddress()
 	codexHome, err := writeCodexConfig(cfg.LLMBaseURL, cfg.MCPServers, codexOTLPEndpoint)
 	if err != nil {
 		tracingProxy.Close()

--- a/internal/tracingproxy/proxy.go
+++ b/internal/tracingproxy/proxy.go
@@ -8,9 +8,11 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
+	collectorlogsv1 "go.opentelemetry.io/proto/otlp/collector/logs/v1"
 	collectortracev1 "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
 	resourcev1 "go.opentelemetry.io/proto/otlp/resource/v1"
@@ -29,6 +31,7 @@ const (
 	messageIDAttributeKey  = "agyn.thread.message.id"
 	workloadIDAttributeKey = "agyn.workload.id"
 	maxHTTPExportBytes     = 32 << 20
+	maxLoggedValueBytes    = 400
 )
 
 type Config struct {
@@ -104,6 +107,7 @@ func Start(ctx context.Context, cfg Config) (*Proxy, error) {
 	proxy.httpAddress = httpListener.Addr().String()
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /v1/traces", proxy.serveHTTPTraces)
+	mux.HandleFunc("POST /v1/logs", proxy.serveHTTPLogs)
 	proxy.httpServer = &http.Server{Handler: mux, ReadHeaderTimeout: 10 * time.Second}
 	go func() {
 		if err := proxy.httpServer.Serve(httpListener); err != nil && !errors.Is(err, http.ErrServerClosed) {
@@ -151,11 +155,65 @@ func (p *Proxy) serveHTTPTraces(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write(encoded)
 }
 
+// serveHTTPLogs records what codex ships over the log signal -- prompts, tool
+// calls and SSE events -- which has no ingest path yet, so it is logged and
+// acknowledged rather than forwarded.
+func (p *Proxy) serveHTTPLogs(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxHTTPExportBytes))
+	if err != nil {
+		http.Error(w, "read body", http.StatusBadRequest)
+		return
+	}
+	request := &collectorlogsv1.ExportLogsServiceRequest{}
+	if err := proto.Unmarshal(body, request); err != nil {
+		http.Error(w, "decode OTLP request", http.StatusBadRequest)
+		return
+	}
+	logExportedRecords(request)
+	encoded, err := proto.Marshal(&collectorlogsv1.ExportLogsServiceResponse{})
+	if err != nil {
+		http.Error(w, "encode OTLP response", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/x-protobuf")
+	_, _ = w.Write(encoded)
+}
+
+func logExportedRecords(request *collectorlogsv1.ExportLogsServiceRequest) {
+	for _, resourceLogs := range request.ResourceLogs {
+		for _, scopeLogs := range resourceLogs.ScopeLogs {
+			scope := ""
+			if scopeLogs.Scope != nil {
+				scope = scopeLogs.Scope.Name
+			}
+			for _, record := range scopeLogs.LogRecords {
+				attrs := make([]string, 0, len(record.Attributes))
+				for _, attr := range record.Attributes {
+					attrs = append(attrs, attr.Key+"="+truncateValue(attr.Value))
+				}
+				log.Printf("otlp log: scope=%s severity=%s body=%s attrs={%s}",
+					scope, record.SeverityText, truncateValue(record.Body), strings.Join(attrs, " "))
+			}
+		}
+	}
+}
+
+func truncateValue(value *commonv1.AnyValue) string {
+	if value == nil {
+		return ""
+	}
+	rendered := strings.ReplaceAll(value.String(), "\n", "\\n")
+	if len(rendered) > maxLoggedValueBytes {
+		return rendered[:maxLoggedValueBytes] + "..."
+	}
+	return rendered
+}
+
 func (p *Proxy) Address() string {
 	return p.address
 }
 
-// HTTPAddress is the OTLP/HTTP endpoint; append /v1/traces for the exporter.
+// HTTPAddress is the OTLP/HTTP collector root; callers append the signal path.
 func (p *Proxy) HTTPAddress() string {
 	return p.httpAddress
 }


### PR DESCRIPTION
Enables codex's OTLP log signal, which is where prompts, tool calls and SSE events ship. `exporter` was `"none"`, so we collected only the Rust `tracing` spans (`busy_ns`, `code.*`) and prompts arrived as `prompt_length`.

- `exporter` now points at the tracing proxy, and `log_user_prompt = true` stops codex reducing the prompt to its length.
- Codex wants a per-signal URL, so the signal path moves into `codexconfig`. The daemon was appending `/v1/traces` itself while the tests passed a bare base, so neither agreed with the other.
- `tracingproxy` gains `POST /v1/logs`. The log signal has no ingest path yet, so it records what arrives and acknowledges it rather than forwarding.

Previously released as v0.14.38 from `native-mode`; that branch was superseded by #165/#166, so this re-applies it on top of main.