### PR TITLE
Settle native codex on HTTP, which the proxy can terminate

### DIFF
--- a/internal/daemon/codexconfig.go
+++ b/internal/daemon/codexconfig.go
@@ -16,11 +16,24 @@ import (
 	codex "github.com/agynio/codex-sdk-go"
 )
 
-// codexNativeConfigTemplate is the same file minus the endpoint: no
-// model_provider and no [model_providers] block, so codex talks to its own
-// vendor. Tracing and the mcp_servers appended below are unaffected.
-const codexNativeConfigTemplate = `approval_policy = "never"
+// codexNativeConfigTemplate names no endpoint and no credential: codex still
+// addresses its own vendor, and requires_openai_auth keeps it on the
+// subscription credential it already reads from auth.json.
+//
+// What the provider does declare is transport. codex prefers a WebSocket to
+// wss://chatgpt.com/backend-api/codex/responses, and the platform intercepts
+// that connection to terminate it on the proxy -- which speaks HTTP, so the
+// upgrade never completes and the vendor answers 404. supports_websockets
+// settles it on HTTP/SSE, over the same host and path.
+const codexNativeConfigTemplate = `model_provider = "openai_http"
+approval_policy = "never"
 sandbox_mode = "danger-full-access"
+
+[model_providers.openai_http]
+name = "OpenAI HTTP/SSE"
+wire_api = "responses"
+requires_openai_auth = true
+supports_websockets = false
 `
 
 // traceHookCommand is the platform's trace hook, delivered to /agyn/bin beside

--- a/internal/daemon/nativemode_test.go
+++ b/internal/daemon/nativemode_test.go
@@ -82,14 +82,23 @@ func TestCodexConfigNativeOmitsProvider(t *testing.T) {
 	}
 	payload := codexConfig(cfg)
 
-	for _, forbidden := range []string{"model_provider", "base_url", "llm-proxy.ziti", "env_key"} {
+	// No endpoint and no credential. The provider below names neither -- it
+	// only settles transport, and codex keeps addressing its own vendor.
+	for _, forbidden := range []string{"base_url", "llm-proxy.ziti", "env_key"} {
 		if strings.Contains(payload, forbidden) {
 			t.Fatalf("native codex config carries %q:\n%s", forbidden, payload)
 		}
 	}
 	// The hook lives in the system config, not this one -- it is the only layer
 	// codex trusts a hook from.
-	for _, required := range []string{"[mcp_servers.platform]", "approval_policy"} {
+	for _, required := range []string{
+		"[mcp_servers.platform]",
+		"approval_policy",
+		// Left on its default, codex opens a WebSocket the proxy cannot
+		// terminate and the vendor answers 404.
+		"supports_websockets = false",
+		"requires_openai_auth = true",
+	} {
 		if !strings.Contains(payload, required) {
 			t.Fatalf("native codex config lost %q:\n%s", required, payload)
 		}


### PR DESCRIPTION
A subscription-mode codex prefers a WebSocket transport — its model catalog carries `prefer_websockets: true` — and opens `wss://chatgpt.com/backend-api/codex/responses`. The platform intercepts that connection to terminate it on the LLM Proxy, which is a request/response server and strips `Upgrade`, so the handshake reaches the vendor as a plain HTTP request and comes back `404`.

```toml
model_provider = "openai_http"

[model_providers.openai_http]
name = "OpenAI HTTP/SSE"
wire_api = "responses"
requires_openai_auth = true
supports_websockets = false
```

**This does not reintroduce endpoint configuration.** The provider names no `base_url` and no `env_key`; `requires_openai_auth` keeps codex on the subscription credential it already reads from `auth.json`, and it addresses the same host and path it would have. The only thing declared is transport — which platform mode has always set on its own provider for the same reason.

The alternative was WebSocket passthrough in the proxy. That is the more general fix, but it makes the stream opaque frames after the upgrade, so per-request metering and tracing go blind on native traffic. This keeps both.

Paired with [llm#56](https://github.com/agynio/llm/pull/56), which fixes the upstream path the proxy composes for that request.