### PR TITLE
Carry the system prompt codex records at session start

### DIFF
--- a/internal/transcript/codex.go
+++ b/internal/transcript/codex.go
@@ -19,6 +19,13 @@ type codexLine struct {
 
 type codexSessionMeta struct {
 	ID string `json:"id"`
+	// What the model was told before anything else. Recorded once, on the line
+	// that opens the session, rather than repeated per turn.
+	BaseInstructions *codexBaseInstructions `json:"base_instructions"`
+}
+
+type codexBaseInstructions struct {
+	Text string `json:"text"`
 }
 
 type codexTurnContext struct {
@@ -85,6 +92,13 @@ func parseCodex(data []byte) ([]Turn, error) {
 			var meta codexSessionMeta
 			if json.Unmarshal(line.Payload, &meta) == nil {
 				sessionID = meta.ID
+				if meta.BaseInstructions != nil && meta.BaseInstructions.Text != "" {
+					seen.add(ContextItem{
+						Role: "system",
+						Text: meta.BaseInstructions.Text,
+						At:   line.Timestamp,
+					})
+				}
 			}
 		case "turn_context":
 			var context codexTurnContext

--- a/internal/transcript/codex_test.go
+++ b/internal/transcript/codex_test.go
@@ -187,3 +187,27 @@ func TestCodexCarriesTheConversationAsContext(t *testing.T) {
 		t.Fatalf("expected the tool output in the context, got %#v", second[2])
 	}
 }
+
+// The system prompt is the first thing the model was shown, and codex records
+// it once on the line that opens the session rather than per turn.
+func TestCodexCarriesTheSystemPrompt(t *testing.T) {
+	turns, err := Parse(FormatCodex, []byte(strings.Join([]string{
+		`{"timestamp":"2026-08-09T05:00:00Z","type":"session_meta","payload":{"id":"session-1","base_instructions":{"text":"You are Codex."}}}`,
+		`{"timestamp":"2026-08-09T05:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"hello"}]}}`,
+		`{"timestamp":"2026-08-09T05:00:02Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi"}]}}`,
+	}, "\n")))
+	if err != nil {
+		t.Fatalf("expected the rollout to parse, got %v", err)
+	}
+
+	context := turns[0].Steps[0].Context
+	if len(context) != 2 {
+		t.Fatalf("expected the system prompt and the prompt, got %d items", len(context))
+	}
+	if context[0].Role != "system" || context[0].Text != "You are Codex." {
+		t.Fatalf("expected the system prompt first, got %#v", context[0])
+	}
+	if context[1].Role != "user" {
+		t.Fatalf("expected the prompt after it, got %#v", context[1])
+	}
+}


### PR DESCRIPTION
The context showed the prompt and the environment block but not the system prompt, which is the first thing the model was shown.

Codex records it once, on the line that opens the session: `session_meta.payload.base_instructions.text` — verified against a live rollout, which begins `You are Codex, an a…`. It is now the first context item, so every call in the session carries it.

**Claude Code does not record its system prompt in the transcript.** Its `system` lines are `turn_duration` and `informational` notices, checked against a real transcript. There is nothing to read, so a Claude call's context starts at the first prompt. Nothing to fix here — worth knowing the two CLIs differ.