### PR TITLE
Disable codex's Apps MCP, which cannot authenticate here

### DIFF
--- a/internal/daemon/codexconfig.go
+++ b/internal/daemon/codexconfig.go
@@ -34,6 +34,14 @@ name = "OpenAI HTTP/SSE"
 wire_api = "responses"
 requires_openai_auth = true
 supports_websockets = false
+
+# codex's own Apps MCP authenticates with a ChatGPT session cookie, which a
+# subscription token is not and the platform cannot mint -- it answers
+# no_biscuit_no_service and warns on every start. Declaring the built-in here
+# disables it. The command satisfies transport validation and never runs.
+[mcp_servers.codex_apps]
+enabled = false
+command = "true"
 `
 
 // traceHookCommand is the platform's trace hook, delivered to /agyn/bin beside

--- a/internal/daemon/nativemode_test.go
+++ b/internal/daemon/nativemode_test.go
@@ -98,6 +98,9 @@ func TestCodexConfigNativeOmitsProvider(t *testing.T) {
 		// terminate and the vendor answers 404.
 		"supports_websockets = false",
 		"requires_openai_auth = true",
+		// Its Apps MCP wants a ChatGPT session cookie, which a subscription
+		// token is not, so it fails on every start.
+		"[mcp_servers.codex_apps]",
 	} {
 		if !strings.Contains(payload, required) {
 			t.Fatalf("native codex config lost %q:\n%s", required, payload)


### PR DESCRIPTION
Every native codex start warns:

```
⚠ MCP client for `codex_apps` failed to start: … HTTP 451: {"message":"no_biscuit_no_service"}
⚠ MCP startup incomplete (failed: codex_apps)
```

`codex_apps` is codex's built-in Apps/connectors MCP, hosted by OpenAI. It authenticates with a **ChatGPT session cookie** — "no biscuit, no service" — and a subscription gives a bearer token. The platform cannot mint a session, and the container holds a blank placeholder by design, so this can never succeed here. It is not fatal: codex drops the apps tools and carries on. It is just noise the operator cannot act on.

```toml
[mcp_servers.codex_apps]
enabled = false
command = "true"
```

Verified against the CLI in the runtime image (`codex 0.147.0`):

```
$ codex mcp list
Name        Command  Args  Env  Cwd  Status    Auth
codex_apps  true     -     -    -    disabled  Unsupported
```

`enabled = false` alone is rejected — `invalid transport in mcp_servers.codex_apps` — so the entry needs a transport to parse. `command` satisfies that and never runs, because the server is disabled.

Native mode only. In platform mode codex authenticates with a platform key rather than a ChatGPT session, and the Apps MCP does not start.