### PR TITLE
Wait for the turn the CLI is still writing

### DIFF
--- a/cmd/agynd-trace-hook/main.go
+++ b/cmd/agynd-trace-hook/main.go
@@ -28,6 +28,14 @@ import (
 
 const exportTimeout = 20 * time.Second
 
+// How long to wait for the CLI to finish writing the turn that just ended. Long
+// enough for a flush, short enough that a hook holding up a turn is not what a
+// user notices.
+const (
+	settleTimeout  = 5 * time.Second
+	settleInterval = 100 * time.Millisecond
+)
+
 // A trace id is 16 bytes, so an id of any other length is a misconfiguration
 // rather than a trace nobody has written to yet.
 const traceIDLength = 16
@@ -62,15 +70,6 @@ func run() error {
 	if path == "" {
 		return fmt.Errorf("hook payload names no transcript")
 	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return fmt.Errorf("read transcript: %w", err)
-	}
-	turns, err := transcript.Parse(format, data)
-	if err != nil {
-		return fmt.Errorf("parse transcript: %w", err)
-	}
-
 	sent, err := loadSent(path)
 	if err != nil {
 		// A sidecar that cannot be read is treated as empty. Re-exporting a
@@ -78,7 +77,10 @@ func run() error {
 		// write rather than a duplicate.
 		log.Printf("read sidecar: %v", err)
 	}
-	fresh := unsent(turns, sent)
+	fresh, err := settledTurns(format, path, sent)
+	if err != nil {
+		return err
+	}
 	if len(fresh) == 0 {
 		return nil
 	}
@@ -108,6 +110,45 @@ func run() error {
 		return fmt.Errorf("export turns: %w", err)
 	}
 	return recordSent(path, sent, fresh)
+}
+
+// settledTurns reads the turns the transcript has not sent, waiting for the one
+// that just ended to appear in it.
+//
+// The hook is run on turn completion, but the CLI does not necessarily finish
+// writing before running it: Claude Code fires Stop with the assistant's reply
+// still unflushed, so a transcript read the instant the hook starts holds a turn
+// with nothing in it. Waiting briefly is the difference between exporting the
+// turn and exporting nothing at all, because the hook is not run again.
+func settledTurns(format transcript.Format, path string, sent map[string]bool) ([]transcript.Turn, error) {
+	deadline := time.Now().Add(settleTimeout)
+	for {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read transcript: %w", err)
+		}
+		turns, err := transcript.Parse(format, data)
+		if err != nil {
+			return nil, fmt.Errorf("parse transcript: %w", err)
+		}
+		fresh := unsent(turns, sent)
+		// A finished turn is what there is to export. One still in flight is
+		// left for the next run rather than waited on: it may be a turn the CLI
+		// has not started answering.
+		if finished(fresh) || !time.Now().Before(deadline) {
+			return fresh, nil
+		}
+		time.Sleep(settleInterval)
+	}
+}
+
+func finished(turns []transcript.Turn) bool {
+	for _, turn := range turns {
+		if !turn.EndedAt.IsZero() {
+			return true
+		}
+	}
+	return false
 }
 
 // hookPayload is what the agent CLI writes to the hook's stdin. The CLIs differ

--- a/cmd/agynd-trace-hook/main_test.go
+++ b/cmd/agynd-trace-hook/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -147,5 +148,80 @@ func TestUnsentSkipsWhatWasAlreadyExported(t *testing.T) {
 
 	if len(fresh) != 1 || fresh[0].ID != "turn-2" {
 		t.Fatalf("expected only the unsent turn, got %v", fresh)
+	}
+}
+
+func writeLines(t *testing.T, path string, lines ...string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+}
+
+const claudePrompt = `{"type":"user","uuid":"turn-1","sessionId":"s","timestamp":"2026-08-09T05:00:00Z","message":{"role":"user","content":"hello"}}`
+const claudeReply = `{"type":"assistant","uuid":"a","sessionId":"s","timestamp":"2026-08-09T05:00:03Z","message":{"id":"m1","role":"assistant","model":"claude","content":[{"type":"text","text":"hi"}]}}`
+
+// Claude Code runs the hook with the assistant's reply still unflushed, so a
+// transcript read the instant the hook starts holds a turn with nothing in it.
+// The hook is not run again, so exporting that is exporting nothing.
+func TestTurnsAreReadOnceTheTranscriptCatchesUp(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	writeLines(t, path, claudePrompt)
+
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		writeLines(t, path, claudePrompt, claudeReply)
+	}()
+
+	turns, err := settledTurns(transcript.FormatClaude, path, map[string]bool{})
+	if err != nil {
+		t.Fatalf("expected the turns to read, got %v", err)
+	}
+	if !finished(turns) {
+		t.Fatal("expected the hook to wait for the turn the CLI was still writing")
+	}
+}
+
+// A transcript that never completes must not hold the turn open: the hook gives
+// up and lets the CLI carry on.
+func TestWaitingForTheTurnIsBounded(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	writeLines(t, path, claudePrompt)
+
+	start := time.Now()
+	turns, err := settledTurns(transcript.FormatClaude, path, map[string]bool{})
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("expected the read to succeed, got %v", err)
+	}
+	if finished(turns) {
+		t.Fatal("expected no finished turn")
+	}
+	if elapsed < settleTimeout {
+		t.Fatalf("expected to wait for the turn, gave up after %s", elapsed)
+	}
+	if elapsed > settleTimeout*2 {
+		t.Fatalf("expected the wait to be bounded, took %s", elapsed)
+	}
+}
+
+// A turn already in the transcript is exported without waiting: codex flushes
+// its rollout before running the hook.
+func TestAFinishedTurnIsReadImmediately(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	writeLines(t, path, claudePrompt, claudeReply)
+
+	start := time.Now()
+	turns, err := settledTurns(transcript.FormatClaude, path, map[string]bool{})
+
+	if err != nil {
+		t.Fatalf("expected the turns to read, got %v", err)
+	}
+	if !finished(turns) {
+		t.Fatal("expected the finished turn")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("expected no wait, took %s", elapsed)
 	}
 }


### PR DESCRIPTION
A Claude agent produced `invocation.message` and nothing else. The hook was installed, registered, and correctly configured — and it ran. It just had nothing to read.

Claude Code fires `Stop` **before** the assistant's reply reaches the transcript. In the run that prompted this, the prompt landed at `07:16:09.137` and the reply at `07:16:14.341`; the hook ran in between, parsed a turn with no steps, exported nothing, and wrote an empty sidecar. Nothing marked it sent, but nothing ran again either — `Stop` fires once, and `SessionEnd` does not come while the workload is alive.

Codex hides this: `hook_transcript_path()` calls `ensure_rollout_materialized()` before handing over the path, so its rollout is always complete. Claude Code makes no such promise.

The hook now waits for the turn it was run for, re-reading until a finished turn appears or five seconds pass, then exports whatever it has. A transcript that is already complete — every codex run — is read once and exported with no wait.

Confirmed on the live workload: running the hook by hand against that same transcript exported the `llm.call` and recorded the turn, which is what proves the export path was never the problem.