### PR TITLE
Put the counts on the call, and the call under its message

### DIFF
--- a/internal/tracingproxy/proxy.go
+++ b/internal/tracingproxy/proxy.go
@@ -62,6 +62,8 @@ type Proxy struct {
 	// call is held until they do and re-emitted with them.
 	llmCallMu sync.Mutex
 	llmCalls  map[string]*pendingLLMCall
+	// The message a conversation is answering, so its calls hang off it.
+	messageSpans map[string]*tracev1.Span
 }
 
 func Start(ctx context.Context, cfg Config) (*Proxy, error) {

--- a/internal/tracingproxy/semantic.go
+++ b/internal/tracingproxy/semantic.go
@@ -200,6 +200,7 @@ func (p *Proxy) messageSpan(record *logsv1.LogRecord, attrs logAttrs) *tracev1.S
 	if length, ok := attrs.int("prompt_length"); ok {
 		span.Attributes = append(span.Attributes, intAttr("agyn.message.length", length))
 	}
+	p.rememberMessage(attrs.str("conversation.id"), span)
 	return span
 }
 
@@ -209,9 +210,21 @@ func (p *Proxy) llmCallSpan(record *logsv1.LogRecord, attrs logAttrs) *tracev1.S
 	if duration, ok := attrs.int("duration_ms"); ok && duration > 0 {
 		start = end - uint64(duration)*uint64(time.Millisecond)
 	}
+	// The call belongs to the message being answered, so it hangs off it: the
+	// run view then reads in the order things happened rather than trusting a
+	// start this proxy derives by subtracting a duration codex reports.
+	parent := p.messageSpanFor(attrs.str("conversation.id"))
+	var parentID []byte
+	if parent != nil {
+		parentID = parent.SpanId
+		if start < parent.StartTimeUnixNano {
+			start = parent.StartTimeUnixNano
+		}
+	}
 	span := &tracev1.Span{
 		TraceId:           traceIDForMessage(p.traceSeed(attrs)),
 		SpanId:            newSpanID(),
+		ParentSpanId:      parentID,
 		Name:              spanLLMCall,
 		Kind:              tracev1.Span_SPAN_KIND_CLIENT,
 		StartTimeUnixNano: start,
@@ -243,10 +256,6 @@ func (p *Proxy) llmCallSpan(record *logsv1.LogRecord, attrs logAttrs) *tracev1.S
 // remembered span there is nothing to attach to -- usage alone is not a call --
 // so the record is dropped.
 func (p *Proxy) llmCallUsageSpan(attrs logAttrs) *tracev1.Span {
-	pending := p.takeLLMCall(attrs.str("conversation.id"))
-	if pending == nil {
-		return nil
-	}
 	usage := []struct {
 		source string
 		key    string
@@ -256,12 +265,45 @@ func (p *Proxy) llmCallUsageSpan(attrs logAttrs) *tracev1.Span {
 		{"cached_token_count", "gen_ai.usage.cache_read.input_tokens"},
 		{"reasoning_token_count", "agyn.usage.reasoning_tokens"},
 	}
+	counted := make([]*commonv1.KeyValue, 0, len(usage))
 	for _, entry := range usage {
 		if value, ok := attrs.int(entry.source); ok {
-			pending.span.Attributes = append(pending.span.Attributes, intAttr(entry.key, value))
+			counted = append(counted, intAttr(entry.key, value))
 		}
 	}
+	// Codex completes a response twice: once to end the stream, and again
+	// carrying the counts. Taking the call on the first would spend it on the
+	// record that has nothing to add and leave the counts nowhere to land.
+	if len(counted) == 0 {
+		return nil
+	}
+	pending := p.takeLLMCall(attrs.str("conversation.id"))
+	if pending == nil {
+		return nil
+	}
+	pending.span.Attributes = append(pending.span.Attributes, counted...)
 	return pending.span
+}
+
+func (p *Proxy) rememberMessage(conversationID string, span *tracev1.Span) {
+	if conversationID == "" {
+		return
+	}
+	p.llmCallMu.Lock()
+	defer p.llmCallMu.Unlock()
+	if p.messageSpans == nil {
+		p.messageSpans = make(map[string]*tracev1.Span, 1)
+	}
+	p.messageSpans[conversationID] = span
+}
+
+func (p *Proxy) messageSpanFor(conversationID string) *tracev1.Span {
+	if conversationID == "" {
+		return nil
+	}
+	p.llmCallMu.Lock()
+	defer p.llmCallMu.Unlock()
+	return p.messageSpans[conversationID]
 }
 
 func (p *Proxy) rememberLLMCall(conversationID string, span *tracev1.Span) {

--- a/internal/tracingproxy/semantic_test.go
+++ b/internal/tracingproxy/semantic_test.go
@@ -121,6 +121,16 @@ func TestSemanticSpansAttachesUsageToTheCall(t *testing.T) {
 		t.Fatalf("expected the call span, got %d", len(call))
 	}
 
+	// Codex completes the response twice; only the second carries counts, and
+	// the first must not spend the pending call.
+	if empty := proxy.semanticSpans(logExport(logRecord(
+		stringAttr("event.name", eventSSE),
+		stringAttr("event.kind", sseResponseCompleted),
+		stringAttr("conversation.id", "conv-1"),
+	))); len(empty) != 0 {
+		t.Fatalf("expected a completion with no counts to emit nothing, got %d", len(empty))
+	}
+
 	usage := proxy.semanticSpans(logExport(logRecord(
 		stringAttr("event.name", eventSSE),
 		stringAttr("event.kind", sseResponseCompleted),
@@ -186,5 +196,38 @@ func TestSemanticSpansGroupSpansByMessage(t *testing.T) {
 	}
 	if len(spans[0].TraceId) != 16 || len(spans[0].SpanId) != 8 {
 		t.Fatalf("expected OTLP id widths, got trace=%d span=%d", len(spans[0].TraceId), len(spans[0].SpanId))
+	}
+}
+
+// The call answers the message, so it hangs off it rather than relying on a
+// start derived by subtracting codex's reported duration.
+func TestSemanticSpansParentTheCallToItsMessage(t *testing.T) {
+	proxy := &Proxy{}
+	message := proxy.semanticSpans(logExport(logRecord(
+		stringAttr("event.name", eventUserPrompt),
+		stringAttr("prompt", "hello"),
+		stringAttr("conversation.id", "conv-1"),
+		stringAttr("event.timestamp", "2026-08-09T00:48:22.310Z"),
+	)))
+	if len(message) != 1 {
+		t.Fatalf("expected the message span, got %d", len(message))
+	}
+
+	// A duration long enough to place the call before the message it answers.
+	call := proxy.semanticSpans(logExport(logRecord(
+		stringAttr("event.name", eventAPIRequest),
+		stringAttr("model", "gpt-5.5"),
+		stringAttr("duration_ms", "5000"),
+		stringAttr("conversation.id", "conv-1"),
+		stringAttr("event.timestamp", "2026-08-09T00:48:23.889Z"),
+	)))
+	if len(call) != 1 {
+		t.Fatalf("expected the call span, got %d", len(call))
+	}
+	if string(call[0].ParentSpanId) != string(message[0].SpanId) {
+		t.Fatal("expected the call to hang off the message it answers")
+	}
+	if call[0].StartTimeUnixNano < message[0].StartTimeUnixNano {
+		t.Fatal("expected the call not to open before the message it answers")
 	}
 }


### PR DESCRIPTION
Two defects in the codex event translation, both visible in the run view: every `llm.call` arrived with no token usage, and the call sorted before the message it answers.

**Counts were dropped.** Codex completes a response *twice* — once to end the stream, and again carrying the token counts. The first completion took the pending call and had nothing to add, so the counts arrived to find it already spent. The call is now taken only by a completion that actually carries counts.

**The call preceded its message.** Its start is derived by subtracting codex's reported `duration_ms` from the moment the request finished, which lands earlier than the prompt was stamped — observed 84ms before. It now hangs off the message as its parent, so the view reads in the order things happened rather than trusting arithmetic across two clocks, and a call cannot open before the message it answers.

Still absent, and not fixable here: prompt context and response text. Codex's event stream carries neither — `response.output_text.delta` has only a duration. Those have to come from llm-proxy.