### PR TITLE
Send the agent's system prompt as the system prompt

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1193,9 +1193,9 @@ func codexModel(cfg config.Config, platformModel string) string {
 }
 
 type codexThreadDefaults struct {
-	model                 *string
-	developerInstructions *string
-	cwd                   *string
+	model            *string
+	baseInstructions *string
+	cwd              *string
 }
 
 func (d *Daemon) codexThreadDefaults() codexThreadDefaults {
@@ -1203,13 +1203,14 @@ func (d *Daemon) codexThreadDefaults() codexThreadDefaults {
 	if model := codexModel(d.cfg, d.agent.GetModel()); model != "" {
 		defaults.model = &model
 	}
-	// The system prompt is the agent's own, and it is layered on codex's rather
-	// than replacing it: base instructions carry the CLI's operating
-	// instructions, and an agent that overwrites them loses how to use its own
-	// tools. The role is an internal label and is not shown to the model.
+	// The agent's system prompt is the system prompt: it is sent as the base
+	// instructions, which codex renders in place of its own rather than
+	// alongside them. An agent that needs the CLI's operating instructions has
+	// to carry them in its own prompt. The role is an internal label and is
+	// never shown to the model.
 	if config, err := parseAgentConfiguration(d.agent.GetConfiguration()); err == nil {
 		if prompt := strings.TrimSpace(config.SystemPrompt); prompt != "" {
-			defaults.developerInstructions = &prompt
+			defaults.baseInstructions = &prompt
 		}
 	} else {
 		log.Printf("agent configuration: %v; starting without a system prompt", err)
@@ -1225,7 +1226,7 @@ func (d *Daemon) resumeCodexThread(ctx context.Context, codexThreadID string) er
 	params := &codex.ThreadResumeParams{ThreadID: codexThreadID}
 	defaults := d.codexThreadDefaults()
 	params.Model = defaults.model
-	params.DeveloperInstructions = defaults.developerInstructions
+	params.BaseInstructions = defaults.baseInstructions
 	params.Cwd = defaults.cwd
 	resp, err := d.codex.ResumeThread(ctx, params)
 	if err != nil {
@@ -1245,7 +1246,7 @@ func (d *Daemon) startCodexThread(ctx context.Context) (string, error) {
 	params := &codex.ThreadStartParams{}
 	defaults := d.codexThreadDefaults()
 	params.Model = defaults.model
-	params.DeveloperInstructions = defaults.developerInstructions
+	params.BaseInstructions = defaults.baseInstructions
 	params.Cwd = defaults.cwd
 	ephemeral := false
 	params.Ephemeral = &ephemeral

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -952,10 +952,10 @@ func TestCodexThreadDefaultsTakeTheSystemPromptFromConfiguration(t *testing.T) {
 
 	defaults := daemon.codexThreadDefaults()
 
-	if defaults.developerInstructions == nil {
+	if defaults.baseInstructions == nil {
 		t.Fatal("expected the configured system prompt to be sent")
 	}
-	if got := *defaults.developerInstructions; got != "you are support agent" {
+	if got := *defaults.baseInstructions; got != "you are support agent" {
 		t.Fatalf("expected the system prompt, got %q", got)
 	}
 }
@@ -967,7 +967,9 @@ func TestCodexThreadDefaultsSendNothingWithoutAPrompt(t *testing.T) {
 
 	defaults := daemon.codexThreadDefaults()
 
-	if defaults.developerInstructions != nil {
-		t.Fatalf("expected no instructions, got %q", *defaults.developerInstructions)
+	// Nothing sent means codex renders its own, which is the only way an agent
+	// without a prompt gets one at all.
+	if defaults.baseInstructions != nil {
+		t.Fatalf("expected no instructions, got %q", *defaults.baseInstructions)
 	}
 }


### PR DESCRIPTION
`configuration.system_prompt` now goes to codex's `baseInstructions` rather than its developer instructions, so an agent's prompt is the system prompt rather than a message layered under codex's own.

**This replaces codex's built-in operating prompt.** Codex renders its default only when no base instructions are supplied, so an agent that needs the CLI's own instructions — how to use its tools, how to apply patches, what its sandbox permits — has to carry them in its own prompt. That is the intended behaviour here, not an oversight.

It also settles the concatenation: codex was composing one developer message from the instructions it was given plus its own `<skills_instructions>` block, so an agent's prompt ran straight into codex's. Base instructions are their own message and are not merged with anything.

An agent with no `system_prompt` configured still sends nothing, so codex renders its default.