### PR TITLE
Name the overlay .agyn, not .ziti

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -90,11 +90,11 @@ func fromEnv(configPath string) (Config, error) {
 	environmentID := strings.TrimSpace(os.Getenv("ENVIRONMENT_ID"))
 	gatewayAddress := strings.TrimSpace(os.Getenv("GATEWAY_ADDRESS"))
 	if gatewayAddress == "" {
-		gatewayAddress = "gateway.ziti:443"
+		gatewayAddress = "gateway.agyn:443"
 	}
 	tracingAddress := strings.TrimSpace(os.Getenv("TRACING_ADDRESS"))
 	if tracingAddress == "" {
-		tracingAddress = "tracing.ziti:443"
+		tracingAddress = "tracing.agyn:443"
 	}
 	agentInstanceID, err := uuidutil.ParseUUID(strings.TrimSpace(os.Getenv("AGENT_INSTANCE_ID")), "AGENT_INSTANCE_ID")
 	if err != nil {
@@ -218,7 +218,7 @@ func llmBaseURLFromEnv() string {
 	if llmBaseURL := strings.TrimSpace(os.Getenv("LLM_BASE_URL")); llmBaseURL != "" {
 		return llmBaseURL
 	}
-	return "http://llm-proxy.ziti:443/v1"
+	return "http://llm-proxy.agyn:443/v1"
 }
 
 func llmAPITokenFromEnv() string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -166,7 +166,7 @@ func TestFromEnvGatewayDefault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if cfg.GatewayAddress != "gateway.ziti:443" {
+	if cfg.GatewayAddress != "gateway.agyn:443" {
 		t.Fatalf("expected default gateway address, got %s", cfg.GatewayAddress)
 	}
 }
@@ -180,7 +180,7 @@ func TestFromEnvTracingAddressDefault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if cfg.TracingAddress != "tracing.ziti:443" {
+	if cfg.TracingAddress != "tracing.agyn:443" {
 		t.Fatalf("expected default tracing address, got %s", cfg.TracingAddress)
 	}
 }
@@ -322,7 +322,7 @@ func TestFromEnvLLMBaseURLDefault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if cfg.LLMBaseURL != "http://llm-proxy.ziti:443/v1" {
+	if cfg.LLMBaseURL != "http://llm-proxy.agyn:443/v1" {
 		t.Fatalf("expected default LLM base URL, got %s", cfg.LLMBaseURL)
 	}
 }
@@ -551,7 +551,7 @@ func TestFromEnvInvalidMode(t *testing.T) {
 func TestFromEnvHolderModeReadsAgentCLIAndLLMConfig(t *testing.T) {
 	configPath := writeAgentConfig(t, "claude", "bin/claude")
 	t.Setenv("AGYND_MODE", ModeHolder)
-	t.Setenv("LLM_BASE_URL", "http://llm-proxy.ziti:443/v1")
+	t.Setenv("LLM_BASE_URL", "http://llm-proxy.agyn:443/v1")
 	t.Setenv("LLM_MODE", "native")
 	t.Setenv("AGENT_MCP_SERVERS", "files:9100")
 
@@ -562,7 +562,7 @@ func TestFromEnvHolderModeReadsAgentCLIAndLLMConfig(t *testing.T) {
 	if cfg.SDK != "claude" {
 		t.Fatalf("expected claude sdk, got %q", cfg.SDK)
 	}
-	if cfg.LLMBaseURL != "http://llm-proxy.ziti:443/v1" {
+	if cfg.LLMBaseURL != "http://llm-proxy.agyn:443/v1" {
 		t.Fatalf("unexpected llm base url: %q", cfg.LLMBaseURL)
 	}
 	if !cfg.LLMNative {

--- a/internal/daemon/claudeconfig_test.go
+++ b/internal/daemon/claudeconfig_test.go
@@ -138,28 +138,28 @@ func TestClaudeBaseURL(t *testing.T) {
 	}{
 		{
 			name:  "strip-v1",
-			input: "http://llm-proxy.ziti:443/v1",
-			want:  "http://llm-proxy.ziti:443",
+			input: "http://llm-proxy.agyn:443/v1",
+			want:  "http://llm-proxy.agyn:443",
 		},
 		{
 			name:  "strip-v1-trailing-slash",
-			input: "http://llm-proxy.ziti:443/v1/",
-			want:  "http://llm-proxy.ziti:443",
+			input: "http://llm-proxy.agyn:443/v1/",
+			want:  "http://llm-proxy.agyn:443",
 		},
 		{
 			name:  "no-strip",
-			input: "http://llm-proxy.ziti:443/v1beta",
-			want:  "http://llm-proxy.ziti:443/v1beta",
+			input: "http://llm-proxy.agyn:443/v1beta",
+			want:  "http://llm-proxy.agyn:443/v1beta",
 		},
 		{
 			name:  "already-base",
-			input: "http://llm-proxy.ziti:443",
-			want:  "http://llm-proxy.ziti:443",
+			input: "http://llm-proxy.agyn:443",
+			want:  "http://llm-proxy.agyn:443",
 		},
 		{
 			name:  "trim-space",
-			input: " http://llm-proxy.ziti:443/v1 ",
-			want:  "http://llm-proxy.ziti:443",
+			input: " http://llm-proxy.agyn:443/v1 ",
+			want:  "http://llm-proxy.agyn:443",
 		},
 	}
 
@@ -212,7 +212,7 @@ func TestWriteClaudeSettingsAcceptsTheBypassDisclaimer(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	if err := writeClaudeSettings("http://llm-proxy.ziti:443", "platform", nil, false); err != nil {
+	if err := writeClaudeSettings("http://llm-proxy.agyn:443", "platform", nil, false); err != nil {
 		t.Fatalf("write settings: %v", err)
 	}
 	data, err := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))

--- a/internal/daemon/codexconfig.go
+++ b/internal/daemon/codexconfig.go
@@ -93,7 +93,7 @@ supports_websockets = false
 const codexAPIKeyEnv = `env_key = "OPENAI_API_KEY"
 `
 
-const zitiHostnameSuffix = ".ziti"
+const zitiHostnameSuffix = ".agyn"
 
 const (
 	codexEnvPath             = "PATH"
@@ -113,10 +113,10 @@ const (
 )
 
 var codexZitiNoProxyHosts = []string{
-	".ziti",
-	"llm-proxy.ziti",
-	"gateway.ziti",
-	"tracing.ziti",
+	".agyn",
+	"llm-proxy.agyn",
+	"gateway.agyn",
+	"tracing.agyn",
 }
 
 var codexAuthEnvMu sync.Mutex

--- a/internal/daemon/codexconfig_test.go
+++ b/internal/daemon/codexconfig_test.go
@@ -93,7 +93,7 @@ func TestWriteCodexConfigForZitiOmitsAPIKeyEnv(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
 
-	baseURL := "http://llm-proxy.ziti:443/v1"
+	baseURL := "http://llm-proxy.agyn:443/v1"
 	codexHome, err := writeCodexConfig(config.Config{LLMBaseURL: baseURL, MCPServers: nil})
 	if err != nil {
 		t.Fatalf("expected config to be written, got %v", err)
@@ -167,10 +167,10 @@ func TestCodexEnvIncludesAPIKeyForPublicLLM(t *testing.T) {
 
 func TestCodexEnvOmitsAPIKeyForZitiLLM(t *testing.T) {
 	t.Setenv("PATH", "/usr/bin")
-	t.Setenv(codexEnvNoProxy, "localhost, llm-proxy.ziti")
+	t.Setenv(codexEnvNoProxy, "localhost, llm-proxy.agyn")
 	t.Setenv(codexEnvNoProxyLower, "127.0.0.1")
 	cfg := config.Config{
-		LLMBaseURL:  "http://llm-proxy.ziti:443/v1",
+		LLMBaseURL:  "http://llm-proxy.agyn:443/v1",
 		LLMAPIToken: "user-token",
 	}
 
@@ -179,7 +179,7 @@ func TestCodexEnvOmitsAPIKeyForZitiLLM(t *testing.T) {
 	if _, ok := env[codexEnvOpenAIAPIKey]; ok {
 		t.Fatalf("expected ziti codex env to omit %s", codexEnvOpenAIAPIKey)
 	}
-	if env[codexEnvNoProxy] != "localhost,llm-proxy.ziti,127.0.0.1,.ziti,gateway.ziti,tracing.ziti" {
+	if env[codexEnvNoProxy] != "localhost,llm-proxy.agyn,127.0.0.1,.agyn,gateway.agyn,tracing.agyn" {
 		t.Fatalf("unexpected %s: %q", codexEnvNoProxy, env[codexEnvNoProxy])
 	}
 	if env[codexEnvNoProxyLower] != env[codexEnvNoProxy] {
@@ -190,13 +190,13 @@ func TestCodexEnvOmitsAPIKeyForZitiLLM(t *testing.T) {
 
 func TestCodexEnvMergesNoProxySpellingsForZitiLLM(t *testing.T) {
 	t.Setenv("PATH", "/usr/bin")
-	t.Setenv(codexEnvNoProxy, "localhost, .ZITI")
-	t.Setenv(codexEnvNoProxyLower, "127.0.0.1, localhost, gateway.ziti")
-	cfg := config.Config{LLMBaseURL: "http://llm-proxy.ziti:443/v1"}
+	t.Setenv(codexEnvNoProxy, "localhost, .AGYN")
+	t.Setenv(codexEnvNoProxyLower, "127.0.0.1, localhost, gateway.agyn")
+	cfg := config.Config{LLMBaseURL: "http://llm-proxy.agyn:443/v1"}
 
 	env := codexEnv(cfg, "/tmp/.codex", "/tmp")
 
-	want := "localhost,.ZITI,127.0.0.1,gateway.ziti,llm-proxy.ziti,tracing.ziti"
+	want := "localhost,.AGYN,127.0.0.1,gateway.agyn,llm-proxy.agyn,tracing.agyn"
 	if env[codexEnvNoProxyLower] != env[codexEnvNoProxy] {
 		t.Fatalf("expected proxy bypass env spellings to match: %s=%q %s=%q", codexEnvNoProxy, env[codexEnvNoProxy], codexEnvNoProxyLower, env[codexEnvNoProxyLower])
 	}
@@ -213,7 +213,7 @@ func TestCodexEnvClearsProxyVarsForZitiLLM(t *testing.T) {
 	for _, key := range codexProxyEnvVars {
 		t.Setenv(key, "http://proxy.invalid:8080")
 	}
-	cfg := config.Config{LLMBaseURL: "http://llm-proxy.ziti:443/v1"}
+	cfg := config.Config{LLMBaseURL: "http://llm-proxy.agyn:443/v1"}
 
 	env := codexEnv(cfg, "/tmp/.codex", "/tmp")
 
@@ -251,8 +251,8 @@ func TestCodexEnvDoesNotSetNoProxyForPublicLLM(t *testing.T) {
 }
 
 func TestZitiNoProxyValue(t *testing.T) {
-	got := zitiNoProxyValue(" localhost, .ZITI,,gateway.ziti ", "127.0.0.1,localhost")
-	want := "localhost,.ZITI,gateway.ziti,127.0.0.1,llm-proxy.ziti,tracing.ziti"
+	got := zitiNoProxyValue(" localhost, .AGYN,,gateway.agyn ", "127.0.0.1,localhost")
+	want := "localhost,.AGYN,gateway.agyn,127.0.0.1,llm-proxy.agyn,tracing.agyn"
 	if got != want {
 		t.Fatalf("expected %q, got %q", want, got)
 	}
@@ -296,7 +296,7 @@ func TestZitiCodexProcessReceivesNoAuthEnvConfig(t *testing.T) {
 	t.Setenv(codexEnvCodexAccessToken, "parent-access-token")
 	t.Setenv("PATH", "/usr/bin")
 	cfg := config.Config{
-		LLMBaseURL:  "http://llm-proxy.ziti:443/v1",
+		LLMBaseURL:  "http://llm-proxy.agyn:443/v1",
 		LLMAPIToken: "agent-env-token",
 	}
 
@@ -332,11 +332,12 @@ func TestIsZitiLLMBaseURL(t *testing.T) {
 		url  string
 		want bool
 	}{
-		{name: "platform proxy", url: "http://llm-proxy.ziti:443/v1", want: true},
-		{name: "nested ziti host", url: "https://models.mesh.ziti/v1", want: true},
-		{name: "uppercase host", url: " HTTP://LLM-PROXY.ZITI:443/v1 ", want: true},
+		{name: "platform proxy", url: "http://llm-proxy.agyn:443/v1", want: true},
+		{name: "nested overlay host", url: "https://models.mesh.agyn/v1", want: true},
+		{name: "uppercase host", url: " HTTP://LLM-PROXY.AGYN:443/v1 ", want: true},
 		{name: "public endpoint", url: "https://llm.example/v1", want: false},
-		{name: "ziti as registrable suffix", url: "https://exampleziti/v1", want: false},
+		{name: "platform's own domain", url: "https://llm-proxy.agyn.dev/v1", want: false},
+		{name: "overlay tld as registrable suffix", url: "https://exampleagyn/v1", want: false},
 		{name: "invalid url", url: "://bad", want: false},
 	}
 

--- a/internal/daemon/daemon_llm_test.go
+++ b/internal/daemon/daemon_llm_test.go
@@ -26,9 +26,9 @@ func TestZitiLLMServiceAddress(t *testing.T) {
 		addr string
 		ok   bool
 	}{
-		{name: "default http", url: "http://llm-proxy.ziti/v1", addr: "llm-proxy.ziti:80", ok: true},
-		{name: "default https", url: "https://llm-proxy.ziti/v1", addr: "llm-proxy.ziti:443", ok: true},
-		{name: "explicit port", url: "http://llm-proxy.ziti:8080/v1", addr: "llm-proxy.ziti:8080", ok: true},
+		{name: "default http", url: "http://llm-proxy.agyn/v1", addr: "llm-proxy.agyn:80", ok: true},
+		{name: "default https", url: "https://llm-proxy.agyn/v1", addr: "llm-proxy.agyn:443", ok: true},
+		{name: "explicit port", url: "http://llm-proxy.agyn:8080/v1", addr: "llm-proxy.agyn:8080", ok: true},
 		{name: "public", url: "https://llm.example/v1", ok: false},
 	}
 
@@ -49,7 +49,7 @@ func TestZitiLLMServiceAddress(t *testing.T) {
 }
 
 func TestZitiLLMServiceAddressRejectsMissingDefaultPort(t *testing.T) {
-	_, _, err := zitiLLMServiceAddress("tcp://llm-proxy.ziti/v1")
+	_, _, err := zitiLLMServiceAddress("tcp://llm-proxy.agyn/v1")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}

--- a/internal/daemon/nativemode_test.go
+++ b/internal/daemon/nativemode_test.go
@@ -15,7 +15,7 @@ func TestWriteClaudeSettingsNativeOmitsEndpoint(t *testing.T) {
 	t.Setenv("HOME", home)
 
 	servers := []config.MCPServer{{Name: "platform", Port: 9100}}
-	if err := writeClaudeSettings("http://llm-proxy.ziti:443", "token", servers, true); err != nil {
+	if err := writeClaudeSettings("http://llm-proxy.agyn:443", "token", servers, true); err != nil {
 		t.Fatalf("write claude settings: %v", err)
 	}
 
@@ -55,7 +55,7 @@ func TestWriteClaudeSettingsPlatformKeepsEndpoint(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	if err := writeClaudeSettings("http://llm-proxy.ziti:443", "token", nil, false); err != nil {
+	if err := writeClaudeSettings("http://llm-proxy.agyn:443", "token", nil, false); err != nil {
 		t.Fatalf("write claude settings: %v", err)
 	}
 	payload, err := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
@@ -66,7 +66,7 @@ func TestWriteClaudeSettingsPlatformKeepsEndpoint(t *testing.T) {
 	if err := json.Unmarshal(payload, &settings); err != nil {
 		t.Fatalf("decode settings: %v", err)
 	}
-	if settings.Env["ANTHROPIC_BASE_URL"] != "http://llm-proxy.ziti:443" {
+	if settings.Env["ANTHROPIC_BASE_URL"] != "http://llm-proxy.agyn:443" {
 		t.Fatalf("platform settings lost the base URL: %+v", settings.Env)
 	}
 	if settings.Env["ANTHROPIC_API_KEY"] != "token" {
@@ -76,7 +76,7 @@ func TestWriteClaudeSettingsPlatformKeepsEndpoint(t *testing.T) {
 
 func TestCodexConfigNativeOmitsProvider(t *testing.T) {
 	cfg := config.Config{
-		LLMBaseURL: "http://llm-proxy.ziti:443/v1",
+		LLMBaseURL: "http://llm-proxy.agyn:443/v1",
 		LLMNative:  true,
 		MCPServers: []config.MCPServer{{Name: "platform", Port: 9100}},
 	}
@@ -84,7 +84,7 @@ func TestCodexConfigNativeOmitsProvider(t *testing.T) {
 
 	// No endpoint and no credential. The provider below names neither -- it
 	// only settles transport, and codex keeps addressing its own vendor.
-	for _, forbidden := range []string{"base_url", "llm-proxy.ziti", "env_key"} {
+	for _, forbidden := range []string{"base_url", "llm-proxy.agyn", "env_key"} {
 		if strings.Contains(payload, forbidden) {
 			t.Fatalf("native codex config carries %q:\n%s", forbidden, payload)
 		}
@@ -109,7 +109,7 @@ func TestCodexConfigNativeOmitsProvider(t *testing.T) {
 }
 
 func TestCodexEnvNativeKeepsPlaceholder(t *testing.T) {
-	cfg := config.Config{LLMBaseURL: "http://llm-proxy.ziti:443/v1", LLMNative: true, LLMAPIToken: "platform"}
+	cfg := config.Config{LLMBaseURL: "http://llm-proxy.agyn:443/v1", LLMNative: true, LLMAPIToken: "platform"}
 	env := codexEnv(cfg, "/home/agent/.codex", "/home/agent")
 
 	// The placeholder codex reads is on the container; overwriting the variable

--- a/internal/daemon/prepare_test.go
+++ b/internal/daemon/prepare_test.go
@@ -22,7 +22,7 @@ func TestHolderModePreparesTheAgentCLI(t *testing.T) {
 		Mode:       config.ModeHolder,
 		SDK:        SDKClaude,
 		WorkDir:    t.TempDir(),
-		LLMBaseURL: "http://llm-proxy.ziti:443/v1",
+		LLMBaseURL: "http://llm-proxy.agyn:443/v1",
 		MCPServers: []config.MCPServer{{Name: "files", Port: 9100}},
 	}
 	if _, err := New(context.Background(), cfg, "test"); err != nil {
@@ -70,7 +70,7 @@ func TestAgentModePreparesStateButDefersSettings(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	cfg := config.Config{Mode: config.ModeAgent, SDK: SDKClaude, LLMBaseURL: "http://llm-proxy.ziti:443/v1"}
+	cfg := config.Config{Mode: config.ModeAgent, SDK: SDKClaude, LLMBaseURL: "http://llm-proxy.agyn:443/v1"}
 	if err := prepareAgentCLI(cfg); err != nil {
 		t.Fatalf("prepare: %v", err)
 	}


### PR DESCRIPTION
Renames the OpenZiti overlay hostnames from `.ziti` to `.agyn`:
`gateway.agyn`, `llm-proxy.agyn`, `tracing.agyn`, and `exposed-<uuid>.agyn`.

The TLD was never a DNS zone — the workload tunneler answers only for
hostnames an `intercept.v1` config names, and forwards everything else
upstream. So this is a naming change, not a networking one.

Not touched: the `ziti` Kubernetes namespace and `*.ziti.svc.cluster.local`,
the `ziti.<domain>` CoreDNS rewrites, and the `ziti-workload-dns` zone keys.

Coordinated across expose, agents-orchestrator, agynd-cli, agyn-cli,
networks, egress, files-mcp, platform-charts, bundle-vm, e2e,
platform-controller and the docs. There is no installed base to migrate.