### PR TITLE
Receive turns from a tracing plugin

### DIFF
--- a/internal/tracingproxy/proxy.go
+++ b/internal/tracingproxy/proxy.go
@@ -2,6 +2,7 @@ package tracingproxy
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -33,6 +34,10 @@ const (
 	workloadIDAttributeKey = "agyn.workload.id"
 	maxHTTPExportBytes     = 32 << 20
 	maxLoggedValueBytes    = 400
+
+	// TurnsPath is where a tracing plugin posts the turns it read from the
+	// agent CLI's session transcript.
+	TurnsPath = "/agyn/v1/turns"
 )
 
 type Config struct {
@@ -115,6 +120,7 @@ func Start(ctx context.Context, cfg Config) (*Proxy, error) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /v1/traces", proxy.serveHTTPTraces)
 	mux.HandleFunc("POST /v1/logs", proxy.serveHTTPLogs)
+	mux.HandleFunc("POST "+TurnsPath, proxy.serveHTTPTurns)
 	proxy.httpServer = &http.Server{Handler: mux, ReadHeaderTimeout: 10 * time.Second}
 	go func() {
 		if err := proxy.httpServer.Serve(httpListener); err != nil && !errors.Is(err, http.ErrServerClosed) {
@@ -199,6 +205,55 @@ func (p *Proxy) serveHTTPLogs(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/x-protobuf")
 	_, _ = w.Write(encoded)
+}
+
+// serveHTTPTurns receives what a tracing plugin read from the agent CLI's
+// session transcript. Its own path rather than an OTLP one: a plugin posts
+// turns, not spans, and knowing how this platform models a trace is exactly
+// what it is spared.
+func (p *Proxy) serveHTTPTurns(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxHTTPExportBytes))
+	if err != nil {
+		http.Error(w, "read body", http.StatusBadRequest)
+		return
+	}
+	var request struct {
+		Turns []Turn `json:"turns"`
+	}
+	if err := json.Unmarshal(body, &request); err != nil {
+		http.Error(w, "decode turns", http.StatusBadRequest)
+		return
+	}
+
+	var spans []*tracev1.Span
+	for _, turn := range request.Turns {
+		turnSpans, err := p.spansFromTurn(turn)
+		if err != nil {
+			// One malformed turn does not discard the batch: a plugin reads a
+			// transcript it did not write, and the turns around it are intact.
+			log.Printf("tracing proxy: skip turn: %v", err)
+			continue
+		}
+		spans = append(spans, turnSpans...)
+	}
+	if len(spans) > 0 {
+		export := &collectortracev1.ExportTraceServiceRequest{
+			ResourceSpans: []*tracev1.ResourceSpans{{
+				ScopeSpans: []*tracev1.ScopeSpans{{
+					Scope: &commonv1.InstrumentationScope{Name: turnScopeName},
+					Spans: spans,
+				}},
+			}},
+		}
+		if _, err := p.Export(r.Context(), export); err != nil {
+			// The plugin is told, so it can leave the turn unrecorded and send
+			// it again rather than marking it delivered.
+			log.Printf("tracing proxy: export turn spans: %v", err)
+			http.Error(w, "export turns", http.StatusBadGateway)
+			return
+		}
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // logUntranslatedRecord reports an event no span was built from, so a codex

--- a/internal/tracingproxy/turn.go
+++ b/internal/tracingproxy/turn.go
@@ -1,0 +1,276 @@
+package tracingproxy
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
+	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
+)
+
+// A tracing plugin reads the agent CLI's session transcript and posts the turns
+// it finds here. The shape is the agent CLI's own vocabulary -- a turn, the
+// model steps it took, the tools each step called -- rather than spans, because
+// a plugin should not have to know how this platform models a trace.
+type Turn struct {
+	// Identifies the turn within its session, so a resumed session that replays
+	// the transcript lands on the spans it wrote before rather than beside them.
+	ID          string      `json:"id"`
+	SessionID   string      `json:"sessionId"`
+	StartedAt   time.Time   `json:"startedAt"`
+	EndedAt     time.Time   `json:"endedAt"`
+	Model       string      `json:"model"`
+	Provider    string      `json:"provider"`
+	UserInput   string      `json:"userInput"`
+	FinalOutput string      `json:"finalOutput"`
+	Steps       []ModelStep `json:"steps"`
+	Usage       *TokenUsage `json:"usage"`
+	// A turn the agent abandoned still describes what it did, so it is stored
+	// and marked rather than dropped.
+	Aborted bool   `json:"aborted"`
+	Error   string `json:"error"`
+	// Set on a subagent's turns, naming the turn that spawned it.
+	ParentTurnID string `json:"parentTurnId"`
+}
+
+type ModelStep struct {
+	StartedAt time.Time   `json:"startedAt"`
+	EndedAt   time.Time   `json:"endedAt"`
+	Reasoning string      `json:"reasoning"`
+	Text      string      `json:"text"`
+	Context   any         `json:"context"`
+	ToolCalls []ToolCall  `json:"toolCalls"`
+	Usage     *TokenUsage `json:"usage"`
+}
+
+type ToolCall struct {
+	CallID    string    `json:"callId"`
+	Name      string    `json:"name"`
+	Server    string    `json:"server"`
+	StartedAt time.Time `json:"startedAt"`
+	EndedAt   time.Time `json:"endedAt"`
+	Arguments any       `json:"arguments"`
+	Output    any       `json:"output"`
+	Error     string    `json:"error"`
+}
+
+type TokenUsage struct {
+	InputTokens     *int64 `json:"inputTokens"`
+	OutputTokens    *int64 `json:"outputTokens"`
+	CachedTokens    *int64 `json:"cachedTokens"`
+	ReasoningTokens *int64 `json:"reasoningTokens"`
+	TotalTokens     *int64 `json:"totalTokens"`
+}
+
+const (
+	spanToolExecution = "tool.execution"
+
+	// Names the spans a plugin's turn produced, as distinct from anything the
+	// agent CLI exported itself.
+	turnScopeName = "agynd.turn"
+)
+
+// spansFromTurn renders one turn as the spans the run view reads: the message
+// that opened it, a call per model step, and an execution per tool the step
+// invoked. Each hangs off the last, so the view reads the turn as it happened
+// rather than by sorting timestamps drawn from different clocks.
+func (p *Proxy) spansFromTurn(turn Turn) ([]*tracev1.Span, error) {
+	if turn.ID == "" {
+		return nil, fmt.Errorf("turn id is required")
+	}
+	if turn.StartedAt.IsZero() {
+		return nil, fmt.Errorf("turn %s has no start time", turn.ID)
+	}
+
+	traceID := traceIDForMessage(p.turnTraceSeed(turn))
+	messageID := turnSpanID(turn.ID, "message")
+
+	message := &tracev1.Span{
+		TraceId:           traceID,
+		SpanId:            messageID,
+		ParentSpanId:      parentTurnSpanID(turn),
+		Name:              spanInvocationMessage,
+		Kind:              tracev1.Span_SPAN_KIND_INTERNAL,
+		StartTimeUnixNano: uint64(turn.StartedAt.UnixNano()),
+		EndTimeUnixNano:   endOf(turn.EndedAt),
+		Attributes: []*commonv1.KeyValue{
+			stringAttr("agyn.message.role", "user"),
+			stringAttr("agyn.message.text", turn.UserInput),
+		},
+		Status: turnStatus(turn),
+	}
+	if turn.FinalOutput != "" {
+		message.Attributes = append(message.Attributes, stringAttr("agyn.llm.response_text", turn.FinalOutput))
+	}
+	if turn.SessionID != "" {
+		message.Attributes = append(message.Attributes, stringAttr("agyn.agent.session.id", turn.SessionID))
+	}
+	spans := []*tracev1.Span{message}
+
+	for i, step := range turn.Steps {
+		call := &tracev1.Span{
+			TraceId:           traceID,
+			SpanId:            turnSpanID(turn.ID, fmt.Sprintf("step.%d", i)),
+			ParentSpanId:      messageID,
+			Name:              spanLLMCall,
+			Kind:              tracev1.Span_SPAN_KIND_CLIENT,
+			StartTimeUnixNano: startOf(step.StartedAt, turn.StartedAt),
+			EndTimeUnixNano:   endOf(step.EndedAt),
+			Attributes: []*commonv1.KeyValue{
+				stringAttr("gen_ai.system", turn.Provider),
+				stringAttr("gen_ai.request.model", turn.Model),
+			},
+			Status: &tracev1.Status{Code: tracev1.Status_STATUS_CODE_OK},
+		}
+		// The context is what the model was shown, and is the reason tracing
+		// stores a turn at all -- without it a call records that it happened.
+		if step.Context != nil {
+			call.Attributes = append(call.Attributes, jsonAttr("agyn.llm.context", step.Context))
+		}
+		if step.Text != "" {
+			call.Attributes = append(call.Attributes, stringAttr("agyn.llm.response_text", step.Text))
+		}
+		if step.Reasoning != "" {
+			call.Attributes = append(call.Attributes, stringAttr("agyn.llm.reasoning", step.Reasoning))
+		}
+		call.Attributes = append(call.Attributes, usageAttrs(step.Usage)...)
+		spans = append(spans, call)
+
+		for j, tool := range step.ToolCalls {
+			spans = append(spans, toolSpan(traceID, call.SpanId, turn.ID, i, j, tool))
+		}
+	}
+
+	// A turn reports usage of its own when the transcript totals it rather than
+	// attributing it per step.
+	if len(turn.Steps) == 0 {
+		message.Attributes = append(message.Attributes, usageAttrs(turn.Usage)...)
+	}
+	return spans, nil
+}
+
+func toolSpan(traceID, parentID []byte, turnID string, step, index int, tool ToolCall) *tracev1.Span {
+	span := &tracev1.Span{
+		TraceId:           traceID,
+		SpanId:            turnSpanID(turnID, fmt.Sprintf("step.%d.tool.%d", step, index)),
+		ParentSpanId:      parentID,
+		Name:              spanToolExecution,
+		Kind:              tracev1.Span_SPAN_KIND_INTERNAL,
+		StartTimeUnixNano: uint64(tool.StartedAt.UnixNano()),
+		EndTimeUnixNano:   endOf(tool.EndedAt),
+		Attributes: []*commonv1.KeyValue{
+			stringAttr("agyn.tool.name", tool.Name),
+		},
+		Status: &tracev1.Status{Code: tracev1.Status_STATUS_CODE_OK},
+	}
+	if tool.StartedAt.IsZero() {
+		span.StartTimeUnixNano = 0
+	}
+	if tool.CallID != "" {
+		span.Attributes = append(span.Attributes, stringAttr("agyn.tool.call_id", tool.CallID))
+	}
+	if tool.Server != "" {
+		span.Attributes = append(span.Attributes, stringAttr("agyn.tool.server", tool.Server))
+	}
+	if tool.Arguments != nil {
+		span.Attributes = append(span.Attributes, jsonAttr("agyn.tool.input", tool.Arguments))
+	}
+	if tool.Output != nil {
+		span.Attributes = append(span.Attributes, jsonAttr("agyn.tool.output", tool.Output))
+	}
+	if tool.Error != "" {
+		span.Attributes = append(span.Attributes, stringAttr("agyn.tool.error", tool.Error))
+		span.Status = &tracev1.Status{Code: tracev1.Status_STATUS_CODE_ERROR, Message: tool.Error}
+	}
+	return span
+}
+
+// turnSpanID derives a span's id from the turn it belongs to rather than
+// drawing a new one. A plugin re-posting a turn -- a resumed session, a turn
+// that was in progress when it was first sent -- then writes the same span ids,
+// and ingest upserts them onto the rows already there instead of doubling them.
+func turnSpanID(turnID, part string) []byte {
+	sum := sha256.Sum256([]byte("agyn.span." + turnID + "." + part))
+	return sum[:8]
+}
+
+// A subagent's turns hang off the turn that spawned them, so the run view shows
+// the work a turn delegated as part of that turn.
+func parentTurnSpanID(turn Turn) []byte {
+	if turn.ParentTurnID == "" {
+		return nil
+	}
+	return turnSpanID(turn.ParentTurnID, "message")
+}
+
+// turnTraceSeed keeps a turn in the trace of the message being answered. A
+// sandbox has no message, so the session stands in and its turns still group.
+func (p *Proxy) turnTraceSeed(turn Turn) string {
+	if messageID := p.messageIDValue(); messageID != "" {
+		return messageID
+	}
+	return turn.SessionID
+}
+
+// Arguments, output and context are whatever the agent CLI recorded, so they
+// are carried as JSON rather than flattened into attributes that would differ
+// per tool.
+func jsonAttr(key string, value any) *commonv1.KeyValue {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return stringAttr(key, fmt.Sprintf("%v", value))
+	}
+	return stringAttr(key, string(encoded))
+}
+
+func turnStatus(turn Turn) *tracev1.Status {
+	switch {
+	case turn.Error != "":
+		return &tracev1.Status{Code: tracev1.Status_STATUS_CODE_ERROR, Message: turn.Error}
+	case turn.Aborted:
+		return &tracev1.Status{Code: tracev1.Status_STATUS_CODE_ERROR, Message: "turn aborted"}
+	default:
+		return &tracev1.Status{Code: tracev1.Status_STATUS_CODE_OK}
+	}
+}
+
+// A turn that has not ended is stored in progress: the run view shows it
+// running, and the plugin's next post completes it through the upsert.
+func endOf(at time.Time) uint64 {
+	if at.IsZero() {
+		return 0
+	}
+	return uint64(at.UnixNano())
+}
+
+func startOf(at, fallback time.Time) uint64 {
+	if at.IsZero() {
+		return uint64(fallback.UnixNano())
+	}
+	return uint64(at.UnixNano())
+}
+
+func usageAttrs(usage *TokenUsage) []*commonv1.KeyValue {
+	if usage == nil {
+		return nil
+	}
+	counts := []struct {
+		value *int64
+		key   string
+	}{
+		{usage.InputTokens, "gen_ai.usage.input_tokens"},
+		{usage.OutputTokens, "gen_ai.usage.output_tokens"},
+		{usage.CachedTokens, "gen_ai.usage.cache_read.input_tokens"},
+		{usage.ReasoningTokens, "agyn.usage.reasoning_tokens"},
+		{usage.TotalTokens, "gen_ai.usage.total_tokens"},
+	}
+	attrs := make([]*commonv1.KeyValue, 0, len(counts))
+	for _, count := range counts {
+		if count.value != nil {
+			attrs = append(attrs, intAttr(count.key, *count.value))
+		}
+	}
+	return attrs
+}

--- a/internal/tracingproxy/turn_test.go
+++ b/internal/tracingproxy/turn_test.go
@@ -1,0 +1,230 @@
+package tracingproxy
+
+import (
+	"testing"
+	"time"
+
+	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
+)
+
+func at(offsetMillis int) time.Time {
+	return time.Date(2026, 8, 9, 5, 0, 0, 0, time.UTC).Add(time.Duration(offsetMillis) * time.Millisecond)
+}
+
+func count(t *testing.T, spans []*tracev1.Span, name string) int {
+	t.Helper()
+	total := 0
+	for _, span := range spans {
+		if span.Name == name {
+			total++
+		}
+	}
+	return total
+}
+
+func spanNamed(t *testing.T, spans []*tracev1.Span, name string) *tracev1.Span {
+	t.Helper()
+	for _, span := range spans {
+		if span.Name == name {
+			return span
+		}
+	}
+	t.Fatalf("expected a %s span, got %d spans", name, len(spans))
+	return nil
+}
+
+func sampleTurn() Turn {
+	input, output := int64(8607), int64(11)
+	return Turn{
+		ID:          "turn-1",
+		SessionID:   "session-1",
+		StartedAt:   at(0),
+		EndedAt:     at(3000),
+		Model:       "gpt-5.5",
+		Provider:    "Agyn LLM",
+		UserInput:   "hello",
+		FinalOutput: "hi there",
+		Steps: []ModelStep{{
+			StartedAt: at(10),
+			EndedAt:   at(2000),
+			Text:      "hi there",
+			Context:   []map[string]string{{"role": "user", "content": "hello"}},
+			Usage:     &TokenUsage{InputTokens: &input, OutputTokens: &output},
+			ToolCalls: []ToolCall{{
+				CallID:    "call-1",
+				Name:      "shell",
+				StartedAt: at(100),
+				EndedAt:   at(900),
+				Arguments: map[string]any{"command": "ls"},
+				Output:    "a\nb",
+			}},
+		}},
+	}
+}
+
+func TestSpansFromTurnCarriesWhatTheModelSawAndSaid(t *testing.T) {
+	spans, err := (&Proxy{}).spansFromTurn(sampleTurn())
+	if err != nil {
+		t.Fatalf("spans from turn: %v", err)
+	}
+	if len(spans) != 3 {
+		t.Fatalf("expected message, call and tool, got %d spans", len(spans))
+	}
+
+	message := spanNamed(t, spans, spanInvocationMessage)
+	requireStringAttr(t, message, "agyn.message.text", "hello")
+	requireStringAttr(t, message, "agyn.llm.response_text", "hi there")
+
+	call := spanNamed(t, spans, spanLLMCall)
+	requireStringAttr(t, call, "gen_ai.request.model", "gpt-5.5")
+	// The context is the reason a turn is stored at all.
+	requireStringAttr(t, call, "agyn.llm.context", `[{"content":"hello","role":"user"}]`)
+	requireIntAttr(t, call, "gen_ai.usage.input_tokens", 8607)
+	requireIntAttr(t, call, "gen_ai.usage.output_tokens", 11)
+
+	tool := spanNamed(t, spans, spanToolExecution)
+	requireStringAttr(t, tool, "agyn.tool.name", "shell")
+	requireStringAttr(t, tool, "agyn.tool.input", `{"command":"ls"}`)
+	requireStringAttr(t, tool, "agyn.tool.output", `"a\nb"`)
+}
+
+// The view reads the turn as it happened rather than by sorting timestamps.
+func TestSpansFromTurnNestMessageCallTool(t *testing.T) {
+	spans, err := (&Proxy{}).spansFromTurn(sampleTurn())
+	if err != nil {
+		t.Fatalf("spans from turn: %v", err)
+	}
+	message := spanNamed(t, spans, spanInvocationMessage)
+	call := spanNamed(t, spans, spanLLMCall)
+	tool := spanNamed(t, spans, spanToolExecution)
+
+	if len(message.ParentSpanId) != 0 {
+		t.Fatal("expected the message to root the turn")
+	}
+	if string(call.ParentSpanId) != string(message.SpanId) {
+		t.Fatal("expected the call to hang off the message")
+	}
+	if string(tool.ParentSpanId) != string(call.SpanId) {
+		t.Fatal("expected the tool to hang off the call that invoked it")
+	}
+	for _, span := range spans {
+		if string(span.TraceId) != string(message.TraceId) {
+			t.Fatal("expected one trace for the turn")
+		}
+	}
+}
+
+// A resumed session replays the transcript, so the same turn must land on the
+// spans it wrote before rather than beside them.
+func TestSpansFromTurnAreStableAcrossReposts(t *testing.T) {
+	first, err := (&Proxy{}).spansFromTurn(sampleTurn())
+	if err != nil {
+		t.Fatalf("spans from turn: %v", err)
+	}
+	second, err := (&Proxy{}).spansFromTurn(sampleTurn())
+	if err != nil {
+		t.Fatalf("spans from turn: %v", err)
+	}
+	for i := range first {
+		if string(first[i].SpanId) != string(second[i].SpanId) {
+			t.Fatalf("span %d changed id between posts", i)
+		}
+		if string(first[i].TraceId) != string(second[i].TraceId) {
+			t.Fatalf("span %d changed trace between posts", i)
+		}
+	}
+}
+
+// A turn still running is stored in progress, and the plugin's next post
+// completes it through the upsert.
+func TestSpansFromTurnLeaveAnUnfinishedTurnInProgress(t *testing.T) {
+	turn := sampleTurn()
+	turn.EndedAt = time.Time{}
+	turn.Steps[0].EndedAt = time.Time{}
+
+	spans, err := (&Proxy{}).spansFromTurn(turn)
+	if err != nil {
+		t.Fatalf("spans from turn: %v", err)
+	}
+	if spanNamed(t, spans, spanInvocationMessage).EndTimeUnixNano != 0 {
+		t.Fatal("expected an unfinished turn to be in progress")
+	}
+	if spanNamed(t, spans, spanLLMCall).EndTimeUnixNano != 0 {
+		t.Fatal("expected an unfinished step to be in progress")
+	}
+}
+
+func TestSpansFromTurnMarksFailures(t *testing.T) {
+	turn := sampleTurn()
+	turn.Steps[0].ToolCalls[0].Error = "exit 1"
+	turn.Aborted = true
+
+	spans, err := (&Proxy{}).spansFromTurn(turn)
+	if err != nil {
+		t.Fatalf("spans from turn: %v", err)
+	}
+	if spanNamed(t, spans, spanInvocationMessage).Status.GetCode() != tracev1.Status_STATUS_CODE_ERROR {
+		t.Fatal("expected an aborted turn to be an error")
+	}
+	tool := spanNamed(t, spans, spanToolExecution)
+	if tool.Status.GetCode() != tracev1.Status_STATUS_CODE_ERROR {
+		t.Fatal("expected a failed tool call to be an error")
+	}
+	requireStringAttr(t, tool, "agyn.tool.error", "exit 1")
+}
+
+// A subagent's work belongs to the turn that delegated it.
+func TestSpansFromTurnNestSubagentUnderItsParent(t *testing.T) {
+	proxy := &Proxy{}
+	parent, err := proxy.spansFromTurn(sampleTurn())
+	if err != nil {
+		t.Fatalf("spans from turn: %v", err)
+	}
+	child, err := proxy.spansFromTurn(Turn{
+		ID:           "turn-2",
+		SessionID:    "session-1",
+		StartedAt:    at(200),
+		EndedAt:      at(800),
+		ParentTurnID: "turn-1",
+	})
+	if err != nil {
+		t.Fatalf("spans from subagent turn: %v", err)
+	}
+	if string(spanNamed(t, child, spanInvocationMessage).ParentSpanId) !=
+		string(spanNamed(t, parent, spanInvocationMessage).SpanId) {
+		t.Fatal("expected the subagent turn to hang off the turn that spawned it")
+	}
+}
+
+func TestSpansFromTurnRejectsATurnItCannotPlace(t *testing.T) {
+	if _, err := (&Proxy{}).spansFromTurn(Turn{StartedAt: at(0)}); err == nil {
+		t.Fatal("expected a turn with no id to be rejected")
+	}
+	if _, err := (&Proxy{}).spansFromTurn(Turn{ID: "turn-1"}); err == nil {
+		t.Fatal("expected a turn with no start time to be rejected")
+	}
+}
+
+func TestSpansFromTurnCountsStepsAndTools(t *testing.T) {
+	turn := sampleTurn()
+	turn.Steps = append(turn.Steps, ModelStep{
+		StartedAt: at(2100),
+		EndedAt:   at(2900),
+		Text:      "done",
+		ToolCalls: []ToolCall{
+			{CallID: "call-2", Name: "read", StartedAt: at(2200), EndedAt: at(2300)},
+			{CallID: "call-3", Name: "write", StartedAt: at(2400), EndedAt: at(2500)},
+		},
+	})
+
+	spans, err := (&Proxy{}).spansFromTurn(turn)
+	if err != nil {
+		t.Fatalf("spans from turn: %v", err)
+	}
+	if got := count(t, spans, spanLLMCall); got != 2 {
+		t.Fatalf("expected a call per step, got %d", got)
+	}
+	if got := count(t, spans, spanToolExecution); got != 3 {
+		t.Fatalf("expected an execution per tool call, got %d", got)
+	}
+}


### PR DESCRIPTION
First piece of [transcript-sourced tracing](https://github.com/agynio/architecture/pull/172): the contract a tracing plugin posts to.

What an agent did is in the session transcript the CLI writes, not the telemetry it exports — the export reports that a call happened, a prompt as a length, and tool calls not at all. A plugin reads the transcript and posts turns to `POST /agyn/v1/turns` on the tracing proxy.

**The contract is the agent CLI's vocabulary** — a turn, the model steps it took, the tools each step called — not spans. A plugin reads a transcript; it should not also have to know how this platform models a trace.

```
turn  → invocation.message   (prompt, final output)
step  → llm.call             (model, context, response, usage)
tool  → tool.execution       (name, input, output, error)
```

Notes:
- **Span ids derive from the turn id**, so a resumed session replaying the transcript writes the same ids and ingest upserts them. Same mechanism completes a turn first posted while running.
- A turn with no end time is stored **in progress**; the run view shows it as such.
- Message roots the turn, calls hang off it, tools off the call that invoked them — so the view reads the turn as it happened rather than sorting timestamps from different clocks. Subagent turns hang off the turn that spawned them.
- One malformed turn is skipped, not the batch. An export failure returns 502 so the plugin can retry rather than mark it delivered.

Nine tests cover nesting, id stability across reposts, in-progress turns, failures, and subagent parenting.

The plugins themselves come next; the OTLP log translation stays until they land.