### PR TITLE
Hand Claude Code a gateway token, not an API key

### DIFF
--- a/internal/daemon/claudeconfig.go
+++ b/internal/daemon/claudeconfig.go
@@ -104,7 +104,13 @@ func writeClaudeSettings(llmBaseURL, apiKey string, mcpServers []config.MCPServe
 	}
 	if !native {
 		settings.Env["ANTHROPIC_BASE_URL"] = llmBaseURL
-		settings.Env["ANTHROPIC_API_KEY"] = apiKey
+		// The gateway token, not an API key. Both satisfy the CLI's demand for
+		// a credential, but an API key is consent-gated -- it stops and asks
+		// whether to trust the key it found, which in a workload nobody answers.
+		// This is the variable meant for a proxy standing in front of the
+		// vendor, and the proxy authorizes the OpenZiti identity rather than
+		// anything sent in a header.
+		settings.Env["ANTHROPIC_AUTH_TOKEN"] = apiKey
 	}
 	if len(mcpServers) > 0 {
 		settings.MCPServers = make(map[string]claudeMCPServer, len(mcpServers))

--- a/internal/daemon/claudeconfig_test.go
+++ b/internal/daemon/claudeconfig_test.go
@@ -56,7 +56,7 @@ func TestWriteClaudeSettings(t *testing.T) {
 		Theme:                             "dark",
 		Env: map[string]string{
 			"ANTHROPIC_BASE_URL":                       baseURL,
-			"ANTHROPIC_API_KEY":                        apiKey,
+			"ANTHROPIC_AUTH_TOKEN":                     apiKey,
 			"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
 			"DISABLE_AUTOUPDATER":                      "1",
 		},
@@ -116,7 +116,7 @@ func TestWriteClaudeSettingsWithMCPServers(t *testing.T) {
 		Theme:                             "dark",
 		Env: map[string]string{
 			"ANTHROPIC_BASE_URL":                       baseURL,
-			"ANTHROPIC_API_KEY":                        apiKey,
+			"ANTHROPIC_AUTH_TOKEN":                     apiKey,
 			"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
 			"DISABLE_AUTOUPDATER":                      "1",
 		},

--- a/internal/daemon/nativemode_test.go
+++ b/internal/daemon/nativemode_test.go
@@ -31,7 +31,7 @@ func TestWriteClaudeSettingsNativeOmitsEndpoint(t *testing.T) {
 	if _, ok := settings.Env["ANTHROPIC_BASE_URL"]; ok {
 		t.Fatal("native settings carry a base URL")
 	}
-	if _, ok := settings.Env["ANTHROPIC_API_KEY"]; ok {
+	if _, ok := settings.Env["ANTHROPIC_AUTH_TOKEN"]; ok {
 		t.Fatal("native settings carry a credential")
 	}
 	// The whole point of still writing the file.
@@ -69,7 +69,7 @@ func TestWriteClaudeSettingsPlatformKeepsEndpoint(t *testing.T) {
 	if settings.Env["ANTHROPIC_BASE_URL"] != "http://llm-proxy.ziti:443" {
 		t.Fatalf("platform settings lost the base URL: %+v", settings.Env)
 	}
-	if settings.Env["ANTHROPIC_API_KEY"] != "token" {
+	if settings.Env["ANTHROPIC_AUTH_TOKEN"] != "token" {
 		t.Fatalf("platform settings lost the credential: %+v", settings.Env)
 	}
 }


### PR DESCRIPTION
Platform-mode workloads stop on first run with:

```
Detected a custom API key in your environment
  ANTHROPIC_API_KEY: sk-ant-...platform
  Do you want to use this API key?
```

`agynd` writes that variable into `~/.claude/settings.json` to satisfy the CLI's demand for a credential. But an API key is **consent-gated**: the CLI records approvals in `customApiKeyResponses` and blocks until someone answers — and in a workload nobody is there to. Suppressing one prompt bought another.

`ANTHROPIC_AUTH_TOKEN` satisfies the same requirement (`ANTHROPIC_API_KEY, ANTHROPIC_AUTH_TOKEN, CLAUDE_CODE_OAUTH_TOKEN, or WIF env vars required`) and is the variable meant for a gateway in front of the vendor — the CLI refers to it as "the gateway token provided via ANTHROPIC_AUTH_TOKEN". Only `ANTHROPIC_API_KEY` is consent-gated.

The value is unused either way: the LLM Proxy authorizes the workload's OpenZiti identity, not a header. Native mode is unaffected — it sets neither.