### PR TITLE
Translate codex's events into the spans the run view reads

### DIFF
--- a/internal/tracingproxy/proxy.go
+++ b/internal/tracingproxy/proxy.go
@@ -15,6 +15,7 @@ import (
 	collectorlogsv1 "go.opentelemetry.io/proto/otlp/collector/logs/v1"
 	collectortracev1 "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
+	logsv1 "go.opentelemetry.io/proto/otlp/logs/v1"
 	resourcev1 "go.opentelemetry.io/proto/otlp/resource/v1"
 	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
 	"google.golang.org/grpc"
@@ -57,6 +58,10 @@ type Proxy struct {
 	threadID  string
 	messageMu sync.RWMutex
 	messageID string
+	// Usage counts arrive on a later event than the call they belong to, so the
+	// call is held until they do and re-emitted with them.
+	llmCallMu sync.Mutex
+	llmCalls  map[string]*pendingLLMCall
 }
 
 func Start(ctx context.Context, cfg Config) (*Proxy, error) {
@@ -155,9 +160,9 @@ func (p *Proxy) serveHTTPTraces(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write(encoded)
 }
 
-// serveHTTPLogs records what codex ships over the log signal -- prompts, tool
-// calls and SSE events -- which has no ingest path yet, so it is logged and
-// acknowledged rather than forwarded.
+// serveHTTPLogs takes the signal codex ships its structured events on -- the
+// prompt, the model call, the usage counts -- and translates them into spans,
+// because the tracing service stores traces and nothing else.
 func (p *Proxy) serveHTTPLogs(w http.ResponseWriter, r *http.Request) {
 	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxHTTPExportBytes))
 	if err != nil {
@@ -169,7 +174,22 @@ func (p *Proxy) serveHTTPLogs(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "decode OTLP request", http.StatusBadRequest)
 		return
 	}
-	logExportedRecords(request)
+	if spans := p.semanticSpans(request); len(spans) > 0 {
+		export := &collectortracev1.ExportTraceServiceRequest{
+			ResourceSpans: []*tracev1.ResourceSpans{{
+				ScopeSpans: []*tracev1.ScopeSpans{{
+					Scope: &commonv1.InstrumentationScope{Name: semanticScopeName},
+					Spans: spans,
+				}},
+			}},
+		}
+		// Export, not the upstream directly: the thread, message and workload
+		// this run belongs to are injected there, and without them a span is
+		// unreachable from the run view.
+		if _, err := p.Export(r.Context(), export); err != nil {
+			log.Printf("tracing proxy: export translated log spans: %v", err)
+		}
+	}
 	encoded, err := proto.Marshal(&collectorlogsv1.ExportLogsServiceResponse{})
 	if err != nil {
 		http.Error(w, "encode OTLP response", http.StatusInternalServerError)
@@ -179,23 +199,16 @@ func (p *Proxy) serveHTTPLogs(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write(encoded)
 }
 
-func logExportedRecords(request *collectorlogsv1.ExportLogsServiceRequest) {
-	for _, resourceLogs := range request.ResourceLogs {
-		for _, scopeLogs := range resourceLogs.ScopeLogs {
-			scope := ""
-			if scopeLogs.Scope != nil {
-				scope = scopeLogs.Scope.Name
-			}
-			for _, record := range scopeLogs.LogRecords {
-				attrs := make([]string, 0, len(record.Attributes))
-				for _, attr := range record.Attributes {
-					attrs = append(attrs, attr.Key+"="+truncateValue(attr.Value))
-				}
-				log.Printf("otlp log: scope=%s severity=%s body=%s attrs={%s}",
-					scope, record.SeverityText, truncateValue(record.Body), strings.Join(attrs, " "))
-			}
-		}
+// logUntranslatedRecord reports an event no span was built from, so a codex
+// release that adds one -- tool calls above all -- surfaces here rather than
+// being dropped in silence. The SSE deltas are the one deliberate omission:
+// they fire per chunk and carry nothing but a duration.
+func logUntranslatedRecord(record *logsv1.LogRecord, name string) {
+	attrs := make([]string, 0, len(record.Attributes))
+	for _, attr := range record.Attributes {
+		attrs = append(attrs, attr.Key+"="+truncateValue(attr.Value))
 	}
+	log.Printf("otlp log: untranslated event=%s attrs={%s}", name, strings.Join(attrs, " "))
 }
 
 func truncateValue(value *commonv1.AnyValue) string {

--- a/internal/tracingproxy/semantic.go
+++ b/internal/tracingproxy/semantic.go
@@ -1,0 +1,291 @@
+package tracingproxy
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"strconv"
+	"strings"
+	"time"
+
+	collectorlogsv1 "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
+	logsv1 "go.opentelemetry.io/proto/otlp/logs/v1"
+	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
+)
+
+// Codex ships its structured events on the OTLP log signal, which nothing here
+// stores: the tracing service speaks traces alone. These are the events worth
+// keeping, translated into the span vocabulary the run view already renders.
+const (
+	eventUserPrompt = "codex.user_prompt"
+	eventAPIRequest = "codex.api_request"
+	eventSSE        = "codex.sse_event"
+
+	spanInvocationMessage = "invocation.message"
+	spanLLMCall           = "llm.call"
+
+	// Names the spans this proxy synthesised, as distinct from the ones codex
+	// exported itself.
+	semanticScopeName = "agynd.codex.semantic"
+
+	sseResponseCompleted = "response.completed"
+)
+
+type logAttrs map[string]*commonv1.AnyValue
+
+func attrsOf(record *logsv1.LogRecord) logAttrs {
+	attrs := make(logAttrs, len(record.Attributes))
+	for _, attr := range record.Attributes {
+		attrs[attr.Key] = attr.Value
+	}
+	return attrs
+}
+
+func (a logAttrs) str(key string) string {
+	value, ok := a[key]
+	if !ok || value == nil {
+		return ""
+	}
+	switch v := value.Value.(type) {
+	case *commonv1.AnyValue_StringValue:
+		return v.StringValue
+	case *commonv1.AnyValue_IntValue:
+		return strconv.FormatInt(v.IntValue, 10)
+	case *commonv1.AnyValue_BoolValue:
+		return strconv.FormatBool(v.BoolValue)
+	}
+	return ""
+}
+
+// Codex is inconsistent about whether a count is an int or a decimal string --
+// input_token_count arrives as a string while cached_token_count is an int --
+// so both spellings are read.
+func (a logAttrs) int(key string) (int64, bool) {
+	value, ok := a[key]
+	if !ok || value == nil {
+		return 0, false
+	}
+	switch v := value.Value.(type) {
+	case *commonv1.AnyValue_IntValue:
+		return v.IntValue, true
+	case *commonv1.AnyValue_StringValue:
+		parsed, err := strconv.ParseInt(strings.TrimSpace(v.StringValue), 10, 64)
+		if err != nil {
+			return 0, false
+		}
+		return parsed, true
+	}
+	return 0, false
+}
+
+func (a logAttrs) eventTime(fallback uint64) uint64 {
+	raw := a.str("event.timestamp")
+	if raw == "" {
+		return fallback
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		return fallback
+	}
+	return uint64(parsed.UnixNano())
+}
+
+func stringAttr(key, value string) *commonv1.KeyValue {
+	return &commonv1.KeyValue{
+		Key:   key,
+		Value: &commonv1.AnyValue{Value: &commonv1.AnyValue_StringValue{StringValue: value}},
+	}
+}
+
+func intAttr(key string, value int64) *commonv1.KeyValue {
+	return &commonv1.KeyValue{
+		Key:   key,
+		Value: &commonv1.AnyValue{Value: &commonv1.AnyValue_IntValue{IntValue: value}},
+	}
+}
+
+// traceIDForMessage keeps every span of one message in one trace. Codex opens a
+// fresh trace per JSON-RPC call, so its own ids scatter a single turn across
+// dozens; the message is the unit the run view shows.
+func traceIDForMessage(seed string) []byte {
+	sum := sha256.Sum256([]byte("agyn.trace." + seed))
+	return sum[:16]
+}
+
+func newSpanID() []byte {
+	id := make([]byte, 8)
+	if _, err := rand.Read(id); err != nil {
+		// A collision only merges two spans in the upsert; refusing to emit
+		// loses the event outright, so a time-derived id is the better failure.
+		now := uint64(time.Now().UnixNano())
+		for i := range id {
+			id[i] = byte(now >> (8 * i))
+		}
+	}
+	return id
+}
+
+// pendingLLMCall is held so the usage counts, which arrive on a later event than
+// the request itself, can be written onto the same span. Ingest upserts on
+// (trace_id, span_id) and replaces the attributes wholesale, so the span is
+// re-emitted complete rather than patched.
+type pendingLLMCall struct {
+	span *tracev1.Span
+}
+
+// semanticSpans translates one OTLP log export into the spans the run view
+// renders. Records it has no mapping for are dropped rather than passed
+// through: the raw event is already in the container log, and a span per SSE
+// delta is the noise this is meant to remove.
+func (p *Proxy) semanticSpans(request *collectorlogsv1.ExportLogsServiceRequest) []*tracev1.Span {
+	var spans []*tracev1.Span
+	for _, resourceLogs := range request.GetResourceLogs() {
+		for _, scopeLogs := range resourceLogs.GetScopeLogs() {
+			for _, record := range scopeLogs.GetLogRecords() {
+				attrs := attrsOf(record)
+				span := p.spanForRecord(record, attrs)
+				if span != nil {
+					spans = append(spans, span)
+					continue
+				}
+				if name := attrs.str("event.name"); name != "" && name != eventSSE {
+					logUntranslatedRecord(record, name)
+				}
+			}
+		}
+	}
+	return spans
+}
+
+func (p *Proxy) spanForRecord(record *logsv1.LogRecord, attrs logAttrs) *tracev1.Span {
+	switch attrs.str("event.name") {
+	case eventUserPrompt:
+		return p.messageSpan(record, attrs)
+	case eventAPIRequest:
+		return p.llmCallSpan(record, attrs)
+	case eventSSE:
+		if attrs.str("event.kind") != sseResponseCompleted {
+			return nil
+		}
+		return p.llmCallUsageSpan(attrs)
+	}
+	return nil
+}
+
+// traceSeed prefers the message the daemon is processing, so a turn's spans
+// group the way the run view reads them, and falls back to codex's own
+// conversation when no message is set -- a sandbox has no message at all.
+func (p *Proxy) traceSeed(attrs logAttrs) string {
+	if messageID := p.messageIDValue(); messageID != "" {
+		return messageID
+	}
+	return attrs.str("conversation.id")
+}
+
+func (p *Proxy) messageSpan(record *logsv1.LogRecord, attrs logAttrs) *tracev1.Span {
+	at := attrs.eventTime(record.GetTimeUnixNano())
+	span := &tracev1.Span{
+		TraceId:           traceIDForMessage(p.traceSeed(attrs)),
+		SpanId:            newSpanID(),
+		Name:              spanInvocationMessage,
+		Kind:              tracev1.Span_SPAN_KIND_INTERNAL,
+		StartTimeUnixNano: at,
+		EndTimeUnixNano:   at,
+		Attributes: []*commonv1.KeyValue{
+			stringAttr("agyn.message.role", "user"),
+			stringAttr("agyn.message.text", attrs.str("prompt")),
+		},
+		Status: &tracev1.Status{Code: tracev1.Status_STATUS_CODE_OK},
+	}
+	if length, ok := attrs.int("prompt_length"); ok {
+		span.Attributes = append(span.Attributes, intAttr("agyn.message.length", length))
+	}
+	return span
+}
+
+func (p *Proxy) llmCallSpan(record *logsv1.LogRecord, attrs logAttrs) *tracev1.Span {
+	end := attrs.eventTime(record.GetTimeUnixNano())
+	start := end
+	if duration, ok := attrs.int("duration_ms"); ok && duration > 0 {
+		start = end - uint64(duration)*uint64(time.Millisecond)
+	}
+	span := &tracev1.Span{
+		TraceId:           traceIDForMessage(p.traceSeed(attrs)),
+		SpanId:            newSpanID(),
+		Name:              spanLLMCall,
+		Kind:              tracev1.Span_SPAN_KIND_CLIENT,
+		StartTimeUnixNano: start,
+		EndTimeUnixNano:   end,
+		Attributes: []*commonv1.KeyValue{
+			stringAttr("gen_ai.system", attrs.str("provider_name")),
+			stringAttr("gen_ai.request.model", attrs.str("model")),
+			stringAttr("agyn.llm.endpoint", attrs.str("endpoint")),
+		},
+		Status: &tracev1.Status{Code: tracev1.Status_STATUS_CODE_OK},
+	}
+	if status, ok := attrs.int("http.response.status_code"); ok {
+		span.Attributes = append(span.Attributes, intAttr("http.response.status_code", status))
+		if status >= 400 {
+			span.Status = &tracev1.Status{Code: tracev1.Status_STATUS_CODE_ERROR}
+		}
+	}
+	if attempt, ok := attrs.int("attempt"); ok {
+		span.Attributes = append(span.Attributes, intAttr("agyn.llm.attempt", attempt))
+	}
+	if message := attrs.str("error.message"); message != "" {
+		span.Status = &tracev1.Status{Code: tracev1.Status_STATUS_CODE_ERROR, Message: message}
+	}
+	p.rememberLLMCall(attrs.str("conversation.id"), span)
+	return span
+}
+
+// llmCallUsageSpan re-emits the call this usage belongs to. Without the
+// remembered span there is nothing to attach to -- usage alone is not a call --
+// so the record is dropped.
+func (p *Proxy) llmCallUsageSpan(attrs logAttrs) *tracev1.Span {
+	pending := p.takeLLMCall(attrs.str("conversation.id"))
+	if pending == nil {
+		return nil
+	}
+	usage := []struct {
+		source string
+		key    string
+	}{
+		{"input_token_count", "gen_ai.usage.input_tokens"},
+		{"output_token_count", "gen_ai.usage.output_tokens"},
+		{"cached_token_count", "gen_ai.usage.cache_read.input_tokens"},
+		{"reasoning_token_count", "agyn.usage.reasoning_tokens"},
+	}
+	for _, entry := range usage {
+		if value, ok := attrs.int(entry.source); ok {
+			pending.span.Attributes = append(pending.span.Attributes, intAttr(entry.key, value))
+		}
+	}
+	return pending.span
+}
+
+func (p *Proxy) rememberLLMCall(conversationID string, span *tracev1.Span) {
+	if conversationID == "" {
+		return
+	}
+	p.llmCallMu.Lock()
+	defer p.llmCallMu.Unlock()
+	if p.llmCalls == nil {
+		p.llmCalls = make(map[string]*pendingLLMCall, 1)
+	}
+	p.llmCalls[conversationID] = &pendingLLMCall{span: span}
+}
+
+func (p *Proxy) takeLLMCall(conversationID string) *pendingLLMCall {
+	if conversationID == "" {
+		return nil
+	}
+	p.llmCallMu.Lock()
+	defer p.llmCallMu.Unlock()
+	pending, ok := p.llmCalls[conversationID]
+	if !ok {
+		return nil
+	}
+	delete(p.llmCalls, conversationID)
+	return pending
+}

--- a/internal/tracingproxy/semantic_test.go
+++ b/internal/tracingproxy/semantic_test.go
@@ -1,0 +1,190 @@
+package tracingproxy
+
+import (
+	"testing"
+
+	collectorlogsv1 "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
+	logsv1 "go.opentelemetry.io/proto/otlp/logs/v1"
+	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
+)
+
+func logRecord(attrs ...*commonv1.KeyValue) *logsv1.LogRecord {
+	return &logsv1.LogRecord{Attributes: attrs}
+}
+
+func logExport(records ...*logsv1.LogRecord) *collectorlogsv1.ExportLogsServiceRequest {
+	return &collectorlogsv1.ExportLogsServiceRequest{
+		ResourceLogs: []*logsv1.ResourceLogs{{
+			ScopeLogs: []*logsv1.ScopeLogs{{LogRecords: records}},
+		}},
+	}
+}
+
+func spanAttr(t *testing.T, span *tracev1.Span, key string) *commonv1.AnyValue {
+	t.Helper()
+	for _, attr := range span.Attributes {
+		if attr.Key == key {
+			return attr.Value
+		}
+	}
+	return nil
+}
+
+func requireStringAttr(t *testing.T, span *tracev1.Span, key, want string) {
+	t.Helper()
+	value := spanAttr(t, span, key)
+	if value == nil {
+		t.Fatalf("expected attribute %q on %s", key, span.Name)
+	}
+	if got := value.GetStringValue(); got != want {
+		t.Fatalf("expected %s=%q, got %q", key, want, got)
+	}
+}
+
+func requireIntAttr(t *testing.T, span *tracev1.Span, key string, want int64) {
+	t.Helper()
+	value := spanAttr(t, span, key)
+	if value == nil {
+		t.Fatalf("expected attribute %q on %s", key, span.Name)
+	}
+	if got := value.GetIntValue(); got != want {
+		t.Fatalf("expected %s=%d, got %d", key, want, got)
+	}
+}
+
+func TestSemanticSpansTranslatesUserPrompt(t *testing.T) {
+	proxy := &Proxy{}
+	spans := proxy.semanticSpans(logExport(logRecord(
+		stringAttr("event.name", eventUserPrompt),
+		stringAttr("prompt", "hello"),
+		stringAttr("prompt_length", "67"),
+		stringAttr("conversation.id", "conv-1"),
+		stringAttr("event.timestamp", "2026-08-09T00:48:22.310Z"),
+	)))
+
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	if spans[0].Name != spanInvocationMessage {
+		t.Fatalf("expected %s, got %s", spanInvocationMessage, spans[0].Name)
+	}
+	requireStringAttr(t, spans[0], "agyn.message.text", "hello")
+	requireStringAttr(t, spans[0], "agyn.message.role", "user")
+	// prompt_length arrives as a decimal string, not an int.
+	requireIntAttr(t, spans[0], "agyn.message.length", 67)
+	if spans[0].StartTimeUnixNano == 0 {
+		t.Fatal("expected the event timestamp to be parsed")
+	}
+}
+
+func TestSemanticSpansTranslatesAPIRequest(t *testing.T) {
+	proxy := &Proxy{}
+	spans := proxy.semanticSpans(logExport(logRecord(
+		stringAttr("event.name", eventAPIRequest),
+		stringAttr("provider_name", "Agyn LLM"),
+		stringAttr("model", "gpt-5.5"),
+		stringAttr("endpoint", "/responses"),
+		intAttr("http.response.status_code", 200),
+		stringAttr("duration_ms", "1551"),
+		intAttr("attempt", 0),
+		stringAttr("conversation.id", "conv-1"),
+		stringAttr("event.timestamp", "2026-08-09T00:48:23.889Z"),
+	)))
+
+	if len(spans) != 1 || spans[0].Name != spanLLMCall {
+		t.Fatalf("expected one %s span, got %#v", spanLLMCall, spans)
+	}
+	requireStringAttr(t, spans[0], "gen_ai.request.model", "gpt-5.5")
+	requireStringAttr(t, spans[0], "gen_ai.system", "Agyn LLM")
+	requireIntAttr(t, spans[0], "http.response.status_code", 200)
+	// duration_ms is a string; the span still has to span the call.
+	if spans[0].EndTimeUnixNano-spans[0].StartTimeUnixNano != 1551*1_000_000 {
+		t.Fatalf("expected a 1551ms span, got %d ns", spans[0].EndTimeUnixNano-spans[0].StartTimeUnixNano)
+	}
+	if spans[0].Status.GetCode() != tracev1.Status_STATUS_CODE_OK {
+		t.Fatalf("expected a 200 to be OK, got %v", spans[0].Status.GetCode())
+	}
+}
+
+// The counts arrive on a later event than the call, so the call is re-emitted
+// with the same ids and ingest upserts it.
+func TestSemanticSpansAttachesUsageToTheCall(t *testing.T) {
+	proxy := &Proxy{}
+	call := proxy.semanticSpans(logExport(logRecord(
+		stringAttr("event.name", eventAPIRequest),
+		stringAttr("model", "gpt-5.5"),
+		stringAttr("conversation.id", "conv-1"),
+		stringAttr("event.timestamp", "2026-08-09T00:48:23.889Z"),
+	)))
+	if len(call) != 1 {
+		t.Fatalf("expected the call span, got %d", len(call))
+	}
+
+	usage := proxy.semanticSpans(logExport(logRecord(
+		stringAttr("event.name", eventSSE),
+		stringAttr("event.kind", sseResponseCompleted),
+		stringAttr("input_token_count", "8607"),
+		stringAttr("output_token_count", "11"),
+		intAttr("cached_token_count", 0),
+		intAttr("reasoning_token_count", 0),
+		stringAttr("conversation.id", "conv-1"),
+	)))
+	if len(usage) != 1 {
+		t.Fatalf("expected the call re-emitted with usage, got %d", len(usage))
+	}
+	if string(usage[0].SpanId) != string(call[0].SpanId) {
+		t.Fatal("expected usage to land on the same span the call was emitted as")
+	}
+	requireIntAttr(t, usage[0], "gen_ai.usage.input_tokens", 8607)
+	requireIntAttr(t, usage[0], "gen_ai.usage.output_tokens", 11)
+	requireIntAttr(t, usage[0], "gen_ai.usage.cache_read.input_tokens", 0)
+}
+
+func TestSemanticSpansDropsSSEDeltasAndUnpairedUsage(t *testing.T) {
+	proxy := &Proxy{}
+	spans := proxy.semanticSpans(logExport(
+		logRecord(
+			stringAttr("event.name", eventSSE),
+			stringAttr("event.kind", "response.output_text.delta"),
+			stringAttr("conversation.id", "conv-1"),
+		),
+		// Usage with no call before it describes nothing on its own.
+		logRecord(
+			stringAttr("event.name", eventSSE),
+			stringAttr("event.kind", sseResponseCompleted),
+			stringAttr("input_token_count", "10"),
+			stringAttr("conversation.id", "conv-unknown"),
+		),
+	))
+	if len(spans) != 0 {
+		t.Fatalf("expected no spans, got %#v", spans)
+	}
+}
+
+// A turn is one trace, whatever codex does with its own trace ids.
+func TestSemanticSpansGroupSpansByMessage(t *testing.T) {
+	proxy := &Proxy{}
+	proxy.SetMessageID("message-1")
+	spans := proxy.semanticSpans(logExport(
+		logRecord(
+			stringAttr("event.name", eventUserPrompt),
+			stringAttr("prompt", "hello"),
+			stringAttr("conversation.id", "conv-1"),
+		),
+		logRecord(
+			stringAttr("event.name", eventAPIRequest),
+			stringAttr("model", "gpt-5.5"),
+			stringAttr("conversation.id", "conv-2"),
+		),
+	))
+	if len(spans) != 2 {
+		t.Fatalf("expected 2 spans, got %d", len(spans))
+	}
+	if string(spans[0].TraceId) != string(spans[1].TraceId) {
+		t.Fatal("expected both spans in the message's trace, despite different conversations")
+	}
+	if len(spans[0].TraceId) != 16 || len(spans[0].SpanId) != 8 {
+		t.Fatalf("expected OTLP id widths, got trace=%d span=%d", len(spans[0].TraceId), len(spans[0].SpanId))
+	}
+}


### PR DESCRIPTION
Codex ships the prompt, the model call and the usage counts on the OTLP **log** signal, which the tracing service does not store — it speaks traces alone. So all of it was decoded, printed and dropped, while the trace signal it does store carries the tokio instrumentation: 40 spans of `busy_ns` and `code.file.path` for a turn whose content is three events.

The log events already carry what the run view wants, so they are translated rather than ingested as a new signal:

| codex event | span | attributes |
|---|---|---|
| `codex.user_prompt` | `invocation.message` | `agyn.message.text`, role |
| `codex.api_request` | `llm.call` | `gen_ai.request.model`, endpoint, status, attempt |
| `response.completed` | merged onto that call | `gen_ai.usage.*` |

Nothing in tracing-app changes — it has always mapped these names, it just never had a producer.

Notes:
- The counts arrive on a later event than the call, so the call is held and re-emitted with them. Ingest upserts on `(trace_id, span_id)` and replaces attributes wholesale, hence re-sending complete rather than patching.
- A turn is one trace, seeded from the message id; codex opens a trace per JSON-RPC call, which scatters one turn across dozens.
- SSE deltas are dropped (one per chunk, a duration and nothing else). Every other unmapped event is logged so tool calls surface rather than vanishing.