### PR TITLE
Write codex's config in holder mode too

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -179,8 +179,22 @@ func New(ctx context.Context, cfg config.Config, version string) (*Daemon, error
 func prepareAgentCLI(cfg config.Config) error {
 	// Which credential a CLI needs on disk follows from the CLI, so it is
 	// derived here rather than delivered: only this knows which one it runs.
-	if cfg.SDK == SDKCodex && cfg.LLMNative {
-		return writeCodexAuth(time.Now())
+	if cfg.SDK == SDKCodex {
+		if cfg.LLMNative {
+			if err := writeCodexAuth(time.Now()); err != nil {
+				return err
+			}
+		}
+		// The agent path writes config.toml later instead, once the platform
+		// has resolved MCP ports into it.
+		if cfg.Mode != config.ModeHolder {
+			return nil
+		}
+		// Holder still needs it: the transport it settles is what keeps codex
+		// off a WebSocket the proxy cannot terminate, and a sandbox is where
+		// someone starts codex by hand.
+		_, err := writeCodexConfig(cfg)
+		return err
 	}
 	if cfg.SDK != SDKClaude {
 		return nil

--- a/internal/daemon/prepare_test.go
+++ b/internal/daemon/prepare_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/agynio/agynd-cli/internal/config"
@@ -95,6 +96,15 @@ func TestPrepareWritesCodexAuthInNativeMode(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Join(home, ".codex", "auth.json")); err != nil {
 		t.Fatalf("codex auth not written: %v", err)
+	}
+	// Without the config the CLI falls back to its own transport, which is a
+	// WebSocket the proxy cannot terminate.
+	config, err := os.ReadFile(filepath.Join(home, ".codex", "config.toml"))
+	if err != nil {
+		t.Fatalf("codex config not written: %v", err)
+	}
+	if !strings.Contains(string(config), "supports_websockets = false") {
+		t.Fatalf("codex config does not settle transport:\n%s", config)
 	}
 	if _, err := os.Stat(filepath.Join(home, claudeStateFileName)); !os.IsNotExist(err) {
 		t.Fatalf("wrote Claude state for a Codex workload: %v", err)


### PR DESCRIPTION
`writeCodexConfig` was only ever called from the agent path, so a [sandbox](https://github.com/agynio/architecture/blob/main/architecture/agynd-cli.md#preparation-in-holder-mode) had `auth.json` and no `config.toml` at all.

That makes [#179](https://github.com/agynio/agynd-cli/pull/179) ineffective exactly where it is needed: without the config, codex falls back to its built-in provider and opens the WebSocket the proxy cannot terminate. A sandbox is the session someone starts codex in by hand, so it is the one that meets it.

Also means a sandbox never had `approval_policy` or `sandbox_mode` either.

This is the rule already documented for the Claude settings and the first-run state — preparation the environment determines runs whether or not anything will be spawned. The agent path still writes its own copy after the platform resolves MCP ports into it.