### PR TITLE
Provision the agent CLI's first-run state, in holder mode too

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,7 +80,7 @@ func fromEnv(configPath string) (Config, error) {
 		return Config{}, err
 	}
 	if mode == ModeHolder {
-		return holderConfigFromEnv(), nil
+		return holderConfig(configPath)
 	}
 
 	agentID, err := uuidutil.ParseUUID(strings.TrimSpace(os.Getenv("AGENT_ID")), "AGENT_ID")
@@ -116,16 +116,7 @@ func fromEnv(configPath string) (Config, error) {
 		return Config{}, err
 	}
 	workloadID = workloadUUID.String()
-	llmBaseURL := strings.TrimSpace(os.Getenv("LLM_BASE_URL"))
-	if llmBaseURL == "" {
-		llmBaseURL = "http://llm-proxy.ziti:443/v1"
-	}
-	llmNative := strings.EqualFold(strings.TrimSpace(os.Getenv("LLM_MODE")), "native")
 	llmModelName := strings.TrimSpace(os.Getenv("LLM_MODEL_NAME"))
-	llmAPIToken := strings.TrimSpace(os.Getenv("LLM_API_TOKEN"))
-	if llmAPIToken == "" {
-		llmAPIToken = "platform"
-	}
 
 	mcpServers, err := parseMCPServers(os.Getenv("AGENT_MCP_SERVERS"))
 	if err != nil {
@@ -168,9 +159,9 @@ func fromEnv(configPath string) (Config, error) {
 		TracingAddress:  tracingAddress,
 		ThreadID:        threadID,
 		WorkloadID:      workloadID,
-		LLMBaseURL:      llmBaseURL,
-		LLMAPIToken:     llmAPIToken,
-		LLMNative:       llmNative,
+		LLMBaseURL:      llmBaseURLFromEnv(),
+		LLMAPIToken:     llmAPITokenFromEnv(),
+		LLMNative:       llmNativeFromEnv(),
 		LLMModelName:    llmModelName,
 		SDK:             sdk,
 		AgentBinary:     agentBinary,
@@ -193,16 +184,52 @@ func parseMode(raw string) (string, error) {
 	}
 }
 
-func holderConfigFromEnv() Config {
+// A sandbox prepares the agent CLI it will not spawn, so holder mode reads the
+// same LLM and MCP variables agent mode does.
+func holderConfig(configPath string) (Config, error) {
 	workDir := strings.TrimSpace(os.Getenv("WORKSPACE_DIR"))
 	if workDir == "" {
 		workDir = HolderDefaultWorkDir
 	}
-	return Config{
-		Mode:    ModeHolder,
-		SDK:     ModeHolder,
-		WorkDir: workDir,
+	mcpServers, err := parseMCPServers(os.Getenv("AGENT_MCP_SERVERS"))
+	if err != nil {
+		return Config{}, err
 	}
+	cfg := Config{
+		Mode:        ModeHolder,
+		SDK:         ModeHolder,
+		WorkDir:     workDir,
+		LLMBaseURL:  llmBaseURLFromEnv(),
+		LLMAPIToken: llmAPITokenFromEnv(),
+		LLMNative:   llmNativeFromEnv(),
+		MCPServers:  mcpServers,
+	}
+	// A workspace-only environment carries no CLI and so no config.json. There
+	// is nothing to prepare, which is not a failure.
+	if agentCfg, err := loadAgentConfig(configPath); err == nil {
+		if sdk := strings.TrimSpace(agentCfg.SDK); sdk != "" {
+			cfg.SDK = sdk
+		}
+	}
+	return cfg, nil
+}
+
+func llmBaseURLFromEnv() string {
+	if llmBaseURL := strings.TrimSpace(os.Getenv("LLM_BASE_URL")); llmBaseURL != "" {
+		return llmBaseURL
+	}
+	return "http://llm-proxy.ziti:443/v1"
+}
+
+func llmAPITokenFromEnv() string {
+	if token := strings.TrimSpace(os.Getenv("LLM_API_TOKEN")); token != "" {
+		return token
+	}
+	return "platform"
+}
+
+func llmNativeFromEnv() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("LLM_MODE")), "native")
 }
 
 func loadAgentConfig(path string) (agentConfig, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -545,3 +545,54 @@ func TestFromEnvInvalidMode(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+// A sandbox prepares the CLI it will not spawn, so holder mode reads what that
+// preparation needs -- including which CLI it is.
+func TestFromEnvHolderModeReadsAgentCLIAndLLMConfig(t *testing.T) {
+	configPath := writeAgentConfig(t, "claude", "bin/claude")
+	t.Setenv("AGYND_MODE", ModeHolder)
+	t.Setenv("LLM_BASE_URL", "http://llm-proxy.ziti:443/v1")
+	t.Setenv("LLM_MODE", "native")
+	t.Setenv("AGENT_MCP_SERVERS", "files:9100")
+
+	cfg, err := fromEnv(configPath)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if cfg.SDK != "claude" {
+		t.Fatalf("expected claude sdk, got %q", cfg.SDK)
+	}
+	if cfg.LLMBaseURL != "http://llm-proxy.ziti:443/v1" {
+		t.Fatalf("unexpected llm base url: %q", cfg.LLMBaseURL)
+	}
+	if !cfg.LLMNative {
+		t.Fatal("expected native mode")
+	}
+	if len(cfg.MCPServers) != 1 || cfg.MCPServers[0].Name != "files" {
+		t.Fatalf("unexpected mcp servers: %v", cfg.MCPServers)
+	}
+}
+
+// A workspace-only environment carries no CLI, and that is not a failure.
+func TestFromEnvHolderModeWithoutAgentConfig(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "missing-config.json")
+	t.Setenv("AGYND_MODE", ModeHolder)
+
+	cfg, err := fromEnv(configPath)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if cfg.SDK != ModeHolder {
+		t.Fatalf("expected holder sdk marker, got %q", cfg.SDK)
+	}
+}
+
+func TestFromEnvHolderModeRejectsMalformedMCPServers(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "missing-config.json")
+	t.Setenv("AGYND_MODE", ModeHolder)
+	t.Setenv("AGENT_MCP_SERVERS", "files")
+
+	if _, err := fromEnv(configPath); err == nil {
+		t.Fatal("expected error for malformed AGENT_MCP_SERVERS")
+	}
+}

--- a/internal/daemon/claudeconfig.go
+++ b/internal/daemon/claudeconfig.go
@@ -11,9 +11,13 @@ import (
 )
 
 type claudeSettings struct {
-	Permissions claudePermissions          `json:"permissions"`
-	Env         map[string]string          `json:"env"`
-	MCPServers  map[string]claudeMCPServer `json:"mcpServers,omitempty"`
+	Permissions claudePermissions `json:"permissions"`
+	// Without this the CLI downgrades bypassPermissions to the default mode and
+	// waits on its disclaimer, which no agent workload can answer.
+	SkipDangerousModePermissionPrompt bool                       `json:"skipDangerousModePermissionPrompt"`
+	Theme                             string                     `json:"theme"`
+	Env                               map[string]string          `json:"env"`
+	MCPServers                        map[string]claudeMCPServer `json:"mcpServers,omitempty"`
 }
 
 type claudePermissions struct {
@@ -62,6 +66,8 @@ func writeClaudeSettings(llmBaseURL, apiKey string, mcpServers []config.MCPServe
 			},
 			Deny: []string{},
 		},
+		SkipDangerousModePermissionPrompt: true,
+		Theme:                             "dark",
 		// Neither of these is endpoint or credential configuration, and both
 		// matter more in native mode than in platform mode: only the vendor's
 		// API host is intercepted, so any other call the CLI makes on its own

--- a/internal/daemon/claudeconfig_test.go
+++ b/internal/daemon/claudeconfig_test.go
@@ -51,6 +51,8 @@ func TestWriteClaudeSettings(t *testing.T) {
 			},
 			Deny: []string{},
 		},
+		SkipDangerousModePermissionPrompt: true,
+		Theme:                             "dark",
 		Env: map[string]string{
 			"ANTHROPIC_BASE_URL":                       baseURL,
 			"ANTHROPIC_API_KEY":                        apiKey,
@@ -108,6 +110,8 @@ func TestWriteClaudeSettingsWithMCPServers(t *testing.T) {
 			},
 			Deny: []string{},
 		},
+		SkipDangerousModePermissionPrompt: true,
+		Theme:                             "dark",
 		Env: map[string]string{
 			"ANTHROPIC_BASE_URL":                       baseURL,
 			"ANTHROPIC_API_KEY":                        apiKey,
@@ -164,5 +168,30 @@ func TestClaudeBaseURL(t *testing.T) {
 				t.Fatalf("expected %q, got %q", test.want, got)
 			}
 		})
+	}
+}
+
+// Without the disclaimer accepted the CLI downgrades bypassPermissions to the
+// default mode, so the permissions block alone does not survive contact.
+func TestWriteClaudeSettingsAcceptsTheBypassDisclaimer(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := writeClaudeSettings("http://llm-proxy.ziti:443", "platform", nil, false); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	var settings claudeSettings
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("parse settings: %v", err)
+	}
+	if !settings.SkipDangerousModePermissionPrompt {
+		t.Fatal("bypass disclaimer not accepted")
+	}
+	if settings.Theme == "" {
+		t.Fatal("theme not set")
 	}
 }

--- a/internal/daemon/claudestate.go
+++ b/internal/daemon/claudestate.go
@@ -1,0 +1,72 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+const claudeStateFileName = ".claude.json"
+
+// What the CLI must already believe about itself to start into work rather than
+// onboarding. Everything else in the file is its own. Theme and the bypass
+// disclaimer are settings.json keys, not state -- see writeClaudeSettings.
+var claudeStateKeys = map[string]any{
+	"hasCompletedOnboarding": true,
+	"installMethod":          "native",
+}
+
+// writeClaudeState merges the first-run keys into ~/.claude.json. The file is
+// the CLI's own state and accumulates across runs, so absent keys are set and
+// the rest is left as found -- unlike a placeholder credential, which is
+// skipped outright once a file exists.
+func writeClaudeState() error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolve home directory: %w", err)
+	}
+	path := filepath.Join(home, claudeStateFileName)
+	state, err := readClaudeState(path)
+	if err != nil {
+		return err
+	}
+	changed := false
+	for key, value := range claudeStateKeys {
+		if _, ok := state[key]; ok {
+			continue
+		}
+		state[key] = value
+		changed = true
+	}
+	if !changed {
+		return nil
+	}
+	payload, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal claude state: %w", err)
+	}
+	if err := os.WriteFile(path, payload, 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+// Unreadable state starts over rather than failing: the CLI rewrites this file
+// itself, and refusing to start over it would strand every workload.
+func readClaudeState(path string) (map[string]any, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return map[string]any{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	state := map[string]any{}
+	if err := json.Unmarshal(data, &state); err != nil {
+		log.Printf("%s is not a JSON object (%v); writing first-run state over it", path, err)
+		return map[string]any{}, nil
+	}
+	return state, nil
+}

--- a/internal/daemon/claudestate_test.go
+++ b/internal/daemon/claudestate_test.go
@@ -1,0 +1,117 @@
+package daemon
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func readState(t *testing.T, home string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(home, claudeStateFileName))
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	state := map[string]any{}
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatalf("parse state: %v", err)
+	}
+	return state
+}
+
+func TestWriteClaudeStateCreatesTheFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := writeClaudeState(); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	state := readState(t, home)
+	for key, want := range claudeStateKeys {
+		if state[key] != want {
+			t.Fatalf("%s = %v, want %v", key, state[key], want)
+		}
+	}
+}
+
+// The file is the CLI's own state and accumulates across runs, so the keys are
+// merged into whatever is already there.
+func TestWriteClaudeStateKeepsExistingKeys(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	existing := `{"numStartups":7,"projects":{"/workspace":{"allowedTools":["Bash"]}}}`
+	if err := os.WriteFile(filepath.Join(home, claudeStateFileName), []byte(existing), 0o600); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+
+	if err := writeClaudeState(); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	state := readState(t, home)
+	if state["numStartups"] != float64(7) {
+		t.Fatalf("numStartups = %v, want 7", state["numStartups"])
+	}
+	if _, ok := state["projects"].(map[string]any)["/workspace"]; !ok {
+		t.Fatalf("projects lost: %v", state["projects"])
+	}
+	if state["hasCompletedOnboarding"] != true {
+		t.Fatalf("hasCompletedOnboarding = %v", state["hasCompletedOnboarding"])
+	}
+}
+
+// A key the CLI already set is the CLI's answer, not ours to overrule.
+func TestWriteClaudeStateDoesNotOverwriteAKeyItSets(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.WriteFile(filepath.Join(home, claudeStateFileName), []byte(`{"installMethod":"brew"}`), 0o600); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+
+	if err := writeClaudeState(); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	if state := readState(t, home); state["installMethod"] != "brew" {
+		t.Fatalf("installMethod = %v, want brew", state["installMethod"])
+	}
+}
+
+// Refusing to start over an unreadable state file would strand every workload
+// carrying one.
+func TestWriteClaudeStateStartsOverOnUnparseableJSON(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.WriteFile(filepath.Join(home, claudeStateFileName), []byte("not json at all"), 0o600); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+
+	if err := writeClaudeState(); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	if state := readState(t, home); state["hasCompletedOnboarding"] != true {
+		t.Fatalf("hasCompletedOnboarding = %v", state["hasCompletedOnboarding"])
+	}
+}
+
+func TestWriteClaudeStateIsIdempotent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := writeClaudeState(); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	first, err := os.Stat(filepath.Join(home, claudeStateFileName))
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if err := writeClaudeState(); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+	second, err := os.Stat(filepath.Join(home, claudeStateFileName))
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if !first.ModTime().Equal(second.ModTime()) {
+		t.Fatal("rewrote a file that needed no change")
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -151,13 +151,11 @@ type platformSetup struct {
 }
 
 func New(ctx context.Context, cfg config.Config, version string) (*Daemon, error) {
+	if err := prepareAgentCLI(cfg); err != nil {
+		return nil, err
+	}
 	if cfg.Mode == config.ModeHolder {
 		return newHolderDaemon(cfg), nil
-	}
-	// Before any SDK is constructed: the CLI reads it at startup, and a shell
-	// exec'd into an agent workload finds it for the same reason holder does.
-	if err := writePlaceholderFile(); err != nil {
-		return nil, fmt.Errorf("write placeholder credential: %w", err)
 	}
 	switch cfg.SDK {
 	case SDKCodex:
@@ -175,6 +173,26 @@ func New(ctx context.Context, cfg config.Config, version string) (*Daemon, error
 	default:
 		return nil, fmt.Errorf("unknown sdk %q", cfg.SDK)
 	}
+}
+
+// prepareAgentCLI writes what the agent CLI needs on disk before anything runs
+// it -- in holder mode too, where nothing will except a person, by hand.
+func prepareAgentCLI(cfg config.Config) error {
+	if err := writePlaceholderFile(); err != nil {
+		return fmt.Errorf("write placeholder credential: %w", err)
+	}
+	if cfg.SDK != SDKClaude {
+		return nil
+	}
+	if err := writeClaudeState(); err != nil {
+		return err
+	}
+	// The agent path writes settings.json later instead, once the platform has
+	// resolved MCP ports into the config.
+	if cfg.Mode != config.ModeHolder {
+		return nil
+	}
+	return writeClaudeSettings(claudeBaseURL(cfg.LLMBaseURL), cfg.LLMAPIToken, cfg.MCPServers, cfg.LLMNative)
 }
 
 func newHolderDaemon(cfg config.Config) *Daemon {

--- a/internal/daemon/holder.go
+++ b/internal/daemon/holder.go
@@ -18,11 +18,6 @@ func runHolder(ctx context.Context, workDir string) error {
 	if err := holderChdir(workDir); err != nil {
 		return fmt.Errorf("set holder work dir %s: %w", workDir, err)
 	}
-	// Holder spawns nothing, but it is not inert: the file has to exist before
-	// an engineer opens a shell, which is the only session this mode serves.
-	if err := writePlaceholderFile(); err != nil {
-		return fmt.Errorf("write placeholder credential: %w", err)
-	}
 	log.Printf("agynd holder mode started in %s", workDir)
 	<-ctx.Done()
 	return operationError(opProcessSignalShutdown, 0, ctx.Err())

--- a/internal/daemon/prepare_test.go
+++ b/internal/daemon/prepare_test.go
@@ -1,0 +1,103 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/agynio/agynd-cli/internal/config"
+)
+
+// A sandbox spawns no agent CLI, but it is the workload a person starts one
+// inside by hand -- so it is the only one where an unprepared CLI stops to ask
+// a question.
+func TestHolderModePreparesTheAgentCLI(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfg := config.Config{
+		Mode:       config.ModeHolder,
+		SDK:        SDKClaude,
+		WorkDir:    t.TempDir(),
+		LLMBaseURL: "http://llm-proxy.ziti:443/v1",
+		MCPServers: []config.MCPServer{{Name: "files", Port: 9100}},
+	}
+	if _, err := New(context.Background(), cfg, "test"); err != nil {
+		t.Fatalf("new holder daemon: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(home, claudeStateFileName)); err != nil {
+		t.Fatalf("first-run state not written: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+	if err != nil {
+		t.Fatalf("settings not written: %v", err)
+	}
+	var settings claudeSettings
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("parse settings: %v", err)
+	}
+	if settings.Permissions.DefaultMode != "bypassPermissions" {
+		t.Fatalf("defaultMode = %q", settings.Permissions.DefaultMode)
+	}
+	if _, ok := settings.MCPServers["files"]; !ok {
+		t.Fatalf("mcp wiring lost: %v", settings.MCPServers)
+	}
+}
+
+// An environment naming no agent runtime image carries no CLI to prepare.
+func TestHolderModeWithoutAnAgentCLIPreparesNothing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfg := config.Config{Mode: config.ModeHolder, SDK: config.ModeHolder, WorkDir: t.TempDir()}
+	if _, err := New(context.Background(), cfg, "test"); err != nil {
+		t.Fatalf("new holder daemon: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(home, claudeStateFileName)); !os.IsNotExist(err) {
+		t.Fatalf("wrote state for a workload with no CLI: %v", err)
+	}
+}
+
+// The agent path writes settings.json only after the platform has resolved MCP
+// ports, so preparation leaves it alone and writes the state file it can.
+func TestAgentModePreparesStateButDefersSettings(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfg := config.Config{Mode: config.ModeAgent, SDK: SDKClaude, LLMBaseURL: "http://llm-proxy.ziti:443/v1"}
+	if err := prepareAgentCLI(cfg); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(home, claudeStateFileName)); err != nil {
+		t.Fatalf("first-run state not written: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".claude", "settings.json")); !os.IsNotExist(err) {
+		t.Fatalf("wrote settings before MCP resolution: %v", err)
+	}
+}
+
+// Codex reads a placeholder credential from a file, not a first-run flag.
+func TestPrepareWritesThePlaceholderForEveryCLI(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(placeholderFilePathEnv, ".codex/auth.json")
+	t.Setenv(placeholderFileContentsEnv, "placeholder")
+
+	cfg := config.Config{Mode: config.ModeHolder, SDK: SDKCodex, WorkDir: t.TempDir()}
+	if err := prepareAgentCLI(cfg); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(home, ".codex", "auth.json")); err != nil {
+		t.Fatalf("placeholder not written: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, claudeStateFileName)); !os.IsNotExist(err) {
+		t.Fatalf("wrote Claude state for a Codex workload: %v", err)
+	}
+}


### PR DESCRIPTION
Implements [architecture#173](https://github.com/agynio/architecture/pull/173).

Claude Code keeps a first-run state file at `~/.claude.json`, separate from the `~/.claude/settings.json` `agynd` already writes. Without `hasCompletedOnboarding` the CLI opens onboarding and waits for an answer nobody gives.

`agynd` is the component that can write it: the path is CLI-specific and resolves against `HOME`, which the platform does not manage and the orchestrator cannot compute. It is merged rather than replaced — the file is the CLI's own state (run counts, project history, tool approvals), so absent keys are set and the rest is left alone. That differs deliberately from the file placeholder, which is skipped once a file exists because there an existing file may be a real credential.

### Holder mode

A sandbox spawns no agent CLI, but it is the workload a person starts one inside by hand — so it is the only one where an interactive gate actually stops anyone. Preparation now runs ahead of the holder branch in `New`, so the state file, the file placeholder and `settings.json` all land regardless. `holderConfig` learns the LLM and MCP variables and reads `config.json` for the CLI, tolerating its absence in a workspace-only environment.

`settings.json` still goes out on the agent path from `newClaudeDaemon`, because it needs MCP ports the platform resolves first.

### The bypass disclaimer

Verified against the CLI binary shipped in the runtime image: `bypassPermissions` carries a one-time disclaimer, and a CLI that has not seen it accepted **downgrades the mode to the default** instead of refusing — `"Permission mode downgraded to default — bypass requires ..."`. So the `permissions` block we already write has been buying nothing and tools have been stopping for approval. `skipDangerousModePermissionPrompt: true` in `settings.json` is what `u7()` reads; the older `.claude.json` key is migrated into it by the CLI itself, so it is set in the file that owns it.

Key choices are from the binary, not guesswork: `!hasCompletedOnboarding` is the whole onboarding gate (`lastOnboardingVersion` is written but never read as one), and `theme` is a settings key rather than state.