### PR TITLE
Read a codex turn from the delimiter, and keep what came before it

### DIFF
--- a/internal/transcript/codex.go
+++ b/internal/transcript/codex.go
@@ -30,6 +30,10 @@ type codexBaseInstructions struct {
 
 type codexTurnContext struct {
 	Model string `json:"model"`
+	// Codex names each turn here, which is the only place it delimits one. A
+	// user-role message does not: the environment context arrives as one, and
+	// so does anything else the harness puts in front of the model.
+	TurnID string `json:"turn_id"`
 }
 
 // A response item is the model's own output: a message it wrote, a reasoning
@@ -79,6 +83,11 @@ func parseCodex(data []byte) ([]Turn, error) {
 	model := ""
 	pending := map[string]*ToolCall{}
 	seen := &history{}
+	turnID := ""
+	// Codex delimits turns in turn_context, but only names them from the
+	// version this ships against. A rollout written by an older one is read the
+	// way it used to be -- on each prompt -- rather than yielding nothing.
+	delimited := hasCodexTurnIDs(data)
 
 	scanner := bufio.NewScanner(bytes.NewReader(data))
 	scanner.Buffer(make([]byte, 0, 64*1024), maxTranscriptLine)
@@ -102,11 +111,26 @@ func parseCodex(data []byte) ([]Turn, error) {
 			}
 		case "turn_context":
 			var context codexTurnContext
-			if json.Unmarshal(line.Payload, &context) == nil && context.Model != "" {
+			if json.Unmarshal(line.Payload, &context) != nil {
+				continue
+			}
+			if context.Model != "" {
 				model = context.Model
 			}
+			if context.TurnID != "" && context.TurnID != turnID {
+				turnID = context.TurnID
+				if current != nil {
+					turns = append(turns, *current)
+				}
+				current = &Turn{
+					ID:        turnID,
+					SessionID: sessionID,
+					StartedAt: line.Timestamp,
+					Model:     model,
+				}
+			}
 		case "response_item":
-			current = applyCodexItem(&turns, current, line, sessionID, model, pending, seen)
+			current = applyCodexItem(&turns, current, line, sessionID, model, pending, seen, delimited)
 		case "event_msg":
 			applyCodexUsage(current, line)
 		}
@@ -120,30 +144,59 @@ func parseCodex(data []byte) ([]Turn, error) {
 	return turns, nil
 }
 
-func applyCodexItem(turns *[]Turn, current *Turn, line codexLine, sessionID, model string, pending map[string]*ToolCall, seen *history) *Turn {
+// hasCodexTurnIDs reports whether the rollout names its turns, which decides
+// whether they are read from the delimiter or from the prompts.
+func hasCodexTurnIDs(data []byte) bool {
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 0, 64*1024), maxTranscriptLine)
+	for scanner.Scan() {
+		var line codexLine
+		if json.Unmarshal(scanner.Bytes(), &line) != nil || line.Type != "turn_context" {
+			continue
+		}
+		var context codexTurnContext
+		if json.Unmarshal(line.Payload, &context) == nil && context.TurnID != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func applyCodexItem(turns *[]Turn, current *Turn, line codexLine, sessionID, model string, pending map[string]*ToolCall, seen *history, delimited bool) *Turn {
 	var item codexResponseItem
 	if err := json.Unmarshal(line.Payload, &item); err != nil {
 		return current
 	}
 
-	// A user message opens a turn. Everything else continues the one in flight,
-	// and is dropped when there is none -- a transcript read mid-write can begin
-	// anywhere.
-	if item.Type == "message" && item.Role == "user" {
-		if current != nil {
+	// What the harness puts in front of the model -- the agent's own
+	// instructions, the environment it runs in -- arrives before any turn is
+	// open. It is context the model was shown, so it is kept, but it opens
+	// nothing.
+	if item.Type == "message" && item.Role != "assistant" {
+		text := codexText(item.Content)
+		seen.add(ContextItem{Role: item.Role, Text: text, At: line.Timestamp})
+		if item.Role != "user" {
+			return current
+		}
+		if !delimited && current != nil {
 			*turns = append(*turns, *current)
+			current = nil
 		}
-		seen.add(ContextItem{Role: "user", Text: codexText(item.Content), At: line.Timestamp})
-		return &Turn{
-			// The rollout has no turn id, so the moment it opened serves: it is
-			// stable across re-reads of the same file, which is what the span
-			// ids derived from it need.
-			ID:        sessionID + "@" + line.Timestamp.UTC().Format(time.RFC3339Nano),
-			SessionID: sessionID,
-			StartedAt: line.Timestamp,
-			Model:     model,
-			UserInput: codexText(item.Content),
+		if current == nil {
+			if delimited {
+				return nil
+			}
+			return &Turn{
+				ID:        sessionID + "@" + line.Timestamp.UTC().Format(time.RFC3339Nano),
+				SessionID: sessionID,
+				StartedAt: line.Timestamp,
+				Model:     model,
+				UserInput: text,
+			}
 		}
+		current.UserInput = joinText(current.UserInput, text)
+		current.EndedAt = line.Timestamp
+		return current
 	}
 	if current == nil {
 		return nil

--- a/internal/transcript/codex_test.go
+++ b/internal/transcript/codex_test.go
@@ -92,7 +92,10 @@ func TestCodexTurnIDIsStableAcrossReads(t *testing.T) {
 	}
 }
 
-func TestCodexSplitsTurnsOnEachUserMessage(t *testing.T) {
+// A rollout whose turn_context does not name a turn is read the older way, on
+// each prompt. Codex names them from the version this ships against, so this is
+// the fallback rather than the path a current rollout takes.
+func TestCodexSplitsUndelimitedTurnsOnEachUserMessage(t *testing.T) {
 	second := `{"timestamp":"2026-01-01T00:01:00.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"And again."}]}}
 {"timestamp":"2026-01-01T00:01:01.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Done."}]}}`
 	turns := parseOrFail(t, FormatCodex, codexTranscript+"\n"+second)
@@ -209,5 +212,53 @@ func TestCodexCarriesTheSystemPrompt(t *testing.T) {
 	}
 	if context[1].Role != "user" {
 		t.Fatalf("expected the prompt after it, got %#v", context[1])
+	}
+}
+
+// The shape a real rollout has: the agent's instructions and the environment
+// arrive as messages before any turn is delimited, and codex names the turn in
+// turn_context rather than in the prompt.
+func TestCodexReadsOneTurnFromTheDelimiterNotThePrompts(t *testing.T) {
+	turns, err := Parse(FormatCodex, []byte(strings.Join([]string{
+		`{"timestamp":"2026-08-09T20:12:07.6Z","type":"session_meta","payload":{"id":"session-1","base_instructions":{"text":"You are Codex."}}}`,
+		`{"timestamp":"2026-08-09T20:12:07.642Z","type":"response_item","payload":{"type":"message","role":"developer","content":[{"type":"input_text","text":"you are support agent"}]}}`,
+		`{"timestamp":"2026-08-09T20:12:07.642Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<environment_context>/tmp</environment_context>"}]}}`,
+		`{"timestamp":"2026-08-09T20:12:07.643Z","type":"turn_context","payload":{"turn_id":"turn-a","model":"gpt-5"}}`,
+		`{"timestamp":"2026-08-09T20:12:07.648Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Hello"}]}}`,
+		`{"timestamp":"2026-08-09T20:12:08.0Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi"}]}}`,
+	}, "\n")))
+	if err != nil {
+		t.Fatalf("expected the rollout to parse, got %v", err)
+	}
+
+	// Three user-role messages would once have been three turns. There is one.
+	if len(turns) != 1 {
+		t.Fatalf("expected a single turn, got %d", len(turns))
+	}
+	if turns[0].ID != "turn-a" {
+		t.Fatalf("expected the turn codex named, got %q", turns[0].ID)
+	}
+	if turns[0].UserInput != "Hello" {
+		t.Fatalf("expected the prompt, got %q", turns[0].UserInput)
+	}
+
+	// The instructions and the environment are what the model was shown, so
+	// they are in the context even though they opened nothing.
+	context := turns[0].Steps[0].Context
+	roles := make([]string, 0, len(context))
+	for _, item := range context {
+		roles = append(roles, item.Role)
+	}
+	want := []string{"system", "developer", "user", "user"}
+	if len(roles) != len(want) {
+		t.Fatalf("expected %v, got %v", want, roles)
+	}
+	for i := range want {
+		if roles[i] != want[i] {
+			t.Fatalf("expected %v, got %v", want, roles)
+		}
+	}
+	if context[1].Text != "you are support agent" {
+		t.Fatalf("expected the agent's own instructions, got %q", context[1].Text)
 	}
 }


### PR DESCRIPTION
The traced context showed codex's default instructions where the agent's own should be. The prompt *was* reaching the model — the parser was dropping it, and mis-segmenting turns while it was at it. A real rollout begins:

```
1  session_meta        base_instructions: "You are Codex, an agent..."
3  response_item       role: developer   "you are support agent"     ← the agent's prompt
4  response_item       role: user        "<environment_context>..."
6  turn_context        turn_id: 019fe827-...                          ← the turn actually starts here
7  response_item       role: user        "thread: ... Hello"
```

Two bugs follow from that shape:

**Anything before the first turn was discarded.** The parser opened a turn on a user-role message and dropped everything that arrived with no turn in flight. The developer message at line 3 — which is where agynd's `system_prompt` lands, since developer instructions layer on codex's own rather than replacing them — arrives first and was thrown away. So the context showed codex's base instructions and nothing of the agent's.

**A user-role message is not a turn boundary.** The environment context arrives as one, so a single exchange was read as several turns, each producing its own `llm.call`. That is the inflated count in the run view — 5 calls against 2 messages — and the reason ordering looked wrong: each fragment's span took its times from the fragment rather than from the model call.

Turns now come from `turn_context.turn_id`, which is the only place codex delimits one, and the span id follows the id codex assigned rather than a synthesised one. Messages before the first delimiter are kept as context without opening anything.

A rollout whose `turn_context` carries no `turn_id` — written by a codex older than the version this ships against — is still read on each prompt rather than yielding nothing.