### PR TITLE
Export what the model was shown, and the calls it made

### DIFF
--- a/internal/tracing/exporter.go
+++ b/internal/tracing/exporter.go
@@ -158,6 +158,61 @@ func SpanID(subject, part string) []byte {
 	return sum[:8]
 }
 
+// The platform proxies one vendor's wire protocol, which is what a reader is
+// being told here -- not which model answered.
+const llmSystem = "openai"
+
+// contextEvents renders what the model was shown, in order.
+func contextEvents(context []transcript.ContextItem) []*tracev1.Span_Event {
+	if len(context) == 0 {
+		return nil
+	}
+	events := make([]*tracev1.Span_Event, 0, len(context))
+	for _, item := range context {
+		attrs := []*commonv1.KeyValue{
+			stringAttr("agyn.context.role", firstNonEmpty(item.Role, "other")),
+			stringAttr("agyn.context.is_new", boolText(item.IsNew)),
+			intAttr("agyn.context.size_bytes", item.SizeBytes()),
+		}
+		if item.Text != "" {
+			attrs = append(attrs, stringAttr("agyn.context.text", item.Text))
+		}
+		if item.JSON != nil {
+			attrs = append(attrs, jsonAttr("agyn.context.content_json", item.JSON))
+		}
+		events = append(events, &tracev1.Span_Event{
+			Name:         eventLLMContextItem,
+			TimeUnixNano: instant(item.At, time.Time{}),
+			Attributes:   attrs,
+		})
+	}
+	return events
+}
+
+// The reader parses this as a list of call_id and name, so it is written in the
+// shape it is read in rather than the shape the transcript held.
+func toolCallsAttr(calls []transcript.ToolCall) *commonv1.KeyValue {
+	if len(calls) == 0 {
+		return nil
+	}
+	payload := make([]map[string]any, 0, len(calls))
+	for _, call := range calls {
+		payload = append(payload, map[string]any{
+			"call_id":   call.CallID,
+			"name":      call.Name,
+			"arguments": call.Arguments,
+		})
+	}
+	return jsonAttr("agyn.llm.tool_calls", payload)
+}
+
+func boolText(value bool) string {
+	if value {
+		return "true"
+	}
+	return "false"
+}
+
 func stringAttr(key, value string) *commonv1.KeyValue {
 	return &commonv1.KeyValue{
 		Key:   key,
@@ -168,6 +223,8 @@ func stringAttr(key, value string) *commonv1.KeyValue {
 const (
 	spanLLMCall       = "llm.call"
 	spanToolExecution = "tool.execution"
+
+	eventLLMContextItem = "agyn.llm.context_item"
 )
 
 // Turns exports what the agent CLI did. A call hangs off the message that
@@ -219,11 +276,18 @@ func (e *Exporter) turnSpans(traceID []byte, turn transcript.Turn) []*tracev1.Sp
 			EndTimeUnixNano:   instant(step.EndedAt, time.Time{}),
 			Attributes: []*commonv1.KeyValue{
 				stringAttr("gen_ai.request.model", firstNonEmpty(step.Model, turn.Model)),
+				stringAttr("gen_ai.system", llmSystem),
 			},
+			// What the model was shown is one event per item rather than one
+			// attribute: a reader pages through a context, and an attribute
+			// carrying a whole conversation cannot be paged.
+			Events: contextEvents(step.Context),
 			Status: &tracev1.Status{Code: tracev1.Status_STATUS_CODE_OK},
 		}
-		if step.Context != nil {
-			call.Attributes = append(call.Attributes, jsonAttr("agyn.llm.context", step.Context))
+		// The calls a turn made belong on the call that made them as well as on
+		// their own spans: a step that only called tools says nothing otherwise.
+		if calls := toolCallsAttr(step.ToolCalls); calls != nil {
+			call.Attributes = append(call.Attributes, calls)
 		}
 		if step.Text != "" {
 			call.Attributes = append(call.Attributes, stringAttr("agyn.llm.response_text", step.Text))

--- a/internal/tracing/turns_test.go
+++ b/internal/tracing/turns_test.go
@@ -253,3 +253,68 @@ func TestExportingNoTurnsSendsNothing(t *testing.T) {
 		t.Fatalf("expected no export, got %d", len(service.requests))
 	}
 }
+
+// The context is what the run view pages through, and it is read from events
+// rather than an attribute -- an attribute carrying a whole conversation cannot
+// be paged.
+func TestCallCarriesWhatTheModelWasShown(t *testing.T) {
+	exporter, service := startExporter(t, "workload-1")
+	turn := sampleTurn()
+	at := turn.StartedAt
+	turn.Steps[0].Context = []transcript.ContextItem{
+		{Role: "user", Text: "list the files", IsNew: false, At: at},
+		{Role: "tool", JSON: map[string]any{"out": "a"}, IsNew: true, At: at.Add(time.Second)},
+	}
+
+	if err := exporter.Turns(context.Background(), []transcript.Turn{turn}); err != nil {
+		t.Fatalf("expected the turn to export, got %v", err)
+	}
+
+	call := spanNamed(t, exportedSpans(t, service), spanLLMCall)
+	if len(call.Events) != 2 {
+		t.Fatalf("expected one event per context item, got %d", len(call.Events))
+	}
+	if call.Events[0].Name != eventLLMContextItem {
+		t.Fatalf("expected %q, got %q", eventLLMContextItem, call.Events[0].Name)
+	}
+	if got := attr(call.Events[0].Attributes, "agyn.context.role"); got != "user" {
+		t.Fatalf("expected the role, got %q", got)
+	}
+	if got := attr(call.Events[0].Attributes, "agyn.context.text"); got != "list the files" {
+		t.Fatalf("expected the text, got %q", got)
+	}
+	// Read as a string, not a bool: that is the shape the reader parses.
+	if got := attr(call.Events[0].Attributes, "agyn.context.is_new"); got != "false" {
+		t.Fatalf("expected carried-over to be false, got %q", got)
+	}
+	if got := intAttrValue(call.Events[0].Attributes, "agyn.context.size_bytes"); got != 14 {
+		t.Fatalf("expected the size, got %d", got)
+	}
+	if got := attr(call.Events[1].Attributes, "agyn.context.is_new"); got != "true" {
+		t.Fatalf("expected the added item to be new, got %q", got)
+	}
+	if got := attr(call.Events[1].Attributes, "agyn.context.content_json"); got != `{"out":"a"}` {
+		t.Fatalf("expected structured content as JSON, got %q", got)
+	}
+}
+
+// A step that only called tools says nothing at all unless the calls are on it:
+// the reader lists them from the call, not from the executions beneath it.
+func TestCallListsTheToolsItCalled(t *testing.T) {
+	exporter, service := startExporter(t, "workload-1")
+
+	if err := exporter.Turns(context.Background(), []transcript.Turn{sampleTurn()}); err != nil {
+		t.Fatalf("expected the turn to export, got %v", err)
+	}
+
+	call := spanNamed(t, exportedSpans(t, service), spanLLMCall)
+	got := attr(call.Attributes, "agyn.llm.tool_calls")
+	// call_id and name are the two fields the reader requires of each entry.
+	want := `[{"arguments":{"command":"ls"},"call_id":"call-1","name":"shell"}]`
+	if got != want {
+		t.Fatalf("expected %s, got %s", want, got)
+	}
+	if got := attr(call.Attributes, "gen_ai.system"); got != llmSystem {
+		t.Fatalf("expected the system, got %q", got)
+	}
+}

--- a/internal/transcript/claude.go
+++ b/internal/transcript/claude.go
@@ -54,6 +54,7 @@ func parseClaude(data []byte) ([]Turn, error) {
 	// A tool's output arrives on a later line than the call, so calls are held
 	// by id until it does.
 	pending := map[string]*ToolCall{}
+	seen := &history{}
 
 	scanner := bufio.NewScanner(bytes.NewReader(data))
 	scanner.Buffer(make([]byte, 0, 64*1024), maxTranscriptLine)
@@ -68,15 +69,16 @@ func parseClaude(data []byte) ([]Turn, error) {
 		switch line.Type {
 		case "user":
 			if text, ok := claudeText(line.Message.Content); ok {
+				seen.add(ContextItem{Role: "user", Text: text, At: line.Timestamp})
 				current = closeAndOpen(&turns, current, line, text)
 				continue
 			}
-			applyToolResults(line, pending)
+			applyToolResults(line, pending, seen)
 		case "assistant":
 			if current == nil {
 				continue
 			}
-			appendAssistant(current, line, pending)
+			appendAssistant(current, line, pending, seen)
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -104,12 +106,12 @@ func closeAndOpen(turns *[]Turn, current *Turn, line claudeLine, text string) *T
 // Claude streams one response as several lines sharing a message id. They are
 // one model step, so the text is joined and the usage taken at its highest
 // rather than counted once per line.
-func appendAssistant(turn *Turn, line claudeLine, pending map[string]*ToolCall) {
+func appendAssistant(turn *Turn, line claudeLine, pending map[string]*ToolCall, seen *history) {
 	stepID := line.Message.ID
 	if stepID == "" {
 		stepID = line.RequestID
 	}
-	step := stepByID(turn, stepID, line)
+	step := stepByID(turn, stepID, line, seen)
 
 	var blocks []claudeBlock
 	if err := json.Unmarshal(line.Message.Content, &blocks); err != nil {
@@ -120,8 +122,10 @@ func appendAssistant(turn *Turn, line claudeLine, pending map[string]*ToolCall) 
 		case "text":
 			step.Text = joinText(step.Text, block.Text)
 			turn.FinalOutput = joinText(turn.FinalOutput, block.Text)
+			seen.add(ContextItem{Role: "assistant", Text: block.Text, At: line.Timestamp})
 		case "thinking":
 			step.Reasoning = joinText(step.Reasoning, block.Text)
+			seen.add(ContextItem{Role: "assistant", Text: block.Text, At: line.Timestamp})
 		case "tool_use":
 			call := ToolCall{
 				CallID:    block.ID,
@@ -131,6 +135,7 @@ func appendAssistant(turn *Turn, line claudeLine, pending map[string]*ToolCall) 
 			}
 			step.ToolCalls = append(step.ToolCalls, call)
 			pending[block.ID] = &step.ToolCalls[len(step.ToolCalls)-1]
+			seen.add(ContextItem{Role: "assistant", Text: block.Name, JSON: call.Arguments, At: line.Timestamp})
 		}
 	}
 	step.EndedAt = line.Timestamp
@@ -142,7 +147,7 @@ func appendAssistant(turn *Turn, line claudeLine, pending map[string]*ToolCall) 
 	}
 }
 
-func stepByID(turn *Turn, id string, line claudeLine) *Step {
+func stepByID(turn *Turn, id string, line claudeLine, seen *history) *Step {
 	for i := range turn.Steps {
 		if turn.Steps[i].ID == id {
 			return &turn.Steps[i]
@@ -153,11 +158,14 @@ func stepByID(turn *Turn, id string, line claudeLine) *Step {
 		StartedAt: line.Timestamp,
 		EndedAt:   line.Timestamp,
 		Model:     line.Message.Model,
+		// Taken when the step opens: what the model was shown is what stood
+		// before it answered.
+		Context: seen.snapshot(),
 	})
 	return &turn.Steps[len(turn.Steps)-1]
 }
 
-func applyToolResults(line claudeLine, pending map[string]*ToolCall) {
+func applyToolResults(line claudeLine, pending map[string]*ToolCall, seen *history) {
 	var blocks []claudeBlock
 	if err := json.Unmarshal(line.Message.Content, &blocks); err != nil {
 		return
@@ -175,6 +183,7 @@ func applyToolResults(line claudeLine, pending map[string]*ToolCall) {
 		if block.IsError {
 			call.Error = textOf(rawValue(block.Content))
 		}
+		seen.add(ContextItem{Role: "tool", JSON: call.Output, At: line.Timestamp})
 		delete(pending, block.ToolUseID)
 	}
 }

--- a/internal/transcript/codex.go
+++ b/internal/transcript/codex.go
@@ -71,6 +71,7 @@ func parseCodex(data []byte) ([]Turn, error) {
 	sessionID := ""
 	model := ""
 	pending := map[string]*ToolCall{}
+	seen := &history{}
 
 	scanner := bufio.NewScanner(bytes.NewReader(data))
 	scanner.Buffer(make([]byte, 0, 64*1024), maxTranscriptLine)
@@ -91,7 +92,7 @@ func parseCodex(data []byte) ([]Turn, error) {
 				model = context.Model
 			}
 		case "response_item":
-			current = applyCodexItem(&turns, current, line, sessionID, model, pending)
+			current = applyCodexItem(&turns, current, line, sessionID, model, pending, seen)
 		case "event_msg":
 			applyCodexUsage(current, line)
 		}
@@ -105,7 +106,7 @@ func parseCodex(data []byte) ([]Turn, error) {
 	return turns, nil
 }
 
-func applyCodexItem(turns *[]Turn, current *Turn, line codexLine, sessionID, model string, pending map[string]*ToolCall) *Turn {
+func applyCodexItem(turns *[]Turn, current *Turn, line codexLine, sessionID, model string, pending map[string]*ToolCall, seen *history) *Turn {
 	var item codexResponseItem
 	if err := json.Unmarshal(line.Payload, &item); err != nil {
 		return current
@@ -118,6 +119,7 @@ func applyCodexItem(turns *[]Turn, current *Turn, line codexLine, sessionID, mod
 		if current != nil {
 			*turns = append(*turns, *current)
 		}
+		seen.add(ContextItem{Role: "user", Text: codexText(item.Content), At: line.Timestamp})
 		return &Turn{
 			// The rollout has no turn id, so the moment it opened serves: it is
 			// stable across re-reads of the same file, which is what the span
@@ -132,15 +134,18 @@ func applyCodexItem(turns *[]Turn, current *Turn, line codexLine, sessionID, mod
 	if current == nil {
 		return nil
 	}
-	step := codexStep(current, line, model)
+	step := codexStep(current, line, model, seen)
 
 	switch item.Type {
 	case "message":
 		text := codexText(item.Content)
 		step.Text = joinText(step.Text, text)
 		current.FinalOutput = joinText(current.FinalOutput, text)
+		seen.add(ContextItem{Role: firstNonEmptyText(item.Role, "assistant"), Text: text, At: line.Timestamp})
 	case "reasoning":
-		step.Reasoning = joinText(step.Reasoning, codexText(item.Summary))
+		reasoning := codexText(item.Summary)
+		step.Reasoning = joinText(step.Reasoning, reasoning)
+		seen.add(ContextItem{Role: "assistant", Text: reasoning, At: line.Timestamp})
 	case "function_call", "local_shell_call", "custom_tool_call", "mcp_tool_call":
 		name := item.Name
 		if name == "" {
@@ -154,6 +159,7 @@ func applyCodexItem(turns *[]Turn, current *Turn, line codexLine, sessionID, mod
 			Arguments: nestedValue(item.Arguments),
 		})
 		pending[item.CallID] = &step.ToolCalls[len(step.ToolCalls)-1]
+		seen.add(ContextItem{Role: "assistant", Text: name, JSON: nestedValue(item.Arguments), At: line.Timestamp})
 	case "function_call_output", "custom_tool_call_output", "mcp_tool_call_output":
 		call, ok := pending[item.CallID]
 		if !ok {
@@ -161,6 +167,7 @@ func applyCodexItem(turns *[]Turn, current *Turn, line codexLine, sessionID, mod
 		}
 		call.EndedAt = line.Timestamp
 		call.Output = nestedValue(item.Output)
+		seen.add(ContextItem{Role: "tool", JSON: call.Output, At: line.Timestamp})
 		if item.Success != nil && !*item.Success {
 			call.Error = textOf(call.Output)
 		}
@@ -173,13 +180,16 @@ func applyCodexItem(turns *[]Turn, current *Turn, line codexLine, sessionID, mod
 
 // Codex does not delimit its model calls, so a turn's output is read as one
 // step. What it called and what it said belong to the same request either way.
-func codexStep(turn *Turn, line codexLine, model string) *Step {
+func codexStep(turn *Turn, line codexLine, model string, seen *history) *Step {
 	if len(turn.Steps) == 0 {
 		turn.Steps = append(turn.Steps, Step{
 			ID:        turn.ID + "@step",
 			StartedAt: line.Timestamp,
 			EndedAt:   line.Timestamp,
 			Model:     model,
+			// Taken when the step opens: what the model was shown is the
+			// conversation as it stood before it answered, not after.
+			Context: seen.snapshot(),
 		})
 	}
 	return &turn.Steps[len(turn.Steps)-1]

--- a/internal/transcript/codex_test.go
+++ b/internal/transcript/codex_test.go
@@ -1,6 +1,9 @@
 package transcript
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // Codex rollout lines: the session, the turn's model, a user message, a tool
 // call and its output, the model's reply, and the usage event that follows.
@@ -128,5 +131,59 @@ func TestCodexMarksAFailedToolCall(t *testing.T) {
 func TestParseRejectsAFormatItDoesNotKnow(t *testing.T) {
 	if _, err := Parse(Format("agn"), []byte("{}")); err == nil {
 		t.Fatal("expected an unknown format to be rejected")
+	}
+}
+
+// A call is worth storing because of what the model was shown. The context is
+// the conversation as it stood when the call was made, with what arrived since
+// the previous call marked as new.
+func TestCodexCarriesTheConversationAsContext(t *testing.T) {
+	turns, err := Parse(FormatCodex, []byte(strings.Join([]string{
+		`{"timestamp":"2026-08-09T05:00:00Z","type":"session_meta","payload":{"id":"session-1"}}`,
+		`{"timestamp":"2026-08-09T05:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"list the files"}]}}`,
+		`{"timestamp":"2026-08-09T05:00:02Z","type":"response_item","payload":{"type":"function_call","name":"shell","call_id":"call-1","arguments":"{\"cmd\":\"ls\"}"}}`,
+		`{"timestamp":"2026-08-09T05:00:03Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call-1","output":"a\nb"}}`,
+		`{"timestamp":"2026-08-09T05:00:10Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"and again"}]}}`,
+		`{"timestamp":"2026-08-09T05:00:11Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}}`,
+	}, "\n")))
+	if err != nil {
+		t.Fatalf("expected the rollout to parse, got %v", err)
+	}
+	if len(turns) != 2 {
+		t.Fatalf("expected two turns, got %d", len(turns))
+	}
+
+	first := turns[0].Steps[0].Context
+	if len(first) != 1 || first[0].Role != "user" || first[0].Text != "list the files" {
+		t.Fatalf("expected the prompt as the first call's context, got %#v", first)
+	}
+	if !first[0].IsNew {
+		t.Fatal("expected the prompt to be new to the first call")
+	}
+
+	// The second call sees everything the first one did, plus what happened in
+	// between. Only the prompt was on screen when the first call was made; the
+	// tool call, its output and the new prompt all arrived after it, so they are
+	// what changed.
+	second := turns[1].Steps[0].Context
+	if len(second) != 4 {
+		t.Fatalf("expected the conversation so far, got %d items", len(second))
+	}
+	if second[0].IsNew {
+		t.Fatal("expected the prompt the first call already saw to be carried over")
+	}
+	for _, item := range second[1:] {
+		if !item.IsNew {
+			t.Fatalf("expected what arrived after the first call to be new, got %#v", item)
+		}
+	}
+	if second[3].Text != "and again" {
+		t.Fatalf("expected the new prompt last, got %#v", second[3])
+	}
+	if second[1].Role != "assistant" || second[1].Text != "shell" {
+		t.Fatalf("expected the tool call in the context, got %#v", second[1])
+	}
+	if second[2].Role != "tool" {
+		t.Fatalf("expected the tool output in the context, got %#v", second[2])
 	}
 }

--- a/internal/transcript/transcript.go
+++ b/internal/transcript/transcript.go
@@ -41,11 +41,62 @@ type Step struct {
 	Model     string
 	Reasoning string
 	Text      string
-	// What the model was shown. The reason a turn is worth storing: without it
-	// a call records only that it happened.
-	Context   any
+	// What the model was shown, in order. The reason a turn is worth storing:
+	// without it a call records only that it happened.
+	Context   []ContextItem
 	ToolCalls []ToolCall
 	Usage     *Usage
+}
+
+// ContextItem is one thing the model was shown: a prompt, a reply it gave
+// earlier, a tool result it is now reading.
+type ContextItem struct {
+	Role string
+	Text string
+	// Set when the item is structured rather than prose -- a tool call's
+	// arguments, a tool's output.
+	JSON any
+	// False for what was carried over from an earlier call in the same session.
+	// A reader looking for what changed reads this rather than diffing.
+	IsNew bool
+	At    time.Time
+}
+
+// SizeBytes is what the item cost to send, which is what a reader comparing
+// calls is actually comparing.
+func (c ContextItem) SizeBytes() int64 {
+	if c.Text != "" {
+		return int64(len(c.Text))
+	}
+	return int64(len(textOf(c.JSON)))
+}
+
+// history accumulates what the session has shown the model, so a step can be
+// given the conversation as it stood when the model was called rather than the
+// fragment that belongs to that step alone.
+type history struct {
+	items []ContextItem
+	// Where the previous step ended, which is what makes the rest new.
+	sent int
+}
+
+func (h *history) add(item ContextItem) {
+	h.items = append(h.items, item)
+}
+
+// snapshot hands out the conversation so far, marking everything added since
+// the last snapshot as new.
+func (h *history) snapshot() []ContextItem {
+	if len(h.items) == 0 {
+		return nil
+	}
+	context := make([]ContextItem, len(h.items))
+	copy(context, h.items)
+	for i := range context {
+		context[i].IsNew = i >= h.sent
+	}
+	h.sent = len(h.items)
+	return context
 }
 
 type ToolCall struct {
@@ -130,6 +181,15 @@ func maxPtr(a, b *int64) *int64 {
 // A transcript line carries a whole prompt or a whole tool output, so the
 // scanner is given room a default one does not have.
 const maxTranscriptLine = 8 << 20
+
+func firstNonEmptyText(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
 
 func joinText(existing, addition string) string {
 	switch {


### PR DESCRIPTION
Three gaps in what a `llm.call` carries, found on a real traced run.

## Context was never populated, and was the wrong shape anyway

`Step.Context` was declared and exported, but **neither parser ever set it** — so `agyn.llm.context` was always absent. It was also an attribute, and the run view reads context from **`agyn.llm.context_item` span events** (`agyn.context.role`, `.text`, `.content_json`, `.is_new`, `.size_bytes`). An attribute holding a whole conversation cannot be paged, which is what the reader does.

Both parsers now accumulate the session as it unfolds, and a step is given the conversation as it stood when the model was called. Anything that arrived since the previous call is marked new, so a reader sees what changed rather than diffing two lists.

## A call that only used tools said nothing

The reader lists a call's tools from `agyn.llm.tool_calls` on the call itself, not from the executions beneath it. It was never emitted, so a step that called tools and wrote no text rendered empty. Now written in the shape the reader parses — `call_id`, `name`, `arguments`.

## The provider was blank

`gen_ai.system` was never set.

Tests cover the event shape (including `is_new` as the string the reader expects), the tool-call payload, and the context accumulating across calls within a session.

The empty **Command** box on codex exec spans is not from here — the span carries `{"cmd": ...}` correctly and the reader looked only for `command`. Fixed in agynio/tracing-app#57.