### PR TITLE
Write less in native mode, and the file placeholder

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,8 +37,12 @@ type MCPServer struct {
 }
 
 type Config struct {
-	Mode            string
-	AgentID         uuid.UUID
+	Mode    string
+	AgentID uuid.UUID
+	// EnvironmentID names the environment this workload runs, whose MCPs and
+	// init scripts apply alongside the agent's. Empty for an agent that names no
+	// environment.
+	EnvironmentID   string
 	AgentInstanceID uuid.UUID
 	GatewayAddress  string
 	TracingAddress  string
@@ -73,6 +77,7 @@ func fromEnv(configPath string) (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	environmentID := strings.TrimSpace(os.Getenv("ENVIRONMENT_ID"))
 	gatewayAddress := strings.TrimSpace(os.Getenv("GATEWAY_ADDRESS"))
 	if gatewayAddress == "" {
 		gatewayAddress = "gateway.ziti:443"
@@ -145,6 +150,7 @@ func fromEnv(configPath string) (Config, error) {
 	return Config{
 		Mode:            mode,
 		AgentID:         agentID,
+		EnvironmentID:   environmentID,
 		AgentInstanceID: agentInstanceID,
 		GatewayAddress:  gatewayAddress,
 		TracingAddress:  tracingAddress,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,11 +53,21 @@ type Config struct {
 	WorkloadID  string
 	LLMBaseURL  string
 	LLMAPIToken string
-	SDK         string
-	AgentBinary string
-	WorkDir     string
-	MCPServers  []MCPServer
-	MCPPort     *int
+	// LLMNative leaves the agent CLI in its stock configuration: it addresses
+	// its vendor directly and interception happens at the network layer, so the
+	// container is never told the proxy exists. Delivered as an environment
+	// variable rather than fetched, so it is knowable in holder mode where
+	// nothing is being prepared.
+	LLMNative bool
+	// LLMModelName pins a model through the CLI's own model setting. Unset --
+	// the common case, and always the case for a sandbox -- leaves the CLI on
+	// its own default and its own picker.
+	LLMModelName string
+	SDK          string
+	AgentBinary  string
+	WorkDir      string
+	MCPServers   []MCPServer
+	MCPPort      *int
 }
 
 func FromEnv() (Config, error) {
@@ -110,6 +120,8 @@ func fromEnv(configPath string) (Config, error) {
 	if llmBaseURL == "" {
 		llmBaseURL = "http://llm-proxy.ziti:443/v1"
 	}
+	llmNative := strings.EqualFold(strings.TrimSpace(os.Getenv("LLM_MODE")), "native")
+	llmModelName := strings.TrimSpace(os.Getenv("LLM_MODEL_NAME"))
 	llmAPIToken := strings.TrimSpace(os.Getenv("LLM_API_TOKEN"))
 	if llmAPIToken == "" {
 		llmAPIToken = "platform"
@@ -158,6 +170,8 @@ func fromEnv(configPath string) (Config, error) {
 		WorkloadID:      workloadID,
 		LLMBaseURL:      llmBaseURL,
 		LLMAPIToken:     llmAPIToken,
+		LLMNative:       llmNative,
+		LLMModelName:    llmModelName,
 		SDK:             sdk,
 		AgentBinary:     agentBinary,
 		WorkDir:         workDir,

--- a/internal/daemon/agn.go
+++ b/internal/daemon/agn.go
@@ -47,7 +47,7 @@ func newAgnDaemon(ctx context.Context, cfg config.Config, version string) (*Daem
 		return nil, err
 	}
 
-	if err := runInitScripts(ctx, setup.agents, cfg.AgentID.String(), cfg.WorkDir); err != nil {
+	if err := runInitScripts(ctx, setup.agents, cfg.AgentID.String(), cfg.EnvironmentID, cfg.WorkDir); err != nil {
 		_ = setup.gatewayConn.Close()
 		return nil, err
 	}

--- a/internal/daemon/claude.go
+++ b/internal/daemon/claude.go
@@ -32,7 +32,7 @@ func newClaudeDaemon(ctx context.Context, cfg config.Config, version string) (*D
 		return nil, err
 	}
 
-	if err := runInitScripts(ctx, setup.agents, cfg.AgentID.String(), cfg.WorkDir); err != nil {
+	if err := runInitScripts(ctx, setup.agents, cfg.AgentID.String(), cfg.EnvironmentID, cfg.WorkDir); err != nil {
 		_ = setup.gatewayConn.Close()
 		return nil, err
 	}

--- a/internal/daemon/claude.go
+++ b/internal/daemon/claude.go
@@ -27,7 +27,7 @@ func newClaudeDaemon(ctx context.Context, cfg config.Config, version string) (*D
 		return nil, err
 	}
 
-	if err := writeClaudeSettings(claudeBaseURL(cfg.LLMBaseURL), cfg.LLMAPIToken, cfg.MCPServers); err != nil {
+	if err := writeClaudeSettings(claudeBaseURL(cfg.LLMBaseURL), cfg.LLMAPIToken, cfg.MCPServers, cfg.LLMNative); err != nil {
 		_ = setup.gatewayConn.Close()
 		return nil, err
 	}
@@ -65,12 +65,17 @@ func newClaudeDaemon(ctx context.Context, cfg config.Config, version string) (*D
 			"IS_SANDBOX=1",
 		},
 	}
-	if model := strings.TrimSpace(setup.agent.GetModel()); model != "" {
+	if model := claudeModel(cfg, setup.agent.GetModel()); model != "" {
 		options.Model = model
-		options.Env = append(options.Env,
-			"ANTHROPIC_MODEL="+model,
-			"ANTHROPIC_CUSTOM_MODEL_OPTION="+model,
-		)
+		if !cfg.LLMNative {
+			// A platform model is a UUID the vendor has never heard of, so the
+			// CLI has to be told it is a model at all. A native model name is
+			// the vendor's own and needs no such help.
+			options.Env = append(options.Env,
+				"ANTHROPIC_MODEL="+model,
+				"ANTHROPIC_CUSTOM_MODEL_OPTION="+model,
+			)
+		}
 	}
 	if role := strings.TrimSpace(setup.agent.GetRole()); role != "" {
 		options.SystemPrompt = role
@@ -139,4 +144,14 @@ func (d *Daemon) handleClaudeMessage(ctx context.Context, message platform.Messa
 		return err
 	}
 	return nil
+}
+
+// claudeModel picks what to pin the CLI to: the platform Model UUID the proxy
+// resolves, or the vendor's own model name. Unset in native mode -- the common
+// case -- leaves the CLI on its own default and its own picker.
+func claudeModel(cfg config.Config, platformModel string) string {
+	if cfg.LLMNative {
+		return strings.TrimSpace(cfg.LLMModelName)
+	}
+	return strings.TrimSpace(platformModel)
 }

--- a/internal/daemon/claudeconfig.go
+++ b/internal/daemon/claudeconfig.go
@@ -27,7 +27,13 @@ type claudeMCPServer struct {
 	URL  string `json:"url"`
 }
 
-func writeClaudeSettings(llmBaseURL, apiKey string, mcpServers []config.MCPServer) error {
+// writeClaudeSettings writes ~/.claude/settings.json. In native mode the
+// endpoint and credential keys are omitted -- the CLI addresses its vendor
+// directly and the placeholder credential comes from the container spec -- but
+// the file is still written, because permissions and mcpServers live in the
+// same document and dropping them would restore interactive tool approval and
+// take the environment's MCP wiring with it.
+func writeClaudeSettings(llmBaseURL, apiKey string, mcpServers []config.MCPServer, native bool) error {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return fmt.Errorf("resolve home directory: %w", err)
@@ -56,12 +62,18 @@ func writeClaudeSettings(llmBaseURL, apiKey string, mcpServers []config.MCPServe
 			},
 			Deny: []string{},
 		},
+		// Neither of these is endpoint or credential configuration, and both
+		// matter more in native mode than in platform mode: only the vendor's
+		// API host is intercepted, so any other call the CLI makes on its own
+		// reaches nothing and waits for a timeout.
 		Env: map[string]string{
-			"ANTHROPIC_BASE_URL":                       llmBaseURL,
-			"ANTHROPIC_API_KEY":                        apiKey,
 			"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
 			"DISABLE_AUTOUPDATER":                      "1",
 		},
+	}
+	if !native {
+		settings.Env["ANTHROPIC_BASE_URL"] = llmBaseURL
+		settings.Env["ANTHROPIC_API_KEY"] = apiKey
 	}
 	if len(mcpServers) > 0 {
 		settings.MCPServers = make(map[string]claudeMCPServer, len(mcpServers))

--- a/internal/daemon/claudeconfig_test.go
+++ b/internal/daemon/claudeconfig_test.go
@@ -16,7 +16,7 @@ func TestWriteClaudeSettings(t *testing.T) {
 
 	baseURL := "https://example.com"
 	apiKey := "test-api-key"
-	if err := writeClaudeSettings(baseURL, apiKey, nil); err != nil {
+	if err := writeClaudeSettings(baseURL, apiKey, nil, false); err != nil {
 		t.Fatalf("expected settings to be written, got %v", err)
 	}
 
@@ -73,7 +73,7 @@ func TestWriteClaudeSettingsWithMCPServers(t *testing.T) {
 		{Name: "memory", Port: 8100},
 		{Name: "cache", Port: 8200},
 	}
-	if err := writeClaudeSettings(baseURL, apiKey, mcpServers); err != nil {
+	if err := writeClaudeSettings(baseURL, apiKey, mcpServers, false); err != nil {
 		t.Fatalf("expected settings to be written, got %v", err)
 	}
 

--- a/internal/daemon/codexconfig.go
+++ b/internal/daemon/codexconfig.go
@@ -13,6 +13,19 @@ import (
 	codex "github.com/agynio/codex-sdk-go"
 )
 
+// codexNativeConfigTemplate is the same file minus the endpoint: no
+// model_provider and no [model_providers] block, so codex talks to its own
+// vendor. Tracing and the mcp_servers appended below are unaffected.
+const codexNativeConfigTemplate = `approval_policy = "never"
+sandbox_mode = "danger-full-access"
+
+[otel]
+# See the platform template for why this is OTLP/HTTP rather than gRPC.
+trace_exporter = { otlp-http = { endpoint = %q, protocol = "binary" } }
+metrics_exporter = "none"
+exporter = "none"
+`
+
 const codexConfigTemplate = `model_provider = "platform"
 approval_policy = "never"
 sandbox_mode = "danger-full-access"
@@ -83,25 +96,25 @@ var codexProxyEnvVars = []string{
 	codexEnvAllProxyLower,
 }
 
-func writeCodexConfig(llmBaseURL string, mcpServers []config.MCPServer, otlpEndpoint string) (string, error) {
+func writeCodexConfig(cfg config.Config, otlpEndpoint string) (string, error) {
 	codexHome := filepath.Join(codexHomeEnv(), ".codex")
 	if err := os.MkdirAll(codexHome, 0o700); err != nil {
 		return "", fmt.Errorf("create codex home dir: %w", err)
 	}
 	configPath := filepath.Join(codexHome, "config.toml")
-	payload := codexConfig(llmBaseURL, mcpServers, otlpEndpoint)
+	payload := codexConfig(cfg, otlpEndpoint)
 	if err := os.WriteFile(configPath, []byte(payload), 0o600); err != nil {
 		return "", fmt.Errorf("write codex config: %w", err)
 	}
 	return codexHome, nil
 }
 
-func codexConfig(llmBaseURL string, mcpServers []config.MCPServer, otlpEndpoint string) string {
-	apiKeyEnv := codexAPIKeyEnv
-	if isZitiLLMBaseURL(llmBaseURL) {
-		apiKeyEnv = ""
+func codexConfig(cfg config.Config, otlpEndpoint string) string {
+	payload := codexPlatformConfig(cfg.LLMBaseURL, otlpEndpoint)
+	if cfg.LLMNative {
+		payload = fmt.Sprintf(codexNativeConfigTemplate, otlpEndpoint)
 	}
-	payload := fmt.Sprintf(codexConfigTemplate, otlpEndpoint, llmBaseURL, apiKeyEnv)
+	mcpServers := cfg.MCPServers
 	if len(mcpServers) == 0 {
 		return payload
 	}
@@ -114,6 +127,14 @@ func codexConfig(llmBaseURL string, mcpServers []config.MCPServer, otlpEndpoint 
 	return builder.String()
 }
 
+func codexPlatformConfig(llmBaseURL, otlpEndpoint string) string {
+	apiKeyEnv := codexAPIKeyEnv
+	if isZitiLLMBaseURL(llmBaseURL) {
+		apiKeyEnv = ""
+	}
+	return fmt.Sprintf(codexConfigTemplate, otlpEndpoint, llmBaseURL, apiKeyEnv)
+}
+
 func codexEnv(cfg config.Config, codexHome, codexHomeValue, otlpEndpoint string) map[string]string {
 	env := map[string]string{
 		codexEnvPath:                     agentPathValue(),
@@ -121,7 +142,9 @@ func codexEnv(cfg config.Config, codexHome, codexHomeValue, otlpEndpoint string)
 		codexEnvHome:                     codexHomeValue,
 		codexEnvOTELExporterOTLPEndpoint: otlpEndpoint,
 	}
-	if isZitiLLMBaseURL(cfg.LLMBaseURL) {
+	// Native mode carries no platform credential at all: the placeholder codex
+	// reads is on the container, and the proxy replaces it upstream.
+	if cfg.LLMNative || isZitiLLMBaseURL(cfg.LLMBaseURL) {
 		noProxyValue := zitiNoProxyValue(
 			os.Getenv(codexEnvNoProxy),
 			os.Getenv(codexEnvNoProxyLower),
@@ -174,7 +197,10 @@ func splitNoProxy(value string) []string {
 }
 
 func newCodexClient(ctx context.Context, cfg config.Config, options ...codex.Option) (codexClient, error) {
-	if !isZitiLLMBaseURL(cfg.LLMBaseURL) {
+	// Native mode is the one case where the ambient auth variables are the
+	// point: the placeholder lives in them, and codex refuses to start without
+	// one. Only the platform path strips them.
+	if cfg.LLMNative || !isZitiLLMBaseURL(cfg.LLMBaseURL) {
 		return codex.NewClient(ctx, options...)
 	}
 	return withoutCodexAuthEnv(func() (codexClient, error) {

--- a/internal/daemon/codexconfig.go
+++ b/internal/daemon/codexconfig.go
@@ -22,8 +22,9 @@ sandbox_mode = "danger-full-access"
 [otel]
 # See the platform template for why this is OTLP/HTTP rather than gRPC.
 trace_exporter = { otlp-http = { endpoint = %q, protocol = "binary" } }
+exporter = { otlp-http = { endpoint = %q, protocol = "binary" } }
+log_user_prompt = true
 metrics_exporter = "none"
-exporter = "none"
 `
 
 const codexConfigTemplate = `model_provider = "platform"
@@ -37,8 +38,11 @@ sandbox_mode = "danger-full-access"
 # and codex then exits before answering the initialize handshake. protocol is
 # required and binary is the OTLP default encoding.
 trace_exporter = { otlp-http = { endpoint = %q, protocol = "binary" } }
+# Prompts, tool calls and SSE events ship over logs, not traces; log_user_prompt
+# is the opt-in that stops codex reducing the prompt to prompt_length.
+exporter = { otlp-http = { endpoint = %q, protocol = "binary" } }
+log_user_prompt = true
 metrics_exporter = "none"
-exporter = "none"
 
 [model_providers.platform]
 name = "Agyn LLM"
@@ -112,7 +116,8 @@ func writeCodexConfig(cfg config.Config, otlpEndpoint string) (string, error) {
 func codexConfig(cfg config.Config, otlpEndpoint string) string {
 	payload := codexPlatformConfig(cfg.LLMBaseURL, otlpEndpoint)
 	if cfg.LLMNative {
-		payload = fmt.Sprintf(codexNativeConfigTemplate, otlpEndpoint)
+		payload = fmt.Sprintf(codexNativeConfigTemplate, otlpSignalEndpoint(otlpEndpoint, "traces"),
+			otlpSignalEndpoint(otlpEndpoint, "logs"))
 	}
 	mcpServers := cfg.MCPServers
 	if len(mcpServers) == 0 {
@@ -132,7 +137,14 @@ func codexPlatformConfig(llmBaseURL, otlpEndpoint string) string {
 	if isZitiLLMBaseURL(llmBaseURL) {
 		apiKeyEnv = ""
 	}
-	return fmt.Sprintf(codexConfigTemplate, otlpEndpoint, llmBaseURL, apiKeyEnv)
+	return fmt.Sprintf(codexConfigTemplate, otlpSignalEndpoint(otlpEndpoint, "traces"),
+		otlpSignalEndpoint(otlpEndpoint, "logs"), llmBaseURL, apiKeyEnv)
+}
+
+// Codex wants a per-signal URL, not a base, so the caller passes the collector
+// root and the signal path is appended here.
+func otlpSignalEndpoint(otlpEndpoint, signal string) string {
+	return strings.TrimSuffix(otlpEndpoint, "/") + "/v1/" + signal
 }
 
 func codexEnv(cfg config.Config, codexHome, codexHomeValue, otlpEndpoint string) map[string]string {

--- a/internal/daemon/codexconfig_test.go
+++ b/internal/daemon/codexconfig_test.go
@@ -386,8 +386,11 @@ sandbox_mode = "danger-full-access"
 # and codex then exits before answering the initialize handshake. protocol is
 # required and binary is the OTLP default encoding.
 trace_exporter = { otlp-http = { endpoint = %q, protocol = "binary" } }
+# Prompts, tool calls and SSE events ship over logs, not traces; log_user_prompt
+# is the opt-in that stops codex reducing the prompt to prompt_length.
+exporter = { otlp-http = { endpoint = %q, protocol = "binary" } }
+log_user_prompt = true
 metrics_exporter = "none"
-exporter = "none"
 
 [model_providers.platform]
 name = "Agyn LLM"
@@ -396,5 +399,5 @@ base_url = %q
 request_max_retries = 0
 stream_max_retries = 0
 supports_websockets = false
-`, otlpEndpoint, baseURL, apiKeyEnv)
+`, otlpEndpoint+"/v1/traces", otlpEndpoint+"/v1/logs", baseURL, apiKeyEnv)
 }

--- a/internal/daemon/codexconfig_test.go
+++ b/internal/daemon/codexconfig_test.go
@@ -41,7 +41,7 @@ func TestWriteCodexConfig(t *testing.T) {
 	t.Setenv("HOME", tmpHome)
 
 	baseURL := "https://example.com"
-	codexHome, err := writeCodexConfig(baseURL, nil, testCodexOTLPEndpoint)
+	codexHome, err := writeCodexConfig(config.Config{LLMBaseURL: baseURL, MCPServers: nil}, testCodexOTLPEndpoint)
 	if err != nil {
 		t.Fatalf("expected config to be written, got %v", err)
 	}
@@ -67,7 +67,7 @@ func TestWriteCodexConfigHomeFallback(t *testing.T) {
 	t.Setenv("HOME", "")
 
 	baseURL := "https://example.com"
-	codexHome, err := writeCodexConfig(baseURL, nil, testCodexOTLPEndpoint)
+	codexHome, err := writeCodexConfig(config.Config{LLMBaseURL: baseURL, MCPServers: nil}, testCodexOTLPEndpoint)
 	if err != nil {
 		t.Fatalf("expected config to be written, got %v", err)
 	}
@@ -94,7 +94,7 @@ func TestWriteCodexConfigForZitiOmitsAPIKeyEnv(t *testing.T) {
 	t.Setenv("HOME", tmpHome)
 
 	baseURL := "http://llm-proxy.ziti:443/v1"
-	codexHome, err := writeCodexConfig(baseURL, nil, testCodexOTLPEndpoint)
+	codexHome, err := writeCodexConfig(config.Config{LLMBaseURL: baseURL, MCPServers: nil}, testCodexOTLPEndpoint)
 	if err != nil {
 		t.Fatalf("expected config to be written, got %v", err)
 	}
@@ -120,7 +120,7 @@ func TestWriteCodexConfigWithMCPServers(t *testing.T) {
 		{Name: "memory", Port: 8100},
 		{Name: "cache", Port: 8200},
 	}
-	codexHome, err := writeCodexConfig(baseURL, mcpServers, testCodexOTLPEndpoint)
+	codexHome, err := writeCodexConfig(config.Config{LLMBaseURL: baseURL, MCPServers: mcpServers}, testCodexOTLPEndpoint)
 	if err != nil {
 		t.Fatalf("expected config to be written, got %v", err)
 	}
@@ -301,7 +301,7 @@ func TestZitiCodexProcessReceivesNoAuthEnvConfig(t *testing.T) {
 	}
 
 	env := codexEnv(cfg, "/tmp/.codex", "/tmp", testCodexOTLPEndpoint)
-	configPayload := codexConfig(cfg.LLMBaseURL, nil, testCodexOTLPEndpoint)
+	configPayload := codexConfig(config.Config{LLMBaseURL: cfg.LLMBaseURL, MCPServers: nil}, testCodexOTLPEndpoint)
 	seenEnv := map[string]bool{}
 	_, err := withoutCodexAuthEnv(func() (codexClient, error) {
 		for _, key := range codexAuthEnvVars {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -154,6 +154,11 @@ func New(ctx context.Context, cfg config.Config, version string) (*Daemon, error
 	if cfg.Mode == config.ModeHolder {
 		return newHolderDaemon(cfg), nil
 	}
+	// Before any SDK is constructed: the CLI reads it at startup, and a shell
+	// exec'd into an agent workload finds it for the same reason holder does.
+	if err := writePlaceholderFile(); err != nil {
+		return nil, fmt.Errorf("write placeholder credential: %w", err)
+	}
 	switch cfg.SDK {
 	case SDKCodex:
 		return newCodexDaemon(ctx, cfg, version)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -325,7 +325,7 @@ func newCodexDaemon(ctx context.Context, cfg config.Config, version string) (*Da
 	otlpEndpoint := "http://" + tracingProxy.Address()
 	// Codex exports over OTLP/HTTP and everything else over gRPC; see the otel
 	// block in the codex config for why.
-	codexOTLPEndpoint := "http://" + tracingProxy.HTTPAddress() + "/v1/traces"
+	codexOTLPEndpoint := "http://" + tracingProxy.HTTPAddress()
 	codexHome, err := writeCodexConfig(cfg, codexOTLPEndpoint)
 	if err != nil {
 		tracingProxy.Close()

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -258,7 +258,7 @@ func tryConnectPlatform(ctx context.Context, cfg config.Config) (*platformSetup,
 		return nil, config.Config{}, fmt.Errorf("list skills: %w", err)
 	}
 
-	mcpDefinitions, err := listMCPs(ctx, agentsClient, cfg.AgentID.String())
+	mcpDefinitions, err := listMCPs(ctx, agentsClient, cfg.AgentID.String(), cfg.EnvironmentID)
 	if err != nil {
 		_ = gatewayConn.Close()
 		return nil, config.Config{}, fmt.Errorf("list MCPs: %w", err)
@@ -322,7 +322,7 @@ func newCodexDaemon(ctx context.Context, cfg config.Config, version string) (*Da
 		return nil, err
 	}
 
-	if err := runInitScripts(ctx, setup.agents, cfg.AgentID.String(), cfg.WorkDir); err != nil {
+	if err := runInitScripts(ctx, setup.agents, cfg.AgentID.String(), cfg.EnvironmentID, cfg.WorkDir); err != nil {
 		tracingProxy.Close()
 		_ = setup.gatewayConn.Close()
 		return nil, err

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -158,6 +158,12 @@ func New(ctx context.Context, cfg config.Config, version string) (*Daemon, error
 	case SDKCodex:
 		return newCodexDaemon(ctx, cfg, version)
 	case SDKAgn:
+		if cfg.LLMNative {
+			// agn has no vendor of its own to be intercepted at: it calls the
+			// platform LLM Proxy by a platform Model UUID, which a native
+			// environment's agents do not carry.
+			return nil, fmt.Errorf("the agn SDK is not supported in native LLM mode")
+		}
 		return newAgnDaemon(ctx, cfg, version)
 	case SDKClaude:
 		return newClaudeDaemon(ctx, cfg, version)
@@ -315,7 +321,7 @@ func newCodexDaemon(ctx context.Context, cfg config.Config, version string) (*Da
 	// Codex exports over OTLP/HTTP and everything else over gRPC; see the otel
 	// block in the codex config for why.
 	codexOTLPEndpoint := "http://" + tracingProxy.HTTPAddress() + "/v1/traces"
-	codexHome, err := writeCodexConfig(cfg.LLMBaseURL, cfg.MCPServers, codexOTLPEndpoint)
+	codexHome, err := writeCodexConfig(cfg, codexOTLPEndpoint)
 	if err != nil {
 		tracingProxy.Close()
 		_ = setup.gatewayConn.Close()
@@ -736,8 +742,12 @@ func (d *Daemon) handleCodexMessage(ctx context.Context, message platform.Messag
 	if err != nil {
 		return err
 	}
-	if err := waitForZitiLLMService(ctx, d.cfg.LLMBaseURL, llmReadyTimeout); err != nil {
-		return fmt.Errorf("wait for LLM service before codex turn: %w", err)
+	// Native mode does not route through the LLM Proxy, so there is nothing
+	// here to wait for -- the vendor host is intercepted on dial.
+	if !d.cfg.LLMNative {
+		if err := waitForZitiLLMService(ctx, d.cfg.LLMBaseURL, llmReadyTimeout); err != nil {
+			return fmt.Errorf("wait for LLM service before codex turn: %w", err)
+		}
 	}
 	turnCtx, cancel := context.WithTimeout(ctx, turnStartTimeout)
 	turnResp, err := d.codex.StartTurn(turnCtx, &codex.TurnStartParams{
@@ -1143,6 +1153,16 @@ func validateMCPProbePayload(payload []byte) error {
 	return nil
 }
 
+// codexModel picks what to pin the thread to: the platform Model UUID the
+// proxy resolves, or the vendor's own model name. Unset in native mode leaves
+// codex on its own default.
+func codexModel(cfg config.Config, platformModel string) string {
+	if cfg.LLMNative {
+		return strings.TrimSpace(cfg.LLMModelName)
+	}
+	return strings.TrimSpace(platformModel)
+}
+
 type codexThreadDefaults struct {
 	model                 *string
 	baseInstructions      *string
@@ -1152,7 +1172,7 @@ type codexThreadDefaults struct {
 
 func (d *Daemon) codexThreadDefaults() codexThreadDefaults {
 	defaults := codexThreadDefaults{}
-	if model := strings.TrimSpace(d.agent.GetModel()); model != "" {
+	if model := codexModel(d.cfg, d.agent.GetModel()); model != "" {
 		defaults.model = &model
 	}
 	if role := strings.TrimSpace(d.agent.GetRole()); role != "" {

--- a/internal/daemon/environment_scope_test.go
+++ b/internal/daemon/environment_scope_test.go
@@ -1,0 +1,83 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	agentsv1 "github.com/agynio/agynd-cli/.gen/go/agynio/api/agents/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type scopedMcpsClient struct {
+	byTarget map[string][]*agentsv1.Mcp
+	requests []string
+}
+
+func (c *scopedMcpsClient) ListMcps(_ context.Context, in *agentsv1.ListMcpsRequest, _ ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error) {
+	target := "agent:" + in.GetAgentId()
+	if in.GetEnvironmentId() != "" {
+		target = "environment:" + in.GetEnvironmentId()
+	}
+	c.requests = append(c.requests, target)
+	return &agentsv1.ListMcpsResponse{Mcps: c.byTarget[target]}, nil
+}
+
+// Environment-level and agent-level servers compose as a union, and on a name
+// collision the agent's wins -- the rule ENV already follows.
+func TestListMCPsMergesEnvironmentAndAgentByName(t *testing.T) {
+	client := &scopedMcpsClient{byTarget: map[string][]*agentsv1.Mcp{
+		"environment:env-1": {
+			{Meta: &agentsv1.EntityMeta{Id: "env-shared", CreatedAt: timestamppb.New(time.Now())}, Name: "files"},
+			{Meta: &agentsv1.EntityMeta{Id: "env-only", CreatedAt: timestamppb.New(time.Now())}, Name: "search"},
+		},
+		"agent:agent-1": {
+			{Meta: &agentsv1.EntityMeta{Id: "agent-shared", CreatedAt: timestamppb.New(time.Now())}, Name: "files"},
+		},
+	}}
+
+	mcps, err := listMCPs(context.Background(), client, "agent-1", "env-1")
+	if err != nil {
+		t.Fatalf("list mcps: %v", err)
+	}
+	byName := map[string]string{}
+	for _, mcp := range mcps {
+		byName[mcp.Name] = mcp.ID
+	}
+	if len(byName) != 2 {
+		t.Fatalf("expected 2 servers, got %d: %v", len(byName), byName)
+	}
+	if byName["files"] != "agent-shared" {
+		t.Fatalf("expected the agent-level server to win on a name collision, got %q", byName["files"])
+	}
+	if byName["search"] != "env-only" {
+		t.Fatalf("expected the environment-only server to survive, got %q", byName["search"])
+	}
+}
+
+// A sandbox has no agent, so it runs the environment's servers alone.
+func TestListMCPsWithoutAnAgentReadsTheEnvironmentOnly(t *testing.T) {
+	client := &scopedMcpsClient{byTarget: map[string][]*agentsv1.Mcp{
+		"environment:env-1": {{Meta: &agentsv1.EntityMeta{Id: "env-only", CreatedAt: timestamppb.New(time.Now())}, Name: "files"}},
+	}}
+
+	mcps, err := listMCPs(context.Background(), client, "", "env-1")
+	if err != nil {
+		t.Fatalf("list mcps: %v", err)
+	}
+	if len(mcps) != 1 || mcps[0].ID != "env-only" {
+		t.Fatalf("unexpected servers: %+v", mcps)
+	}
+	for _, req := range client.requests {
+		if req == "agent:" {
+			t.Fatal("expected no agent-scoped request without an agent")
+		}
+	}
+}
+
+func TestListMCPsRequiresATarget(t *testing.T) {
+	if _, err := listMCPs(context.Background(), &scopedMcpsClient{}, "", ""); err == nil {
+		t.Fatal("expected an error with neither an agent nor an environment")
+	}
+}

--- a/internal/daemon/holder.go
+++ b/internal/daemon/holder.go
@@ -18,6 +18,11 @@ func runHolder(ctx context.Context, workDir string) error {
 	if err := holderChdir(workDir); err != nil {
 		return fmt.Errorf("set holder work dir %s: %w", workDir, err)
 	}
+	// Holder spawns nothing, but it is not inert: the file has to exist before
+	// an engineer opens a shell, which is the only session this mode serves.
+	if err := writePlaceholderFile(); err != nil {
+		return fmt.Errorf("write placeholder credential: %w", err)
+	}
 	log.Printf("agynd holder mode started in %s", workDir)
 	<-ctx.Done()
 	return operationError(opProcessSignalShutdown, 0, ctx.Err())

--- a/internal/daemon/init_scripts.go
+++ b/internal/daemon/init_scripts.go
@@ -28,8 +28,8 @@ type initScript struct {
 	Description string
 }
 
-func runInitScripts(ctx context.Context, client initScriptsClient, agentID string, workDir string) error {
-	scripts, err := listInitScripts(ctx, client, agentID)
+func runInitScripts(ctx context.Context, client initScriptsClient, agentID string, environmentID string, workDir string) error {
+	scripts, err := listInitScripts(ctx, client, agentID, environmentID)
 	if err != nil {
 		return err
 	}
@@ -41,21 +41,45 @@ func runInitScripts(ctx context.Context, client initScriptsClient, agentID strin
 	return nil
 }
 
-func listInitScripts(ctx context.Context, client initScriptsClient, agentID string) ([]initScript, error) {
+// listInitScripts returns the environment's scripts first, then the agent's,
+// each in creation order. Names do not collide -- every script runs -- so the
+// order is the whole contract.
+func listInitScripts(ctx context.Context, client initScriptsClient, agentID string, environmentID string) ([]initScript, error) {
 	if client == nil {
 		return nil, fmt.Errorf("init scripts client is required")
 	}
 	agentID = strings.TrimSpace(agentID)
-	if agentID == "" {
-		return nil, fmt.Errorf("agent id is required")
+	environmentID = strings.TrimSpace(environmentID)
+	if agentID == "" && environmentID == "" {
+		return nil, fmt.Errorf("agent id or environment id is required")
 	}
+	var ordered []initScript
+	if environmentID != "" {
+		scripts, err := listInitScriptsForTarget(ctx, client, &agentsv1.ListInitScriptsRequest{EnvironmentId: environmentID})
+		if err != nil {
+			return nil, err
+		}
+		ordered = append(ordered, scripts...)
+	}
+	if agentID != "" {
+		scripts, err := listInitScriptsForTarget(ctx, client, &agentsv1.ListInitScriptsRequest{AgentId: agentID})
+		if err != nil {
+			return nil, err
+		}
+		ordered = append(ordered, scripts...)
+	}
+	return ordered, nil
+}
+
+func listInitScriptsForTarget(ctx context.Context, client initScriptsClient, req *agentsv1.ListInitScriptsRequest) ([]initScript, error) {
 	var scripts []initScript
 	pageToken := ""
 	for {
 		resp, err := client.ListInitScripts(ctx, &agentsv1.ListInitScriptsRequest{
-			AgentId:   agentID,
-			PageSize:  initScriptsPageSize,
-			PageToken: pageToken,
+			AgentId:       req.GetAgentId(),
+			EnvironmentId: req.GetEnvironmentId(),
+			PageSize:      initScriptsPageSize,
+			PageToken:     pageToken,
 		})
 		if err != nil {
 			return nil, err

--- a/internal/daemon/init_scripts_test.go
+++ b/internal/daemon/init_scripts_test.go
@@ -114,7 +114,7 @@ func TestListInitScriptsOrdersByCreatedAtThenID(t *testing.T) {
 		},
 	}
 	fake := &fakeInitScriptsClient{responses: []*agentsv1.ListInitScriptsResponse{resp1, resp2}}
-	scripts, err := listInitScripts(context.Background(), fake, "agent-1")
+	scripts, err := listInitScripts(context.Background(), fake, "agent-1", "")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -152,7 +152,7 @@ func TestRunInitScriptsExecutesInOrder(t *testing.T) {
 			},
 		},
 	}}}
-	if err := runInitScripts(context.Background(), fake, "agent-1", workDir); err != nil {
+	if err := runInitScripts(context.Background(), fake, "agent-1", "", workDir); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	data, err := os.ReadFile(outputPath)

--- a/internal/daemon/mcps.go
+++ b/internal/daemon/mcps.go
@@ -24,21 +24,59 @@ type mcpDefinition struct {
 	CreatedAt time.Time
 }
 
-func listMCPs(ctx context.Context, client mcpsClient, agentID string) ([]mcpDefinition, error) {
+// listMCPs merges the environment's servers with the agent's. Both run in an
+// agent workload; a sandbox has no agent and gets the environment's alone. On a
+// name collision the agent-level server wins, the rule ENV follows.
+func listMCPs(ctx context.Context, client mcpsClient, agentID string, environmentID string) ([]mcpDefinition, error) {
 	if client == nil {
 		return nil, fmt.Errorf("mcps client is required")
 	}
 	agentID = strings.TrimSpace(agentID)
-	if agentID == "" {
-		return nil, fmt.Errorf("agent id is required")
+	environmentID = strings.TrimSpace(environmentID)
+	if agentID == "" && environmentID == "" {
+		return nil, fmt.Errorf("agent id or environment id is required")
 	}
+	byName := map[string]mcpDefinition{}
+	if environmentID != "" {
+		environmentMCPs, err := listMCPsForTarget(ctx, client, &agentsv1.ListMcpsRequest{EnvironmentId: environmentID})
+		if err != nil {
+			return nil, err
+		}
+		for _, mcp := range environmentMCPs {
+			byName[mcp.Name] = mcp
+		}
+	}
+	if agentID != "" {
+		agentMCPs, err := listMCPsForTarget(ctx, client, &agentsv1.ListMcpsRequest{AgentId: agentID})
+		if err != nil {
+			return nil, err
+		}
+		for _, mcp := range agentMCPs {
+			byName[mcp.Name] = mcp
+		}
+	}
+	mcps := make([]mcpDefinition, 0, len(byName))
+	for _, mcp := range byName {
+		mcps = append(mcps, mcp)
+	}
+	sort.Slice(mcps, func(i, j int) bool {
+		if mcps[i].CreatedAt.Equal(mcps[j].CreatedAt) {
+			return mcps[i].ID < mcps[j].ID
+		}
+		return mcps[i].CreatedAt.Before(mcps[j].CreatedAt)
+	})
+	return mcps, nil
+}
+
+func listMCPsForTarget(ctx context.Context, client mcpsClient, req *agentsv1.ListMcpsRequest) ([]mcpDefinition, error) {
 	var mcps []mcpDefinition
 	pageToken := ""
 	for {
 		resp, err := client.ListMcps(ctx, &agentsv1.ListMcpsRequest{
-			AgentId:   agentID,
-			PageSize:  mcpsPageSize,
-			PageToken: pageToken,
+			AgentId:       req.GetAgentId(),
+			EnvironmentId: req.GetEnvironmentId(),
+			PageSize:      mcpsPageSize,
+			PageToken:     pageToken,
 		})
 		if err != nil {
 			return nil, err

--- a/internal/daemon/nativemode_test.go
+++ b/internal/daemon/nativemode_test.go
@@ -1,0 +1,133 @@
+package daemon
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/agynio/agynd-cli/internal/config"
+)
+
+func TestWriteClaudeSettingsNativeOmitsEndpoint(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	servers := []config.MCPServer{{Name: "platform", Port: 9100}}
+	if err := writeClaudeSettings("http://llm-proxy.ziti:443", "token", servers, true); err != nil {
+		t.Fatalf("write claude settings: %v", err)
+	}
+
+	payload, err := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	var settings claudeSettings
+	if err := json.Unmarshal(payload, &settings); err != nil {
+		t.Fatalf("decode settings: %v", err)
+	}
+
+	if _, ok := settings.Env["ANTHROPIC_BASE_URL"]; ok {
+		t.Fatal("native settings carry a base URL")
+	}
+	if _, ok := settings.Env["ANTHROPIC_API_KEY"]; ok {
+		t.Fatal("native settings carry a credential")
+	}
+	// The whole point of still writing the file.
+	if settings.Permissions.DefaultMode != "bypassPermissions" {
+		t.Fatalf("native settings lost permissions: %+v", settings.Permissions)
+	}
+	if _, ok := settings.MCPServers["platform"]; !ok {
+		t.Fatalf("native settings lost MCP wiring: %+v", settings.MCPServers)
+	}
+	// Neither is endpoint configuration, and an autoupdate check in native mode
+	// reaches a host nothing intercepts.
+	if settings.Env["DISABLE_AUTOUPDATER"] != "1" {
+		t.Fatal("native settings dropped the autoupdater guard")
+	}
+	if settings.Env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] != "1" {
+		t.Fatal("native settings dropped the nonessential traffic guard")
+	}
+}
+
+func TestWriteClaudeSettingsPlatformKeepsEndpoint(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := writeClaudeSettings("http://llm-proxy.ziti:443", "token", nil, false); err != nil {
+		t.Fatalf("write claude settings: %v", err)
+	}
+	payload, err := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	var settings claudeSettings
+	if err := json.Unmarshal(payload, &settings); err != nil {
+		t.Fatalf("decode settings: %v", err)
+	}
+	if settings.Env["ANTHROPIC_BASE_URL"] != "http://llm-proxy.ziti:443" {
+		t.Fatalf("platform settings lost the base URL: %+v", settings.Env)
+	}
+	if settings.Env["ANTHROPIC_API_KEY"] != "token" {
+		t.Fatalf("platform settings lost the credential: %+v", settings.Env)
+	}
+}
+
+func TestCodexConfigNativeOmitsProvider(t *testing.T) {
+	cfg := config.Config{
+		LLMBaseURL: "http://llm-proxy.ziti:443/v1",
+		LLMNative:  true,
+		MCPServers: []config.MCPServer{{Name: "platform", Port: 9100}},
+	}
+	payload := codexConfig(cfg, "http://127.0.0.1:4318/v1/traces")
+
+	for _, forbidden := range []string{"model_provider", "base_url", "llm-proxy.ziti", "env_key"} {
+		if strings.Contains(payload, forbidden) {
+			t.Fatalf("native codex config carries %q:\n%s", forbidden, payload)
+		}
+	}
+	for _, required := range []string{"[mcp_servers.platform]", "approval_policy", "[otel]"} {
+		if !strings.Contains(payload, required) {
+			t.Fatalf("native codex config lost %q:\n%s", required, payload)
+		}
+	}
+}
+
+func TestCodexEnvNativeKeepsPlaceholder(t *testing.T) {
+	cfg := config.Config{LLMBaseURL: "http://llm-proxy.ziti:443/v1", LLMNative: true, LLMAPIToken: "platform"}
+	env := codexEnv(cfg, "/home/agent/.codex", "/home/agent", "http://127.0.0.1:4318")
+
+	// The placeholder codex reads is on the container; overwriting the variable
+	// here with a platform token would replace it with something the proxy does
+	// not expect and the vendor would never accept.
+	if _, ok := env[codexEnvOpenAIAPIKey]; ok {
+		t.Fatalf("native codex env sets a platform credential: %+v", env)
+	}
+	if env[codexEnvNoProxy] == "" {
+		t.Fatal("native codex env lost the ziti no_proxy list")
+	}
+}
+
+func TestModelSelectionFollowsMode(t *testing.T) {
+	const platformModel = "1c9b3a1e-0000-4000-8000-000000000000"
+	cases := []struct {
+		name string
+		cfg  config.Config
+		want string
+	}{
+		{"platform uses the model UUID", config.Config{}, platformModel},
+		{"native uses the vendor model name", config.Config{LLMNative: true, LLMModelName: "claude-sonnet-4-6"}, "claude-sonnet-4-6"},
+		{"native without a name leaves the CLI on its default", config.Config{LLMNative: true}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := claudeModel(tc.cfg, platformModel); got != tc.want {
+				t.Fatalf("claudeModel = %q, want %q", got, tc.want)
+			}
+			if got := codexModel(tc.cfg, platformModel); got != tc.want {
+				t.Fatalf("codexModel = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/daemon/placeholder.go
+++ b/internal/daemon/placeholder.go
@@ -1,0 +1,53 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// A vendor whose CLI reads its subscription credential from a file rather than
+// an environment variable needs that file present before the CLI starts. The
+// orchestrator cannot write it: the path is CLI-specific and resolves against
+// HOME, which the platform does not manage. It arrives on the container spec
+// instead, verbatim from the LLM service, so nothing here knows which vendor
+// or which CLI it belongs to.
+const (
+	placeholderFilePathEnv     = "LLM_PLACEHOLDER_FILE_PATH"
+	placeholderFileContentsEnv = "LLM_PLACEHOLDER_FILE_CONTENTS"
+)
+
+// writePlaceholderFile writes the file placeholder when one is declared. It
+// runs in holder mode too: holder spawns nothing, but a sandbox shell opened
+// hours later still finds the file, which is the whole reason this kind exists.
+//
+// An existing file is left alone. A real credential may already be there --
+// written by the CLI's own login, or by a previous session -- and replacing it
+// with a placeholder would log the engineer out of their own subscription.
+func writePlaceholderFile() error {
+	path := strings.TrimSpace(os.Getenv(placeholderFilePathEnv))
+	if path == "" {
+		return nil
+	}
+	if filepath.IsAbs(path) || strings.Contains(path, "..") {
+		return fmt.Errorf("placeholder path %q must be relative to HOME", path)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolve home directory: %w", err)
+	}
+	target := filepath.Join(home, path)
+	if _, err := os.Stat(target); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat %s: %w", target, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+		return fmt.Errorf("create %s: %w", filepath.Dir(target), err)
+	}
+	if err := os.WriteFile(target, []byte(os.Getenv(placeholderFileContentsEnv)), 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", target, err)
+	}
+	return nil
+}

--- a/internal/daemon/placeholder_test.go
+++ b/internal/daemon/placeholder_test.go
@@ -1,0 +1,85 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWritePlaceholderFileCreatesTheFileAndItsDirectory(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(placeholderFilePathEnv, ".codex/auth.json")
+	t.Setenv(placeholderFileContentsEnv, `{"tokens":{"access_token":"placeholder"}}`)
+
+	if err := writePlaceholderFile(); err != nil {
+		t.Fatalf("write placeholder: %v", err)
+	}
+	contents, err := os.ReadFile(filepath.Join(home, ".codex", "auth.json"))
+	if err != nil {
+		t.Fatalf("read placeholder: %v", err)
+	}
+	if string(contents) != `{"tokens":{"access_token":"placeholder"}}` {
+		t.Fatalf("contents = %s", contents)
+	}
+}
+
+// A real credential may already be there -- the CLI's own login, or a previous
+// session -- and replacing it with a placeholder would log the engineer out of
+// their own subscription.
+func TestWritePlaceholderFileLeavesAnExistingFileAlone(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(placeholderFilePathEnv, ".codex/auth.json")
+	t.Setenv(placeholderFileContentsEnv, "placeholder")
+
+	target := filepath.Join(home, ".codex", "auth.json")
+	if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("the engineer's own token"), 0o600); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+
+	if err := writePlaceholderFile(); err != nil {
+		t.Fatalf("write placeholder: %v", err)
+	}
+	contents, _ := os.ReadFile(target)
+	if string(contents) != "the engineer's own token" {
+		t.Fatalf("an existing credential was overwritten: %s", contents)
+	}
+}
+
+// Nothing declared is the platform-mode and Anthropic cases, which must not
+// leave a stray file behind.
+func TestWritePlaceholderFileIsANoOpWithoutAPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(placeholderFilePathEnv, "")
+
+	if err := writePlaceholderFile(); err != nil {
+		t.Fatalf("write placeholder: %v", err)
+	}
+	entries, err := os.ReadDir(home)
+	if err != nil {
+		t.Fatalf("read home: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("home is not empty: %v", entries)
+	}
+}
+
+// The path comes from the container environment, which a workload's own ENVs
+// can also reach. Escaping HOME has to be refused rather than written.
+func TestWritePlaceholderFileRefusesAnEscapingPath(t *testing.T) {
+	for _, path := range []string{"/etc/passwd", "../../etc/passwd"} {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv(placeholderFilePathEnv, path)
+		t.Setenv(placeholderFileContentsEnv, "x")
+
+		if err := writePlaceholderFile(); err == nil {
+			t.Fatalf("path %q was accepted", path)
+		}
+	}
+}

--- a/internal/tracingproxy/proxy.go
+++ b/internal/tracingproxy/proxy.go
@@ -8,9 +8,11 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
+	collectorlogsv1 "go.opentelemetry.io/proto/otlp/collector/logs/v1"
 	collectortracev1 "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
 	resourcev1 "go.opentelemetry.io/proto/otlp/resource/v1"
@@ -29,6 +31,7 @@ const (
 	messageIDAttributeKey  = "agyn.thread.message.id"
 	workloadIDAttributeKey = "agyn.workload.id"
 	maxHTTPExportBytes     = 32 << 20
+	maxLoggedValueBytes    = 400
 )
 
 type Config struct {
@@ -104,6 +107,7 @@ func Start(ctx context.Context, cfg Config) (*Proxy, error) {
 	proxy.httpAddress = httpListener.Addr().String()
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /v1/traces", proxy.serveHTTPTraces)
+	mux.HandleFunc("POST /v1/logs", proxy.serveHTTPLogs)
 	proxy.httpServer = &http.Server{Handler: mux, ReadHeaderTimeout: 10 * time.Second}
 	go func() {
 		if err := proxy.httpServer.Serve(httpListener); err != nil && !errors.Is(err, http.ErrServerClosed) {
@@ -151,11 +155,65 @@ func (p *Proxy) serveHTTPTraces(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write(encoded)
 }
 
+// serveHTTPLogs records what codex ships over the log signal -- prompts, tool
+// calls and SSE events -- which has no ingest path yet, so it is logged and
+// acknowledged rather than forwarded.
+func (p *Proxy) serveHTTPLogs(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxHTTPExportBytes))
+	if err != nil {
+		http.Error(w, "read body", http.StatusBadRequest)
+		return
+	}
+	request := &collectorlogsv1.ExportLogsServiceRequest{}
+	if err := proto.Unmarshal(body, request); err != nil {
+		http.Error(w, "decode OTLP request", http.StatusBadRequest)
+		return
+	}
+	logExportedRecords(request)
+	encoded, err := proto.Marshal(&collectorlogsv1.ExportLogsServiceResponse{})
+	if err != nil {
+		http.Error(w, "encode OTLP response", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/x-protobuf")
+	_, _ = w.Write(encoded)
+}
+
+func logExportedRecords(request *collectorlogsv1.ExportLogsServiceRequest) {
+	for _, resourceLogs := range request.ResourceLogs {
+		for _, scopeLogs := range resourceLogs.ScopeLogs {
+			scope := ""
+			if scopeLogs.Scope != nil {
+				scope = scopeLogs.Scope.Name
+			}
+			for _, record := range scopeLogs.LogRecords {
+				attrs := make([]string, 0, len(record.Attributes))
+				for _, attr := range record.Attributes {
+					attrs = append(attrs, attr.Key+"="+truncateValue(attr.Value))
+				}
+				log.Printf("otlp log: scope=%s severity=%s body=%s attrs={%s}",
+					scope, record.SeverityText, truncateValue(record.Body), strings.Join(attrs, " "))
+			}
+		}
+	}
+}
+
+func truncateValue(value *commonv1.AnyValue) string {
+	if value == nil {
+		return ""
+	}
+	rendered := strings.ReplaceAll(value.String(), "\n", "\\n")
+	if len(rendered) > maxLoggedValueBytes {
+		return rendered[:maxLoggedValueBytes] + "..."
+	}
+	return rendered
+}
+
 func (p *Proxy) Address() string {
 	return p.address
 }
 
-// HTTPAddress is the OTLP/HTTP endpoint; append /v1/traces for the exporter.
+// HTTPAddress is the OTLP/HTTP collector root; callers append the signal path.
 func (p *Proxy) HTTPAddress() string {
 	return p.httpAddress
 }


### PR DESCRIPTION
In native mode the agent CLI is left in its stock configuration: no base URL, no custom model provider, no platform model UUID. The files are still written — permissions and MCP wiring share a document with the endpoint, and dropping them would restore interactive tool approval and take the environment's sidecars with it.

Two keys stay in the Claude env block. Neither is endpoint or credential configuration, and both matter more here than in platform mode: only the vendor's API host is intercepted, so an autoupdate check reaches nothing and waits out a timeout.

agynd writes the file-kind placeholder, in agent and holder mode alike — the filesystem outliving the writer is the whole reason that kind exists. An existing file is left alone: a real credential may be there from the CLI's own login. A path escaping HOME is refused.

agn is refused in native mode: it has no vendor of its own to be intercepted at.

Part of native LLM mode.