### PR TITLE
Take the system prompt from the configuration, not the role

### DIFF
--- a/internal/daemon/claude.go
+++ b/internal/daemon/claude.go
@@ -76,8 +76,16 @@ func newClaudeDaemon(ctx context.Context, cfg config.Config, version string) (*D
 			)
 		}
 	}
-	if role := strings.TrimSpace(setup.agent.GetRole()); role != "" {
-		options.SystemPrompt = role
+	// The agent's own prompt, not its role: the role is an internal label and
+	// naming it here left the model with a single word for instructions.
+	agentConfig, err := parseAgentConfiguration(setup.agent.GetConfiguration())
+	if err != nil {
+		_ = tracingExporter.Close()
+		_ = setup.gatewayConn.Close()
+		return nil, err
+	}
+	if prompt := strings.TrimSpace(agentConfig.SystemPrompt); prompt != "" {
+		options.SystemPrompt = prompt
 	}
 	claudeClient, err := claude.Start(ctx, options)
 	if err != nil {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1180,7 +1180,6 @@ func codexModel(cfg config.Config, platformModel string) string {
 
 type codexThreadDefaults struct {
 	model                 *string
-	baseInstructions      *string
 	developerInstructions *string
 	cwd                   *string
 }
@@ -1190,11 +1189,16 @@ func (d *Daemon) codexThreadDefaults() codexThreadDefaults {
 	if model := codexModel(d.cfg, d.agent.GetModel()); model != "" {
 		defaults.model = &model
 	}
-	if role := strings.TrimSpace(d.agent.GetRole()); role != "" {
-		defaults.baseInstructions = &role
-	}
-	if config := strings.TrimSpace(d.agent.GetConfiguration()); config != "" {
-		defaults.developerInstructions = &config
+	// The system prompt is the agent's own, and it is layered on codex's rather
+	// than replacing it: base instructions carry the CLI's operating
+	// instructions, and an agent that overwrites them loses how to use its own
+	// tools. The role is an internal label and is not shown to the model.
+	if config, err := parseAgentConfiguration(d.agent.GetConfiguration()); err == nil {
+		if prompt := strings.TrimSpace(config.SystemPrompt); prompt != "" {
+			defaults.developerInstructions = &prompt
+		}
+	} else {
+		log.Printf("agent configuration: %v; starting without a system prompt", err)
 	}
 	if d.cfg.WorkDir != "" {
 		workDir := d.cfg.WorkDir
@@ -1207,7 +1211,6 @@ func (d *Daemon) resumeCodexThread(ctx context.Context, codexThreadID string) er
 	params := &codex.ThreadResumeParams{ThreadID: codexThreadID}
 	defaults := d.codexThreadDefaults()
 	params.Model = defaults.model
-	params.BaseInstructions = defaults.baseInstructions
 	params.DeveloperInstructions = defaults.developerInstructions
 	params.Cwd = defaults.cwd
 	resp, err := d.codex.ResumeThread(ctx, params)
@@ -1228,7 +1231,6 @@ func (d *Daemon) startCodexThread(ctx context.Context) (string, error) {
 	params := &codex.ThreadStartParams{}
 	defaults := d.codexThreadDefaults()
 	params.Model = defaults.model
-	params.BaseInstructions = defaults.baseInstructions
 	params.DeveloperInstructions = defaults.developerInstructions
 	params.Cwd = defaults.cwd
 	ephemeral := false

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -940,3 +940,34 @@ func TestBuildInputPrefersTheSenderHandle(t *testing.T) {
 		t.Fatalf("unexpected input: %q", got)
 	}
 }
+
+// The role is an internal label -- 64 characters, often a single word. Sending
+// it as the model's instructions left the agent with that word and nothing
+// else, and overwrote the CLI's own operating instructions with it.
+func TestCodexThreadDefaultsTakeTheSystemPromptFromConfiguration(t *testing.T) {
+	daemon := &Daemon{agent: &agentsv1.Agent{
+		Role:          "support",
+		Configuration: `{"system_prompt":"you are support agent"}`,
+	}}
+
+	defaults := daemon.codexThreadDefaults()
+
+	if defaults.developerInstructions == nil {
+		t.Fatal("expected the configured system prompt to be sent")
+	}
+	if got := *defaults.developerInstructions; got != "you are support agent" {
+		t.Fatalf("expected the system prompt, got %q", got)
+	}
+}
+
+// An agent with no prompt configured runs on the CLI's own instructions rather
+// than on its role.
+func TestCodexThreadDefaultsSendNothingWithoutAPrompt(t *testing.T) {
+	daemon := &Daemon{agent: &agentsv1.Agent{Role: "support", Configuration: "{}"}}
+
+	defaults := daemon.codexThreadDefaults()
+
+	if defaults.developerInstructions != nil {
+		t.Fatalf("expected no instructions, got %q", *defaults.developerInstructions)
+	}
+}


### PR DESCRIPTION
The traced context showed an agent's system prompt as the single word `support`. That was accurate: agynd was sending `agent.role` as the model's instructions.

`role` is spec'd as an "Agent role label (max 64 chars)" — internal, not something the model should see. The system prompt lives in `configuration.system_prompt`, which the spec describes as "interpreted by the agent runtime". agynd was interpreting neither.

Two SDKs were affected, and both were wrong in the same way:

- **codex** sent `role` as `BaseInstructions` and the whole `configuration` JSON as `DeveloperInstructions`. Base instructions are not additive — supplying them **replaces codex's own operating instructions**, so the agent lost every instruction about how to use its tools and got one word instead. Meanwhile the real prompt reached the model as the literal string `{"system_prompt": "you are support agent"}`.
- **Claude Code** set `options.SystemPrompt = role`, so the prompt was that same single word and the configured one was never read.

**agn was already correct** — it parses the configuration and uses `SystemPrompt` — so this makes the other two match it.

Both now read `configuration.system_prompt`. For codex it goes to developer instructions, which layer on top of the CLI's own rather than replacing them, so an agent keeps its tool-use instructions and gains its persona. `baseInstructions` is left unset — codex uses its default — and the now-dead field is removed so a label cannot be wired back into it.