### PR TITLE
Declare the hook where codex trusts it, and name the thread Tracing verifies

### DIFF
--- a/internal/daemon/codexconfig.go
+++ b/internal/daemon/codexconfig.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"log"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -20,7 +21,7 @@ import (
 // vendor. Tracing and the mcp_servers appended below are unaffected.
 const codexNativeConfigTemplate = `approval_policy = "never"
 sandbox_mode = "danger-full-access"
-` + codexHookTemplate
+`
 
 // traceHookCommand is the platform's trace hook, delivered to /agyn/bin beside
 // agynd and reached by name because that directory is on the agent's PATH.
@@ -38,12 +39,22 @@ const (
 // codexHookTemplate runs the platform's trace hook when a turn completes.
 // Codex hands it the rollout path, which is the record of what the turn
 // actually did -- its telemetry reports only that a call happened.
-const codexHookTemplate = `
-[[hooks.Stop]]
+//
+// It is written to the system config rather than the user one. Codex registers
+// a hook only when it is managed or carries a trust hash matching its contents,
+// and a hook declared in the user config is neither: it is discovered, found
+// untrusted, and dropped without a word. Only the system layer is managed, and
+// the flag that would bypass the check is a CLI argument the app-server
+// subcommand does not accept.
+const codexHookTemplate = `[[hooks.Stop]]
 [[hooks.Stop.hooks]]
 type = "command"
 command = "` + traceHookCommand + `"
 `
+
+// The system config layer, which is what makes a hook declared in it managed.
+// A variable so a test can write somewhere it is allowed to.
+var codexSystemConfigPath = "/etc/codex/config.toml"
 
 const codexConfigTemplate = `model_provider = "platform"
 approval_policy = "never"
@@ -56,7 +67,7 @@ base_url = %q
 request_max_retries = 0
 stream_max_retries = 0
 supports_websockets = false
-` + codexHookTemplate
+`
 
 const codexAPIKeyEnv = `env_key = "OPENAI_API_KEY"
 `
@@ -114,7 +125,22 @@ func writeCodexConfig(cfg config.Config) (string, error) {
 	if err := os.WriteFile(configPath, []byte(payload), 0o600); err != nil {
 		return "", fmt.Errorf("write codex config: %w", err)
 	}
+	if err := writeCodexSystemConfig(); err != nil {
+		// Tracing is optional: an agent that cannot be traced still answers.
+		log.Printf("tracing: register trace hook: %v", err)
+	}
 	return codexHome, nil
+}
+
+// writeCodexSystemConfig declares the trace hook where codex will trust it.
+func writeCodexSystemConfig() error {
+	if err := os.MkdirAll(filepath.Dir(codexSystemConfigPath), 0o755); err != nil {
+		return fmt.Errorf("create codex system config dir: %w", err)
+	}
+	if err := os.WriteFile(codexSystemConfigPath, []byte(codexHookTemplate), 0o644); err != nil {
+		return fmt.Errorf("write codex system config: %w", err)
+	}
+	return nil
 }
 
 func codexPlatformConfig(llmBaseURL string) string {

--- a/internal/daemon/codexconfig_test.go
+++ b/internal/daemon/codexconfig_test.go
@@ -397,5 +397,53 @@ base_url = %q
 request_max_retries = 0
 stream_max_retries = 0
 supports_websockets = false
-`+codexHookTemplate, baseURL, apiKeyEnv)
+`, baseURL, apiKeyEnv)
+}
+
+// Codex registers a hook only when it is managed or carries a matching trust
+// hash. The system layer is the managed one, so a hook written anywhere else is
+// discovered, found untrusted and dropped in silence.
+func TestWriteCodexConfigRegistersTheHookWhereCodexTrustsIt(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	systemConfig := filepath.Join(t.TempDir(), "etc", "codex", "config.toml")
+	original := codexSystemConfigPath
+	codexSystemConfigPath = systemConfig
+	t.Cleanup(func() { codexSystemConfigPath = original })
+
+	if _, err := writeCodexConfig(config.Config{LLMBaseURL: "https://example.com"}); err != nil {
+		t.Fatalf("expected config to be written, got %v", err)
+	}
+
+	content, err := os.ReadFile(systemConfig)
+	if err != nil {
+		t.Fatalf("expected the system config to be readable, got %v", err)
+	}
+	if string(content) != codexHookTemplate {
+		t.Fatalf("expected the hook in the system config, got %q", string(content))
+	}
+	// The user config is not a layer codex trusts hooks from, so declaring it
+	// there as well would be a second untrusted copy rather than a fallback.
+	userConfig, err := os.ReadFile(filepath.Join(tmpHome, ".codex", "config.toml"))
+	if err != nil {
+		t.Fatalf("expected the user config to be readable, got %v", err)
+	}
+	if strings.Contains(string(userConfig), "hooks.Stop") {
+		t.Fatal("expected no hook in the user config")
+	}
+}
+
+// Tracing is optional: an agent whose hook cannot be registered still answers.
+func TestWriteCodexConfigSurvivesAnUnwritableSystemConfig(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	original := codexSystemConfigPath
+	codexSystemConfigPath = filepath.Join(t.TempDir(), "file", "config.toml")
+	if err := os.WriteFile(filepath.Dir(filepath.Dir(codexSystemConfigPath))+"/file", nil, 0o600); err != nil {
+		t.Fatalf("seed an unwritable path: %v", err)
+	}
+	t.Cleanup(func() { codexSystemConfigPath = original })
+
+	if _, err := writeCodexConfig(config.Config{LLMBaseURL: "https://example.com"}); err != nil {
+		t.Fatalf("expected the config to be written anyway, got %v", err)
+	}
 }

--- a/internal/daemon/nativemode_test.go
+++ b/internal/daemon/nativemode_test.go
@@ -87,7 +87,9 @@ func TestCodexConfigNativeOmitsProvider(t *testing.T) {
 			t.Fatalf("native codex config carries %q:\n%s", forbidden, payload)
 		}
 	}
-	for _, required := range []string{"[mcp_servers.platform]", "approval_policy", "[[hooks.Stop]]"} {
+	// The hook lives in the system config, not this one -- it is the only layer
+	// codex trusts a hook from.
+	for _, required := range []string{"[mcp_servers.platform]", "approval_policy"} {
 		if !strings.Contains(payload, required) {
 			t.Fatalf("native codex config lost %q:\n%s", required, payload)
 		}

--- a/internal/tracing/exporter.go
+++ b/internal/tracing/exporter.go
@@ -28,6 +28,7 @@ const (
 
 	spanInvocationMessage = "invocation.message"
 
+	threadIDAttributeKey   = "agyn.thread.id"
 	messageIDAttributeKey  = "agyn.thread.message.id"
 	workloadIDAttributeKey = "agyn.workload.id"
 )
@@ -122,11 +123,15 @@ func (e *Exporter) InvocationMessage(ctx context.Context, message Message) error
 	return err
 }
 
-// The message is the one attribution a producer asserts. The thread it belongs
-// to is resolved from it, and the identity the connection carries settles the
-// rest.
+// The message and the thread it came from are both asserted. Tracing authorizes
+// the message against its thread before storing it, so a message named without
+// one is rejected rather than stored unverified. A workload is not thread-scoped
+// -- but the item that opened a turn is, and this is the producer that knows it.
 func (e *Exporter) resourceAttributes(message Message) []*commonv1.KeyValue {
 	attrs := []*commonv1.KeyValue{stringAttr(messageIDAttributeKey, message.ID)}
+	if message.ThreadID != "" {
+		attrs = append(attrs, stringAttr(threadIDAttributeKey, message.ThreadID))
+	}
 	if e.workloadID != "" {
 		attrs = append(attrs, stringAttr(workloadIDAttributeKey, e.workloadID))
 	}

--- a/internal/tracing/exporter_test.go
+++ b/internal/tracing/exporter_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/agynio/agynd-cli/internal/transcript"
+
 	collectortracev1 "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
 	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
@@ -87,16 +89,35 @@ func TestInvocationMessageCarriesTheMessageAndItsAttribution(t *testing.T) {
 	if attr(span.Attributes, "agyn.message.text") != "hello" {
 		t.Fatal("expected the message body on the span")
 	}
-	// The message is the one attribution a producer asserts; the thread is
-	// resolved from it and the identity settles the rest.
+	// The message and its thread are both asserted: Tracing authorizes the one
+	// against the other before storing it, and rejects a message named without
+	// a thread.
 	if got := attr(resource, messageIDAttributeKey); got != "message-1" {
 		t.Fatalf("expected the message id as a resource attribute, got %q", got)
 	}
 	if got := attr(resource, workloadIDAttributeKey); got != "workload-1" {
 		t.Fatalf("expected the workload id as a resource attribute, got %q", got)
 	}
-	if attr(resource, "agyn.thread.id") != "" {
-		t.Fatal("expected no thread attribution: an instance serves an inbox drawn from many threads")
+	if got := attr(resource, threadIDAttributeKey); got != "thread-1" {
+		t.Fatalf("expected the thread id alongside the message, got %q", got)
+	}
+}
+
+// A turn read from a transcript names the message the agent CLI was handed, not
+// one this process was told about, so the hook's spans assert neither.
+func TestTurnsAssertNoMessageOrThread(t *testing.T) {
+	exporter, service := startExporter(t, "workload-1")
+
+	if err := exporter.Turns(context.Background(), []transcript.Turn{sampleTurn()}); err != nil {
+		t.Fatalf("expected the turn to export, got %v", err)
+	}
+
+	resource := service.requests[0].ResourceSpans[0].Resource.GetAttributes()
+	if attr(resource, messageIDAttributeKey) != "" || attr(resource, threadIDAttributeKey) != "" {
+		t.Fatal("expected the hook to assert only its workload")
+	}
+	if got := attr(resource, workloadIDAttributeKey); got != "workload-1" {
+		t.Fatalf("expected the workload id, got %q", got)
 	}
 }
 


### PR DESCRIPTION
Two reasons a traced turn produced nothing, both found on a real workload running agynd 0.17.0 and codex 0.147.0.

## The hook was never run

`agynd-trace-hook` was on the PATH, `config.toml` declared it, the env was right, and running it by hand exported correctly and wrote its sidecar. Codex simply never invoked it.

Codex registers a handler only if it is **managed** or carries a **trust hash matching its contents** (`engine/discovery.rs`): a hook declared in the user config is neither, so it is discovered, marked `Untrusted`, and dropped without a warning. `hook_metadata_for_config_layer_source` makes only the System, MDM and managed layers trusted; `User` and `Project` are not. The escape hatch — `--dangerously-bypass-hook-trust`, whose own help says "intended only for automation that already vets hook sources" — is a CLI argument that the `app-server` subcommand does not accept.

So the hook moves to `/etc/codex/config.toml`, the system layer, which is managed by definition. Writing it is best-effort: an agent whose hook cannot be registered still answers.

## The invocation message was rejected

`InvalidArgument: thread id is required for message verification`. Tracing authorizes a message against its thread before storing it, so a message named without one is refused — the span never landed.

The spec says no producer asserts a thread, and for the hook that is right: a workload serves an inbox drawn from many threads. But the item that *opened* a turn is thread-scoped, and agynd is the producer that knows which. It already carried `ThreadID` on the message and simply never put it on the resource.

A test asserted the wrong half of this — that no thread is attributed — and is inverted, with a new one pinning that the hook's own spans still assert only their workload.